### PR TITLE
Find data - images #4a7q30

### DIFF
--- a/components/SearchResults/FileSearchResults.vue
+++ b/components/SearchResults/FileSearchResults.vue
@@ -1,0 +1,135 @@
+<template>
+  <el-table :data="tableData">
+    <el-table-column :fixed="true" prop="name" label="Name" width="300" />
+    <el-table-column prop="fileType" label="File Type" />
+    <el-table-column prop="size" label="Size">
+      <template slot-scope="scope">
+        {{ formatMetric(scope.row.size) }}
+      </template>
+    </el-table-column>
+    <el-table-column
+      align="right"
+      fixed="right"
+      label="Operation"
+      min-width="100"
+      width="100"
+    >
+      <template slot-scope="scope">
+        <el-dropdown trigger="click" @command="onCommandClick">
+          <el-button icon="el-icon-more" />
+          <el-dropdown-menu slot="dropdown">
+            <el-dropdown-item
+              :command="{
+                type: 'requestDownloadFile',
+                scope
+              }"
+            >
+              Download
+            </el-dropdown-item>
+            <el-dropdown-item
+              :command="{
+                type: 'openDataset',
+                scope
+              }"
+            >
+              Open Dataset
+            </el-dropdown-item>
+          </el-dropdown-menu>
+        </el-dropdown>
+      </template>
+    </el-table-column>
+  </el-table>
+</template>
+
+<script>
+import { compose, last, defaultTo, split, pathOr, propOr } from 'ramda'
+import StorageMetrics from '@/mixins/bf-storage-metrics'
+
+export default {
+  name: 'FileSearchResults',
+
+  mixins: [StorageMetrics],
+
+  props: {
+    tableData: {
+      type: Array,
+      default: () => []
+    }
+  },
+
+  methods: {
+    /**
+     * Callback for operations menu click
+     * Invoke method for the received command, if available
+     */
+    onCommandClick: function(evt) {
+      const scope = propOr({}, 'scope', evt)
+      const type = propOr({}, 'type', evt)
+      const handler = this[type]
+
+      if (typeof handler === 'function') {
+        handler(scope)
+      }
+    },
+
+    /**
+     * Open dataset that the file belongs to
+     * @param {Object} scope
+     */
+    openDataset: function(scope) {
+      const datasetId = pathOr('', ['row', 'datasetId'], scope)
+      if (datasetId) {
+        this.$router.push({
+          name: 'datasets-datasetId',
+          params: { datasetId }
+        })
+      }
+    },
+
+    /**
+     * Download file
+     * @param {Object} scope
+     */
+    requestDownloadFile: function(scope) {
+      const filePath = compose(
+        last,
+        defaultTo([]),
+        split('s3://blackfynn-discover-use1/'),
+        pathOr('', ['row', 'uri'])
+      )(scope)
+
+      const fileName = pathOr('', ['row', 'name'], scope)
+
+      const requestUrl = `/api/download?key=${filePath}`
+
+      this.$axios.get(requestUrl).then(response => {
+        this.downloadFile(fileName, response.data)
+      })
+    },
+
+    /**
+     * Create an `a` tag to trigger downloading file
+     * @param {String} filename
+     * @param {String} url
+     */
+    downloadFile: function(filename, url) {
+      const el = document.createElement('a')
+      el.setAttribute('href', url)
+      el.setAttribute('download', filename)
+
+      el.style.display = 'none'
+      document.body.appendChild(el)
+
+      el.click()
+
+      document.body.removeChild(el)
+    }
+  }
+}
+</script>
+
+<style lang="scss" scoped>
+.el-table {
+  width: 100%;
+}
+</style>

--- a/pages/data/index.vue
+++ b/pages/data/index.vue
@@ -137,7 +137,7 @@ const searchTypes = [
 ]
 
 const searchData = {
-  limit: 5,
+  limit: 12,
   skip: 0,
   items: []
 }

