### PR TITLE
Atlas page use the basic page layout

### DIFF
--- a/pages/atlas/index.vue
+++ b/pages/atlas/index.vue
@@ -1,7 +1,11 @@
 <template>
-<div class="atlas">
-    Atlas
-</div>
+  <div class="atlas">
+    <div class="container">
+      <div class="subpage">
+        Atlas
+      </div>
+    </div>
+  </div>
 </template>
 
 <script>
@@ -9,12 +13,3 @@ export default {
   name: 'Atlas'
 }
 </script>
-
-<style lang="scss" scoped>
-.atlas {
-  margin-top: 8rem;
-  @media screen and (max-width: 1023px) {
-    margin-top: 3rem;
-  }
-}
-</style>


### PR DESCRIPTION
# Description

The purpose of this PR is to have the atlas page use the basic page layout. This is an empty page and will be used for the Atlas component that the MAP Core is creating.

## Type of change

- [x] New feature (non-breaking change which adds functionality)

# How Has This Been Tested?

- Visit the Atlas page using the main navigation
- You should see the page in the basic page layout

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
