### PR TITLE
Fix PageHero styles

### DIFF
--- a/components/PageHero/PageHero.vue
+++ b/components/PageHero/PageHero.vue
@@ -23,13 +23,8 @@ export default {
   font-size: 1em;
   line-height: 1.5rem;
   padding: 2rem 1rem;
-  text-align: center;
-  margin-top: 1rem;
   @media (min-width: 768px) {
-    font-size: 1.625em;
-    line-height: 2.375rem;
     padding: 1.5rem 0;
-    margin-top: 7rem;
   }
   &.large {
     background-image: linear-gradient(

--- a/components/header/Header.vue
+++ b/components/header/Header.vue
@@ -258,7 +258,6 @@ export default {
 
 .header__nav {
   background-color: $navy;
-  height: 40px;
   width: 100%;
 }
 


### PR DESCRIPTION
# Description

During our PR merges yesterday, some of the `PageHero` styles got overwritten, specifically for the default styles. In addition, I removed the set height for the header as that was causing the body of the site to go under the header.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

- Homepage hero should have large centered text, and a purple gradient background
- About page hero should be small left aligned text, and have a green gradient background

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