--- a/pages/data/index.vue
+++ b/pages/data/index.vue
@@ -317,8 +317,16 @@ export default {
       this.isLoadingSearch = true
 
       const searchType = pathOr('', ['query', 'type'], this.$route)
+      let url = `${process.env.discover_api_host}/search/${searchType}s?offset=${this.searchData.skip}&limit=${this.searchData.limit}&organization=SPARC%20Consortium`
+
+      if (searchType === 'file') {
+        url += '&fileType=tiff'
+      }
+
       const query = pathOr('', ['query', 'q'], this.$route)
-      const url = `${process.env.discover_api_host}/search/${searchType}s?offset=${this.searchData.skip}&limit=${this.searchData.limit}&query=${query}`
+      if (query) {
+        url += `&query=${query}`
+      }
 
       this.$axios
         .$get(url)

--- a/pages/data/index.vue
+++ b/pages/data/index.vue
@@ -93,11 +93,14 @@ const EventSearchResults = () =>
   import('@/components/SearchResults/EventSearchResults.vue')
 const DatasetSearchResults = () =>
   import('@/components/SearchResults/DatasetSearchResults.vue')
+const FileSearchResults = () =>
+  import('@/components/SearchResults/FileSearchResults.vue')
 
 const searchResultsComponents = {
   dataset: DatasetSearchResults,
   sparcAward: ProjectSearchResults,
-  event: EventSearchResults
+  event: EventSearchResults,
+  file: FileSearchResults
 }
 
 const searchTypes = [
@@ -484,6 +487,14 @@ export default {
   }
   ::v-deep .el-row--flex.is-justify-center {
     justify-content: flex-start;
+  }
+}
+.page-wrap {
+  padding-bottom: 1em;
+  padding-top: 1em;
+  @media (min-width: 48em) {
+    padding-bottom: 3em;
+    padding-top: 3em;
   }
 }
 .table-wrap {

--- a/pages/data/index.vue
+++ b/pages/data/index.vue
@@ -201,6 +201,26 @@ export default {
 
   computed: {
     /**
+     * Compute the URL for using a Blackfynn API
+     * @returns {String}
+     */
+    blackfynnApiUrl: function() {
+      const searchType = pathOr('', ['query', 'type'], this.$route)
+      let url = `${process.env.discover_api_host}/search/${searchType}s?offset=${this.searchData.skip}&limit=${this.searchData.limit}&organization=SPARC%20Consortium`
+
+      if (searchType === 'file') {
+        url += '&fileType=tiff'
+      }
+
+      const query = pathOr('', ['query', 'q'], this.$route)
+      if (query) {
+        url += `&query=${query}`
+      }
+
+      return url
+    },
+
+    /**
      * Compute search type
      * @returns {String}
      */
@@ -319,21 +339,11 @@ export default {
     fetchFromBlackfynn: function() {
       this.isLoadingSearch = true
 
-      const searchType = pathOr('', ['query', 'type'], this.$route)
-      let url = `${process.env.discover_api_host}/search/${searchType}s?offset=${this.searchData.skip}&limit=${this.searchData.limit}&organization=SPARC%20Consortium`
-
-      if (searchType === 'file') {
-        url += '&fileType=tiff'
-      }
-
-      const query = pathOr('', ['query', 'q'], this.$route)
-      if (query) {
-        url += `&query=${query}`
-      }
-
       this.$axios
-        .$get(url)
+        .$get(this.blackfynnApiUrl)
         .then(response => {
+          const searchType = pathOr('', ['query', 'type'], this.$route)
+
           const searchData = {
             skip: response.offset,
             items: response[`${searchType}s`],


### PR DESCRIPTION
# Description

The purpose of this PR is to add functionality for the images tab on the Find Data page.

Notable missing features:
- Empty state for no filters
- Ability to download a file

## Type of change

- [x] New feature (non-breaking change which adds functionality)

# How Has This Been Tested?

- Go to the Find Data page
- Click on the Images tab
- You should see search results for the images, and all search functionality should work
- Click on a file's menu button, and select "Open Dataset"
- You should be taken to that dataset's landing page

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
