### PR TITLE
Help landing page and details page #4c6hvm

### DIFF
--- a/assets/_base.scss
+++ b/assets/_base.scss
@@ -23,7 +23,7 @@ h2 {
 }
 
 h3 {
-  font-size: 2.375em;
+  font-size: 1.75em;
   font-weight: normal;
   line-height: 2.75rem;
   margin: 0 0 0.5rem;

--- a/assets/_base.scss
+++ b/assets/_base.scss
@@ -2,28 +2,64 @@ body {
   background-color: #F7FAFF;
   font-family: 'Asap', sans-serif;
   /* font-family: Asap,serif; */
+  line-height: 1.5rem;
   margin: 0;
 }
 
 h1 {
-  font-size: 3em;
+  font-size: 2.875em;
   font-weight: normal;
-  padding: 0;
   margin: 0;
+  line-height: 3.75rem;
+  padding: 0;
 }
 
 h2 {
-  font-size: 2em;
+  font-size: 2.25em;
   font-weight: normal;
+  line-height: 3rem;
+  margin: 0 0 1rem;
   padding: 0;
-  margin: 0;
 }
 
 h3 {
-  font-size: 1.5em;
+  font-size: 2.375em;
   font-weight: normal;
+  line-height: 2.75rem;
+  margin: 0 0 0.5rem;
   padding: 0;
-  margin: 0;
+}
+
+h4 {
+  font-size: 1.375em;
+  font-weight: normal;
+  line-height: 2.25rem;
+  margin: 0 0 0.5rem;
+  padding: 0;
+}
+
+h5 {
+  font-size: 1.125em;
+  font-weight: normal;
+  line-height: 1.875rem;
+  margin: 0 0 0.5rem;
+  padding: 0;
+}
+
+h6 {
+  font-size: 1em;
+  font-weight: normal;
+  line-height: 1.75rem;
+  margin: 0 0 0.5rem;
+  padding: 0;
+}
+
+p {
+  margin: 0 0 1rem;
+}
+
+hr {
+  margin: 0 0 1rem;
 }
 
 .btn-link {

--- a/assets/_layout.scss
+++ b/assets/_layout.scss
@@ -16,8 +16,9 @@
   background: #fff;
   border: 1px solid #dcdfe6;
   margin: 1em 0;
-  padding: 2em;
+  padding: 1em;
   @media (min-width: 48em) {
     margin: 2.5em 0;
-  }
+   padding: 2em;
+}
 }

--- a/assets/_layout.scss
+++ b/assets/_layout.scss
@@ -11,3 +11,13 @@
   max-width: 1280px;
   padding: 0 1em;
 }
+
+.subpage {
+  background: #fff;
+  border: 1px solid #dcdfe6;
+  margin: 1em 0;
+  padding: 2em;
+  @media (min-width: 48em) {
+    margin: 2.5em 0;
+  }
+}

--- a/components/EventBannerImage/EventBannerImage.vue
+++ b/components/EventBannerImage/EventBannerImage.vue
@@ -58,3 +58,10 @@ export default {
   }
 }
 </script>
+<style lang="scss" scoped>
+img {
+  height: auto;
+  max-width: 400px;
+  width: 100%;
+}
+</style>

