### PR TITLE
Dynamically load filters based on the search type

### DIFF
--- a/components/SearchFilters/SearchFilters.vue
+++ b/components/SearchFilters/SearchFilters.vue
@@ -8,7 +8,7 @@
         </h3>
         <div class="filter__checkbox__wrap">
           <el-checkbox
-            v-for="item in filter.items"
+            v-for="item in filter.filters"
             :key="`${item.category}_${item.key}`"
             v-model="item.value"
             @change="$emit('input', value)"

--- a/nuxt.config.js
+++ b/nuxt.config.js
@@ -41,6 +41,12 @@ export default {
     ctf_support_page_id: '59F0dM5goobqjw3TsqINRw',
     ctf_home_page_id: '4qJ9WUWXg09FAUvCnbGxBY',
     ctf_project_id: 'sparcAward',
+    ctf_filter_id: '6bya4tyw8399',
+    ctf_filters_dataset_id: '7fL88ABgKSB2tPJmysn2V',
+    ctf_filters_project_id: 'YVan5NSd4bgj2Q5WZdOVw',
+    ctf_filters_organ_id: '5Hhlb7Lf4yijMQUSBai1fh',
+    ctf_filters_image_id: '4R4zfdND13xLLGU9nPpNCD',
+    ctf_filters_simulation_id: '6qMQRugMyzeaUrTIPQDdF1',
     CTF_SPACE_ID: process.env.CTF_SPACE_ID,
     CTF_CDA_ACCESS_TOKEN: process.env.CTF_CDA_ACCESS_TOKEN,
     CTF_API_HOST: process.env.CTF_API_HOST


### PR DESCRIPTION
# Description

The purpose of this PR is to add functionality to dynamically load filters based on the search type. These filters are [in contentful as a Filter type](https://app.contentful.com/spaces/6bya4tyw8399/entries). I already created filters for each type, and we just need to fill in the categories and filters.

## Type of change

- [x] New feature (non-breaking change which adds functionality)

# How Has This Been Tested?

- Go to the Find Data page
- The Datasets filters should be loaded
- Go to the Projects tab
- The Projects filters should be loaded
- Select some filters. They should show checked, and the checked filters should be displayed above the table.
- Go to the Organs tab
- Organs have no filters, so there should no nothing displayed (we don't have an empty state at the moment.)

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
