### PR TITLE
Find Data - Organs

### DIFF
--- a/components/SearchResults/OrganSearchResults.vue
+++ b/components/SearchResults/OrganSearchResults.vue
@@ -1,0 +1,79 @@
+<template>
+  <el-table :data="tableData">
+    <el-table-column
+      :fixed="true"
+      prop="fields.title"
+      label="Title"
+      width="300"
+    >
+      <template slot-scope="scope">
+        <nuxt-link
+          :to="{
+            name: 'organs-organId',
+            params: { organId: scope.row.sys.id }
+          }"
+        >
+          {{ scope.row.fields.name }}
+        </nuxt-link>
+      </template>
+    </el-table-column>
+    <el-table-column :fixed="true" prop="fields.title" label="Banner">
+      <template slot-scope="scope">
+        <img
+          :src="getImageSrc(scope)"
+          :alt="getImageAlt(scope)"
+          height="128"
+          width="128"
+        />
+      </template>
+    </el-table-column>
+  </el-table>
+</template>
+
+<script>
+import { pathOr } from 'ramda'
+
+export default {
+  name: 'OrganSearchResults',
+
+  props: {
+    tableData: {
+      type: Array,
+      default: () => []
+    }
+  },
+
+  methods: {
+    /**
+     * Get image source
+     * @param {Object} scope
+     * @returns {String}
+     */
+    getImageSrc: function(scope) {
+      return pathOr(
+        '',
+        ['row', 'fields', 'bannerImage', 'fields', 'file', 'url'],
+        scope
+      )
+    },
+    /**
+     * Get image source
+     * @param {Object} scope
+     * @returns {String}
+     */
+    getImageAlt: function(scope) {
+      return pathOr(
+        '',
+        ['row', 'fields', 'bannerImage', 'fields', 'file', 'description'],
+        scope
+      )
+    }
+  }
+}
+</script>
+
+<style lang="scss" scoped>
+.el-table {
+  width: 100%;
+}
+</style>

--- a/nuxt.config.js
+++ b/nuxt.config.js
@@ -42,6 +42,7 @@ export default {
     ctf_support_page_id: '59F0dM5goobqjw3TsqINRw',
     ctf_home_page_id: '4qJ9WUWXg09FAUvCnbGxBY',
     ctf_project_id: 'sparcAward',
+    ctf_organ_id: 'organ',
     ctf_filter_id: '6bya4tyw8399',
     ctf_filters_dataset_id: '7fL88ABgKSB2tPJmysn2V',
     ctf_filters_project_id: 'YVan5NSd4bgj2Q5WZdOVw',

--- a/pages/data/index.vue
+++ b/pages/data/index.vue
@@ -95,12 +95,15 @@ const DatasetSearchResults = () =>
   import('@/components/SearchResults/DatasetSearchResults.vue')
 const FileSearchResults = () =>
   import('@/components/SearchResults/FileSearchResults.vue')
+const OrganSearchResults = () =>
+  import('@/components/SearchResults/OrganSearchResults.vue')
 
 const searchResultsComponents = {
   dataset: DatasetSearchResults,
   sparcAward: ProjectSearchResults,
   event: EventSearchResults,
-  file: FileSearchResults
+  file: FileSearchResults,
+  organ: OrganSearchResults
 }
 
 const searchTypes = [
@@ -118,7 +121,7 @@ const searchTypes = [
   },
   {
     label: 'Organs',
-    type: 'organ',
+    type: process.env.ctf_organ_id,
     filterId: process.env.ctf_filters_organ_id,
     dataSource: 'contentful'
   },

--- a/pages/organs/_organId.vue
+++ b/pages/organs/_organId.vue
@@ -1,0 +1,11 @@
+<template>
+  <div />
+</template>
+
+<script>
+export default {
+  name: 'OrganDetails'
+}
+</script>
+
+<style lang="scss" scoped></style>


### PR DESCRIPTION
# Description
The purpose of this PR is to add the logic for Find Data - Organs. Please note, the [columns for the search results are not yet defined](https://www.wrike.com/open.htm?id=452840115).

## Type of change

- [x] New feature (non-breaking change which adds functionality)

# How Has This Been Tested?

- Go to the Data page
- Go to the Organs tab
- One organ should load
- Click on the organ's name
- You should be taken to the organ's details page (this page has no functionality, and only serves as a dynamic route at the moment.)

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