--- a/components/EventCard/EventCard.vue
+++ b/components/EventCard/EventCard.vue
@@ -85,7 +85,6 @@ export default {
 .event-card {
   //   border: solid 1px $pudendal;
   border-radius: 3px 3px 0 0;
-  max-width: 800px;
   background-color: white;
   margin-bottom: 5px;
 }
@@ -130,7 +129,7 @@ h3 {
 .event-content {
   display: flex;
   flex-direction: row;
-  padding: 24px 16px;
+  // padding: 24px 16px;
   img {
     display: block;
     width: 86px;

--- a/components/HelpCard/HelpCard.vue
+++ b/components/HelpCard/HelpCard.vue
@@ -1,13 +1,13 @@
 <template>
-  <div class="event-content">
-    <div class="event-content-wrap">
+  <div class="help-card">
+    <h3>
       <nuxt-link
         :to="{ name: 'help-helpId', params: { helpId: helpItem.sys.id } }"
       >
-        <h3>{{ helpItem.title }}</h3>
+        {{ helpItem.fields.title }}
       </nuxt-link>
-      <p>{{ helpItem.summary }}</p>
-    </div>
+    </h3>
+    <p>{{ helpItem.fields.summary }}</p>
   </div>
 </template>
 
@@ -30,30 +30,4 @@ export default {
 
 <style lang="scss" scoped>
 @import '@/assets/_variables.scss';
-h3 {
-  color: $vagus;
-  font-size: 18px;
-  font-weight: 600;
-  line-height: 1.2;
-  word-break: break-word;
-}
-.event-content {
-  display: flex;
-  flex-direction: row;
-  // padding: 16px 16px;
-  background-color: white;
-  border: 0px;
-  margin-bottom: 5px;
-  min-height: 100px;
-
-  .event-content-wrap {
-    margin-left: 16px;
-    padding: 16px 80px;
-  }
-}
-a {
-  &:focus {
-    color: $vagus;
-  }
-}
 </style>

--- a/components/HelpSection/HelpSection.vue
+++ b/components/HelpSection/HelpSection.vue
@@ -1,21 +1,16 @@
 <template>
-  <!-- <div class="event-card"> -->
-  <!-- <div class="event-content"> -->
-  <div class="event-content-wrap">
-    <h3>
+  <div class="help-section">
+    <h2>
       {{ section.fields.title }}
-    </h3>
-    <div class="section events">
-      <div
+    </h2>
+    <div class="section">
+      <help-card
         v-for="(item, index) in section.fields.helpDocuments"
         :key="`${item}-${index}`"
-      >
-        <help-card :help-item="item" />
-      </div>
+        :help-item="item"
+      />
     </div>
   </div>
-  <!-- </div> -->
-  <!-- </div> -->
 </template>
 
 <script>
@@ -44,85 +39,4 @@ export default {
 
 <style lang="scss" scoped>
 @import '@/assets/_variables.scss';
-.event-card {
-  //   border: solid 1px $pudendal;
-  border-radius: 3px 3px 0 0;
-  max-width: 800px;
-}
-h3 {
-  color: $vagus;
-  font-size: 18px;
-  font-weight: 600;
-  line-height: 1.2;
-  margin: 0 0 8px;
-  word-break: break-word;
-}
-.subtitle {
-  color: #000;
-  font-size: 14px;
-  font-weight: normal;
-  line-height: 24px;
-  margin-bottom: 16px;
-}
-.details {
-  margin-top: 16px;
-  display: flex;
-  justify-content: flex-start;
-  flex-wrap: wrap;
-  .detail {
-    align-items: center;
-    display: flex;
-    padding-right: 24px;
-    color: #404554;
-    font-size: 14px;
-    font-weight: 400;
-    letter-spacing: 0px;
-    line-height: 16px;
-    margin-bottom: 8px;
-    .svg-icon {
-      margin-right: 8px;
-    }
-    .eventinfo {
-      margin-top: 8px;
-    }
-  }
-}
-.event-content {
-  display: flex;
-  flex-direction: row;
-  //   padding: 24px 16px;
-  img {
-    display: block;
-    width: 86px;
-    height: 86px;
-  }
-
-  .image {
-    margin: 2px;
-  }
-
-  .event-content-wrap {
-    margin-left: 16px;
-  }
-}
-.meta {
-  border-top: solid 1px $pudendal;
-  display: flex;
-  flex-direction: row;
-  justify-content: space-between;
-  padding: 8px 16px;
-  .author {
-    font-size: 12px;
-    line-height: 14px;
-  }
-  .tags {
-    font-size: 12px;
-    line-height: 14px;
-  }
-}
-a {
-  &:focus {
-    color: $vagus;
-  }
-}
 </style>

--- a/components/footer/Footer.vue
+++ b/components/footer/Footer.vue
@@ -8,10 +8,12 @@
       </div>
       <div class="footer__info--blurb">
         <p>
-          Lorem ipsum dolor sit amet, consectetur adipiscing sed do eiusmod tempor incididunt ut labore et dolore eiusmod magna aliqua.
-          Ut enim minim veniam, quis anim exercitation ullamco laboris nis ut aliquip ex commodo consequat.
-          Dus aute irure dolor in consectetur reprehenderit in voluptate velit esse cillum dolore fugiat nulla pariatur.
-          Excepteur sint occaecat cupidatat proident.
+          Lorem ipsum dolor sit amet, consectetur adipiscing sed do eiusmod
+          tempor incididunt ut labore et dolore eiusmod magna aliqua. Ut enim
+          minim veniam, quis anim exercitation ullamco laboris nis ut aliquip ex
+          commodo consequat. Dus aute irure dolor in consectetur reprehenderit
+          in voluptate velit esse cillum dolore fugiat nulla pariatur. Excepteur
+          sint occaecat cupidatat proident.
         </p>
       </div>
       <div class="footer__info--social">
@@ -27,7 +29,8 @@
           Data Resource Center &copy; 2020 All rights reserved.
           <nuxt-link :to="{ name: 'terms-of-service' }">
             Terms of Service
-          </nuxt-link> |
+          </nuxt-link>
+          |
           <nuxt-link :to="{ name: 'privacy' }">
             Privacy Policy
           </nuxt-link>
@@ -56,7 +59,8 @@
         <ul>
           <li>
             <a
-              href="https://www.wrike.com/frontend/requestforms/index.html?token=eyJhY2NvdW50SWQiOjMyMDM1ODgsInRhc2tGb3JtSWQiOjI2NzEzMn0JNDcyNTk5ODQyNjYyOAllODRhYTBkZWQ2ODY2Y2U3OWNhZWI5ODkyZWMwNjgyNTBiZjExMDIzMjk4MGMxZGM1MGNhYzY0ZmQxOGMxN2Ji">
+              href="https://www.wrike.com/frontend/requestforms/index.html?token=eyJhY2NvdW50SWQiOjMyMDM1ODgsInRhc2tGb3JtSWQiOjI2NzEzMn0JNDcyNTk5ODQyNjYyOAllODRhYTBkZWQ2ODY2Y2U3OWNhZWI5ODkyZWMwNjgyNTBiZjExMDIzMjk4MGMxZGM1MGNhYzY0ZmQxOGMxN2Ji"
+            >
               Site Feedback
             </a>
           </li>
@@ -88,7 +92,8 @@
           Data Resource Center &copy; 2020 All rights reserved.
           <nuxt-link :to="{ name: 'terms-of-service' }">
             Terms of Service
-          </nuxt-link> |
+          </nuxt-link>
+          |
           <nuxt-link :to="{ name: 'privacy' }">
             Privacy Policy
           </nuxt-link>
@@ -120,7 +125,9 @@ export default {
 
   &__info {
     width: 80%;
-    padding-right: 12rem;
+    @media (min-width: 64em) {
+      padding-right: 12rem;
+    }
 
     &--logo {
       height: 4rem;

--- a/pages/about/index.vue
+++ b/pages/about/index.vue
@@ -6,13 +6,15 @@
       </p>
     </page-hero>
     <div class="page-wrap container">
-      <el-row type="flex" justify="center">
-        <el-col :xs="24" :md="22" :lg="20" :xl="18">
-          <!-- eslint-disable vue/no-v-html -->
-          <!-- marked will sanitize the HTML injected -->
-          <div v-html="parseMarkdown(copy)" />
-        </el-col>
-      </el-row>
+      <div class="subpage">
+        <el-row type="flex" justify="center">
+          <el-col :row="24">
+            <!-- eslint-disable vue/no-v-html -->
+            <!-- marked will sanitize the HTML injected -->
+            <div v-html="parseMarkdown(copy)" />
+          </el-col>
+        </el-row>
+      </div>
     </div>
   </div>
 </template>
@@ -37,7 +39,7 @@ export default {
   asyncData() {
     return Promise.all([
       // Get page content
-      client.getEntry( process.env.ctf_about_page_id)
+      client.getEntry(process.env.ctf_about_page_id)
     ])
       .then(([page]) => {
         return { ...page.fields }

--- a/pages/data/index.vue
+++ b/pages/data/index.vue
@@ -1,6 +1,6 @@
 <template>
   <div class="data-page">
-    <page-hero class="subpage">
+    <page-hero>
       <search-form v-model="searchQuery" @search="submitSearch" />
 
       <ul class="search-tabs">

--- a/pages/events/_eventId.vue
+++ b/pages/events/_eventId.vue
@@ -1,39 +1,53 @@
 <template>
   <div>
-    <div class="header">
-      <div class="gradient">
-        <el-row type="flex" justify="center">
-          <el-col :xs="22" :sm="22" :md="22" :lg="20" :xl="18">
-            <div class="breadcrumb">
-              <h3>{{ event.fields.title }}</h3>
-              <p>{{ startDate }} - {{ endDate }}</p>
-            </div>
+    <page-hero>
+      <h3>{{ event.fields.title }}</h3>
+      <p>{{ startDate }} - {{ endDate }}</p>
+    </page-hero>
+
+    <div class="page-wrap container">
+      <div class="subpage">
+        <el-row :gutter="32" type="flex">
+          <el-col :xs="24" :md="6">
+            <event-banner-image :src="bannerUrl" />
+          </el-col>
+          <el-col :xs="24" :md="18">
+            <template v-if="event.fields.summary">
+              <h2>Overview</h2>
+              <p>{{ event.fields.summary }}</p>
+            </template>
+            <p>
+              {{ event.fields.eventType }} - SPARC Attendees:
+              {{ event.fields.sparcAttendees }}
+            </p>
+            <template v-if="event.fields.location">
+              <h2>Location</h2>
+              <p>{{ event.fields.location }}</p>
+            </template>
+            <template v-if="event.fields.url">
+              <h2>Website</h2>
+              <p>
+                <a :href="event.fields.url" target="_blank">
+                  <bf-button>Visit website</bf-button>
+                </a>
+              </p>
+            </template>
           </el-col>
         </el-row>
       </div>
-    </div>
-    <div :key="$route.fullPath" class="event-content">
-      <div class="image">
-        <event-banner-image :src="bannerUrl" />
-      </div>
-
-      <div class="description">
-        <h3>Overview</h3>
-        <p>{{ event.fields.description }}</p>
-      </div>
-    </div>
-
-    <div class="section">
-      {{ event.fields }}
     </div>
   </div>
 </template>
 
 <script>
-import createClient from '@/plugins/contentful.js'
-import { format, parseISO } from 'date-fns'
-import eventBannerImage from '@/components/EventBannerImage/EventBannerImage.vue'
 import { pathOr } from 'ramda'
+import { format, parseISO } from 'date-fns'
+
+import eventBannerImage from '@/components/EventBannerImage/EventBannerImage.vue'
+import PageHero from '@/components/PageHero/PageHero.vue'
+import BfButton from '@/components/shared/BfButton/BfButton.vue'
+
+import createClient from '@/plugins/contentful.js'
 
 const client = createClient()
 
@@ -41,13 +55,15 @@ export default {
   name: 'EventDetail',
 
   components: {
-    eventBannerImage
+    BfButton,
+    eventBannerImage,
+    PageHero
   },
 
-  asyncData(env) {
+  asyncData(ctx) {
     return Promise.all([
       // fetch all blog posts sorted by creation date
-      client.getEntry(env.params.eventId)
+      client.getEntry(ctx.route.params.eventId)
     ])
       .then(([events]) => {
         // return data that should be available
@@ -60,6 +76,10 @@ export default {
   },
 
   computed: {
+    /**
+     * Compute the banner URL for the event
+     * @returns {String}
+     */
     bannerUrl: function() {
       return pathOr(
         '',
@@ -67,9 +87,17 @@ export default {
         this.event
       )
     },
+    /**
+     * Compute the start date of the event
+     * @returns {String}
+     */
     startDate: function() {
       return format(parseISO(this.event.fields.startDate), 'MM/dd/yyyy')
     },
+    /**
+     * Compute the end date of the event
+     * @returns {String}
+     */
     endDate: function() {
       return format(parseISO(this.event.fields.endDate), 'MM/dd/yyyy')
     }
@@ -88,33 +116,6 @@ export default {
     .breadcrumb {
       width: 75%;
     }
-  }
-}
-
-.event-content {
-  display: flex;
-  flex-direction: row;
-  padding: 24px 16px;
-  img {
-    display: block;
-    width: 200px;
-    height: 200px;
-  }
-
-  h3: {
-    margin-bottom: 8px;
-  }
-
-  .image {
-    margin: 16px;
-  }
-
-  .description {
-    max-width: 600px;
-  }
-
-  .event-content-wrap {
-    margin-left: 16px;
   }
 }
 </style>

--- a/pages/events/index.vue
+++ b/pages/events/index.vue
@@ -1,24 +1,23 @@
 <template>
   <div class="events-page">
-    <div class="header">
-      <div class="gradient">
+    <page-hero>
+      <h3>SPARC Events:</h3>
+      <p>
+        Join the SPARC teams at the following events, conferences and workshops
+      </p>
+    </page-hero>
+
+    <div class="page-wrap container">
+      <div class="subpage">
         <el-row type="flex" justify="center">
-          <el-col :xs="22" :sm="22" :md="22" :lg="20" :xl="18">
-            <div class="breadcrumb">
-              <h3>SPARC Events:</h3>
-              <p>
-                Join the SPARC teams at the following events, conferences and
-                workshops
-              </p>
-            </div>
+          <el-col :row="24">
+            <event-card
+              v-for="(event, index) in events"
+              :key="`${event}-${index}`"
+              :event="event"
+            />
           </el-col>
         </el-row>
-      </div>
-    </div>
-
-    <div class="section events">
-      <div v-for="(event, index) in events" :key="`${event}-${index}`">
-        <event-card :event="event" />
       </div>
     </div>
   </div>
@@ -26,6 +25,7 @@
 
 <script>
 import EventCard from '@/components/EventCard/EventCard.vue'
+import PageHero from '@/components/PageHero/PageHero.vue'
 import createClient from '@/plugins/contentful.js'
 
 const client = createClient()
@@ -33,7 +33,8 @@ const client = createClient()
 export default {
   name: 'EventPage',
   components: {
-    EventCard
+    EventCard,
+    PageHero
   },
 
   asyncData() {
@@ -60,25 +61,7 @@ export default {
 
 <style lang="scss" scoped>
 @import '@/assets/_variables.scss';
-.header {
-  .gradient {
-    padding: 1.5em 0;
-    color: #f0f2f5;
-    background-image: linear-gradient(90deg, #0026ff 0%, #00ffb9 100%);
-
-    .breadcrumb {
-      width: 75%;
-    }
-  }
-}
-
-.events-page {
-  margin-top: 7rem;
-}
-
-.events {
-  margin-left: 32px;
-  margin: 24px auto;
-  width: 80%;
+.event-card {
+  margin-bottom: 2em;
 }
 </style>

--- a/pages/help/_helpId.vue
+++ b/pages/help/_helpId.vue
@@ -1,6 +1,6 @@
 <template>
   <div class="events-page">
-    <page-hero class="subpage">
+    <page-hero>
       <HelpSearchControls
         :search-on-load="true"
         submit-text="Go"
@@ -8,7 +8,7 @@
       />
     </page-hero>
     <div class="page-wrap container">
-      <div class="help-section">
+      <div class="subpage">
         <div class="header">
           <h2>{{ helpItem.fields.title }}</h2>
           <div class="summary">
@@ -49,14 +49,15 @@ export default {
   mixins: [MarkedMixin],
 
   asyncData(env) {
-    console.log('fetching data: ' + process.env.ctf_help_id)
     return Promise.all([client.getEntry(env.params.helpId)])
       .then(([helpItem]) => {
         return {
           helpItem: helpItem
         }
       })
-      .catch(console.error)
+      .catch(() => {
+        throw Error
+      })
   },
 
   computed: {
@@ -87,47 +88,24 @@ export default {
 
 <style lang="scss" scoped>
 @import '@/assets/_variables.scss';
-.help-section {
-  color: $vestibular;
-  margin-top: 32px;
-  margin: 24px auto;
-  width: 80%;
-  background-color: #fff;
-  padding: 8px;
-  border-radius: 16px;
-  max-width: 900px;
 
-  @media screen and (min-width: 48em) {
-    padding: 16px 120px;
+.content {
+  & ::v-deep {
+    color: $vestibular;
   }
-
-  .content {
-    & ::v-deep {
-      color: $vestibular;
-    }
-    & ::v-deep p {
-      margin-bottom: 8px;
-    }
-    & ::v-deep img {
-      width: 100%;
-      margin: 5px 0;
-    }
+  & ::v-deep p {
+    margin-bottom: 8px;
   }
+  & ::v-deep img {
+    width: 100%;
+    margin: 5px 0;
+  }
+}
 
-  .header {
-    margin-bottom: 48px;
-    h2 {
-      color: $vagus;
-    }
-    .summary {
-      font-size: 1.1em;
-      color: grey;
-      margin-bottom: 8px;
-    }
-
-    .updated {
-      color: #aaa;
-    }
+.header {
+  margin-bottom: 3em;
+  .updated {
+    color: #aaa;
   }
 }
 </style>

--- a/pages/help/index.vue
+++ b/pages/help/index.vue
@@ -8,6 +8,11 @@
       <p>
         <!-- {{ heroCopy }} -->
       </p>
+      <HelpSearchControls
+        :search-on-load="true"
+        submit-text="Go"
+        @query="onSearchQuery"
+      />
     </page-hero>
 
     <div class="page-wrap container">
@@ -38,6 +43,7 @@
 
 <script>
 import HelpSection from '@/components/HelpSection/HelpSection.vue'
+import HelpSearchControls from '@/components/help-search-controls/HelpSearchControls.vue'
 import PageHero from '@/components/PageHero/PageHero.vue'
 import createClient from '@/plugins/contentful.js'
 
@@ -48,6 +54,7 @@ export default {
 
   components: {
     HelpSection,
+    HelpSearchControls,
     PageHero
   },
 
@@ -60,21 +67,6 @@ export default {
         return {
           helpData: resp.fields
         }
-        // let docDict = {}
-        // for (let i = 0; i < docs.items.length; i++) {
-        //   docDict[docs.items[i].sys.id] = docs.items[i].fields
-        // }
-        // for (let i = 0; i < resp.fields.sections.length; i++) {
-        //   var curSection = resp.fields.sections[i]
-        //   for (let j = 0; j < curSection.fields.helpDocuments.length; j++) {
-        //     let curDoc = curSection.fields.helpDocuments[j]
-        //     curDoc['title'] = docDict[curDoc.sys.id]['title']
-        //     curDoc['summary'] = docDict[curDoc.sys.id]['summary']
-        //   }
-        // }
-        // return {
-        //   topics: resp
-        // }
       })
       .catch(console.error)
   },
@@ -82,6 +74,12 @@ export default {
   data() {
     return {
       helpData: []
+    }
+  },
+
+  methods: {
+    onSearchQuery: function() {
+      return 0
     }
   }
 }

--- a/pages/help/index.vue
+++ b/pages/help/index.vue
@@ -1,9 +1,9 @@
 <template>
-  <div class="events-page">
-    <page-hero class="subpage">
-      <h3>SPARC Support Center</h3>
+  <div class="help-page">
+    <page-hero>
+      <h2>{{ helpData.title }}</h2>
       <p>
-        Documentation about SPARC, Data, Maps, and Simulation resources
+        {{ helpData.summary }}
       </p>
       <p>
         <!-- {{ heroCopy }} -->
@@ -11,27 +11,27 @@
     </page-hero>
 
     <div class="page-wrap container">
-      <el-row type="flex" justify="center">
-        <el-col :xs="24" :md="22" :lg="6">
-          <h2>Menu</h2>
-          <ul>
-            <li><a href="#">Lorem Ipsum</a></li>
-            <li><a href="#">Lorem Ipsum</a></li>
-            <li><a href="#">Lorem Ipsum</a></li>
-            <li><a href="#">Lorem Ipsum</a></li>
-          </ul>
-        </el-col>
-        <el-col :xs="24" :md="22" :lg="18">
-          <div
-            v-for="(item, index) in topics.fields.sections"
-            :key="`${item}-${index}`"
-          >
-            <div class="help-section">
-              <help-section :section="item" />
-            </div>
-          </div>
-        </el-col>
-      </el-row>
+      <div class="subpage">
+        <el-row type="flex" :gutter="32">
+          <el-col :xs="24" :md="22" :lg="6">
+            <h2>Menu</h2>
+            <ul>
+              <li><a href="#">Lorem Ipsum</a></li>
+              <li><a href="#">Lorem Ipsum</a></li>
+              <li><a href="#">Lorem Ipsum</a></li>
+              <li><a href="#">Lorem Ipsum</a></li>
+            </ul>
+          </el-col>
+          <el-col :xs="24" :md="22" :lg="18">
+            <help-section
+              v-for="item in helpData.sections"
+              :key="item.sys.id"
+              class="help-section"
+              :section="item"
+            />
+          </el-col>
+        </el-row>
+      </div>
     </div>
   </div>
 </template>
@@ -54,65 +54,42 @@ export default {
   asyncData() {
     return Promise.all([
       // fetch all blog posts sorted by creation date
-      client.getEntry(process.env.ctf_support_page_id, { include: 1 }),
-      client.getEntries({
-        content_type: 'helpDocument',
-        select: 'fields.title,fields.summary'
-      })
+      client.getEntry(process.env.ctf_support_page_id, { include: 2 })
     ])
-      .then(([resp, docs]) => {
-        let docDict = {}
-        for (let i = 0; i < docs.items.length; i++) {
-          docDict[docs.items[i].sys.id] = docs.items[i].fields
-        }
-
-        for (let i = 0; i < resp.fields.sections.length; i++) {
-          var curSection = resp.fields.sections[i]
-          for (let j = 0; j < curSection.fields.helpDocuments.length; j++) {
-            let curDoc = curSection.fields.helpDocuments[j]
-            curDoc['title'] = docDict[curDoc.sys.id]['title']
-            curDoc['summary'] = docDict[curDoc.sys.id]['summary']
-          }
-        }
+      .then(([resp]) => {
         return {
-          topics: resp
+          helpData: resp.fields
         }
+        // let docDict = {}
+        // for (let i = 0; i < docs.items.length; i++) {
+        //   docDict[docs.items[i].sys.id] = docs.items[i].fields
+        // }
+        // for (let i = 0; i < resp.fields.sections.length; i++) {
+        //   var curSection = resp.fields.sections[i]
+        //   for (let j = 0; j < curSection.fields.helpDocuments.length; j++) {
+        //     let curDoc = curSection.fields.helpDocuments[j]
+        //     curDoc['title'] = docDict[curDoc.sys.id]['title']
+        //     curDoc['summary'] = docDict[curDoc.sys.id]['summary']
+        //   }
+        // }
+        // return {
+        //   topics: resp
+        // }
       })
       .catch(console.error)
   },
 
-  computed: {}
+  data() {
+    return {
+      helpData: []
+    }
+  }
 }
 </script>
 
 <style lang="scss" scoped>
 @import '@/assets/_variables.scss';
-.header {
-  margin-top: 7rem;
-  .gradient {
-    padding: 1.5em 0;
-    color: #f0f2f5;
-    background-image: linear-gradient(90deg, #0026ff 0%, #00ffb9 100%);
-
-    .breadcrumb {
-      width: 75%;
-    }
-  }
-}
-
 .help-section {
-  color: $vestibular;
-  margin-top: 32px;
-  margin: 24px auto;
-  width: 80%;
-  // background-color: #FFF;
-  padding: 16px 120px;
-  // padding-right: 120px;
-  border-radius: 16px;
-  max-width: 900px;
-
-  @media screen and (max-width: 800px) {
-    padding: 8px;
-  }
+  margin: 0 0 2em;
 }
 </style>

--- a/pages/privacy/index.vue
+++ b/pages/privacy/index.vue
@@ -1,6 +1,19 @@
 <template>
   <div class="privacy-policy">
-    Privacy Policy
+    <div class="page-wrap container">
+      <div class="subpage">
+        <el-row type="flex" justify="center">
+          <el-col :row="24">
+            <p>
+              Lorem ipsum dolor sit amet consectetur adipisicing elit. Amet
+              similique numquam accusamus quae, aliquid vero obcaecati facilis
+              reprehenderit. Fugit quibusdam placeat repellendus vitae similique
+              reprehenderit, aspernatur velit blanditiis non dicta.
+            </p>
+          </el-col>
+        </el-row>
+      </div>
+    </div>
   </div>
 </template>
 
@@ -10,8 +23,4 @@ export default {
 }
 </script>
 
-<style lang="scss" scoped>
-.privacy-policy {
-  margin-top: 9rem;
-}
-</style>
+<style lang="scss" scoped></style>

--- a/pages/resources/index.vue
+++ b/pages/resources/index.vue
@@ -1,17 +1,40 @@
 <template>
-<div class="resources">
-    Resources
-</div>
+  <div class="resources">
+    <page-hero v-if="heroCopy" class="subpage">
+      <p>
+        {{ heroCopy }}
+      </p>
+    </page-hero>
+    <div class="page-wrap container">
+      <div class="subpage">
+        <el-row type="flex" justify="center">
+          <el-col :row="24" />
+        </el-row>
+      </div>
+    </div>
+  </div>
 </template>
 
 <script>
+import PageHero from '@/components/PageHero/PageHero.vue'
+
 export default {
-  name: 'Resources'
+  name: 'Resources',
+
+  components: {
+    PageHero
+  },
+
+  data() {
+    return {
+      heroCopy: ''
+    }
+  }
 }
 </script>
 
 <style lang="scss" scoped>
- .resources {
-   margin-top: 9rem;
- }
+.resources {
+  margin-top: 9rem;
+}
 </style>

--- a/pages/terms-of-service/index.vue
+++ b/pages/terms-of-service/index.vue
@@ -1,6 +1,19 @@
 <template>
   <div class="terms-of-service">
-    Terms of Service
+    <div class="page-wrap container">
+      <div class="subpage">
+        <el-row type="flex" justify="center">
+          <el-col :row="24">
+            <p>
+              Lorem ipsum dolor sit amet consectetur adipisicing elit. Amet
+              similique numquam accusamus quae, aliquid vero obcaecati facilis
+              reprehenderit. Fugit quibusdam placeat repellendus vitae similique
+              reprehenderit, aspernatur velit blanditiis non dicta.
+            </p>
+          </el-col>
+        </el-row>
+      </div>
+    </div>
   </div>
 </template>
 
@@ -10,8 +23,4 @@ export default {
 }
 </script>
 
-<style lang="scss" scoped>
-.terms-of-service {
-  margin-top: 9rem;
-}
-</style>
+<style lang="scss" scoped></style>


### PR DESCRIPTION
# Description

The purpose of this PR is to fix and style the get help landing page and details pages. This functionality was broken due to some Contentful changes. 

## Type of change

- [x] New feature (non-breaking change which adds functionality)

# How Has This Been Tested?

- Go to the "Need Help" landing page by using the aux nav in the header
- You should see a list of help articles grouped by their sections.
- Click on one of the help article's headings to go to its details page
- You should see the help article's content wrapped in the Basic Page Layout.

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
