### PR TITLE
Header search - Search functionality, Hide on Find Data #4a7456 #4a9p8d

### DIFF
--- a/components/header/Header.vue
+++ b/components/header/Header.vue
@@ -32,6 +32,7 @@
             <sparc-logo />
           </div>
           <button
+            v-if="shouldShowSearch"
             class="nav-main-container__mobile-search"
             @click="openMobileSearch"
             @enter="executeSearch"
@@ -99,7 +100,7 @@
               </a>
             </div>
           </div>
-          <div class="nav-main-container__search">
+          <div v-if="shouldShowSearch" class="nav-main-container__search">
             <input
               v-model="searchQuery"
               type="text"
@@ -161,6 +162,16 @@ export default {
     searchOpen: false,
     searchQuery: ''
   }),
+
+  computed: {
+    /**
+     * Compute if search should be visible
+     * @returns {Boolean}
+     */
+    shouldShowSearch: function() {
+      return this.$route.name !== 'data'
+    }
+  },
 
   watch: {
     /**

--- a/components/header/Header.vue
+++ b/components/header/Header.vue
@@ -101,6 +101,7 @@
           </div>
           <div class="nav-main-container__search">
             <input
+              v-model="searchQuery"
               type="text"
               class="nav-main-container__search-input"
               placeholder="Search"
@@ -157,14 +158,15 @@ export default {
   data: () => ({
     links,
     menuOpen: false,
-    searchOpen: false
+    searchOpen: false,
+    searchQuery: ''
   }),
 
   watch: {
-   /**
-    * Watches for the route path to hide
-    * mobile nav on menu click
-   **/
+    /**
+     * Watches for the route path to hide
+     * mobile nav on menu click
+     **/
     '$nuxt.$route.path': {
       handler: function(val) {
         if (val) {
@@ -218,7 +220,15 @@ export default {
      * Executes a search query
      */
     executeSearch: function() {
-      // logic goes here
+      this.$router.push({
+        name: 'data',
+        query: {
+          q: this.searchQuery,
+          type: 'dataset'
+        }
+      })
+
+      this.searchQuery = ''
     }
   }
 }
@@ -410,7 +420,8 @@ export default {
   }
 }
 
-::placeholder {  /* Chrome, Firefox, Opera, Safari 10.1+ */
+::placeholder {
+  /* Chrome, Firefox, Opera, Safari 10.1+ */
   color: lightgray;
   opacity: 1; /* Firefox */
   font-size: 14px;
@@ -419,7 +430,8 @@ export default {
   padding-left: 7px;
 }
 
-:-ms-input-placeholder {   /* Internet Explorer 10-11 */
+:-ms-input-placeholder {
+  /* Internet Explorer 10-11 */
   color: lightgray;
   font-size: 14px;
   font-weight: 300;
@@ -549,7 +561,8 @@ export default {
     width: 90%;
   }
 
-  ::placeholder {  /* Chrome, Firefox, Opera, Safari 10.1+ */
+  ::placeholder {
+    /* Chrome, Firefox, Opera, Safari 10.1+ */
     color: lightgrey;
     opacity: 1; /* Firefox */
     font-size: 16px;
@@ -558,7 +571,8 @@ export default {
     padding-left: 7px;
   }
 
-  :-ms-input-placeholder { /* Internet Explorer 10-11 */
+  :-ms-input-placeholder {
+    /* Internet Explorer 10-11 */
     color: lightgrey;
     font-size: 16px;
     font-weight: 300;

--- a/pages/data/index.vue
+++ b/pages/data/index.vue
@@ -287,9 +287,11 @@ export default {
     if (!this.$route.query.type) {
       const firstTabType = compose(propOr('', 'type'), head)(searchTypes)
 
-      this.$router.replace({ query: { type: firstTabType } }).then(() => {
-        this.fetchFromContentful()
-      })
+      this.$router
+        .replace({ query: { type: firstTabType, ...this.$route.query } })
+        .then(() => {
+          this.fetchFromContentful()
+        })
     } else {
       this.fetchFromContentful()
     }


### PR DESCRIPTION
# Description

The purpose of this PR is to add the following for the header search component:
- Search functionality. This will take the user to the Find Data page, and search for datasets based on their input
- Hide on Find Data page

## Type of change

- [x] New feature (non-breaking change which adds functionality)

# How Has This Been Tested?

- Enter a search query in the header and click on the button
- You should be taken to the Find Data page, and you should be shown results for your query.
- The search form in the header should not be visible on the Find Data page
- Navigate to another page to reveal the search form in the header

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas