### PR TITLE
Find data filters active filters change #4a9p4j

### DIFF
--- a/components/SearchFilters/SearchFilters.vue
+++ b/components/SearchFilters/SearchFilters.vue
@@ -5,7 +5,7 @@
     @open="onOpen"
     @close="closeDialog"
   >
-    <bf-dialog-header slot="title" :title="dialogHeader" />
+    <bf-dialog-header slot="title" :title="dialogTitle" />
 
     <dialog-body>
       <template v-for="filter in filters">
@@ -38,15 +38,7 @@
 </template>
 
 <script>
-import {
-  assocPath,
-  clone,
-  compose,
-  filter,
-  propEq,
-  flatten,
-  pluck
-} from 'ramda'
+import { clone } from 'ramda'
 import BfDialogHeader from '@/components/bf-dialog-header/BfDialogHeader.vue'
 import DialogBody from '@/components/dialog-body/DialogBody.vue'
 import BfButton from '@/components/shared/BfButton/BfButton.vue'
@@ -78,35 +70,16 @@ export default {
     isLoading: {
       type: Boolean,
       default: false
+    },
+    dialogTitle: {
+      type: String,
+      default: ''
     }
   },
 
   data() {
     return {
       filters: []
-    }
-  },
-
-  computed: {
-    /**
-     * Compute active filters
-     * @returns {Array}
-     */
-    activeFilters: function() {
-      return compose(
-        filter(propEq('value', true)),
-        flatten,
-        pluck('filters')
-      )(this.filters)
-    },
-
-    /**
-     * Compute dialog header based on how many active filters
-     * @returns {String}
-     */
-    dialogHeader: function() {
-      const activeFilterLength = this.activeFilters.length
-      return activeFilterLength ? `Filters (${activeFilterLength})` : `Filters`
     }
   },
 

--- a/components/SearchFilters/SearchFilters.vue
+++ b/components/SearchFilters/SearchFilters.vue
@@ -8,26 +8,6 @@
     <bf-dialog-header slot="title" :title="dialogHeader" />
 
     <dialog-body>
-      <div v-if="activeFilters.length" class="active__filters-wrap">
-        <div class="active__filters">
-          <div
-            v-for="(filter, filterIdx) in filters"
-            :key="filter.category"
-            class="active__filters__category"
-          >
-            <template v-for="(item, itemIdx) in filter.filters">
-              <el-tag
-                v-if="item.value"
-                :key="`${item.key}`"
-                closable
-                @close="clearFilter(filterIdx, itemIdx)"
-              >
-                {{ item.label }}
-              </el-tag>
-            </template>
-          </div>
-        </div>
-      </div>
       <template v-for="filter in filters">
         <div :key="filter.category">
           <h3>
@@ -153,20 +133,6 @@ export default {
     applyFilters: function() {
       this.$emit('input', this.filters)
       this.closeDialog()
-    },
-
-    /**
-     * Clear filter's value
-     * @param {Number} filterIdx
-     * @param {Number} itemIdx
-     */
-    clearFilter: function(filterIdx, itemIdx) {
-      const filters = assocPath(
-        [filterIdx, 'filters', itemIdx, 'value'],
-        false,
-        this.filters
-      )
-      this.filters = filters
     },
 
     /**

--- a/pages/data/index.vue
+++ b/pages/data/index.vue
@@ -34,7 +34,7 @@
                 @click="isFiltersVisible = true"
               >
                 <svg-icon name="icon-preset" height="20" width="20" />
-                Filters
+                {{ activeFiltersLabel }}
               </button>
             </div>
           </div>
@@ -76,6 +76,7 @@
       v-model="filters"
       :visible.sync="isFiltersVisible"
       :is-loading="isLoadingFilters"
+      :dialog-title="activeFiltersLabel"
     />
   </div>
 </template>
@@ -302,6 +303,27 @@ export default {
         flatten,
         pluck('items')
       )(this.filters)
+    },
+
+    /**
+     * Compute active filters
+     * @returns {Array}
+     */
+    activeFilters: function() {
+      return compose(
+        filter(propEq('value', true)),
+        flatten,
+        pluck('filters')
+      )(this.filters)
+    },
+
+    /**
+     * Compute dialog header based on how many active filters
+     * @returns {String}
+     */
+    activeFiltersLabel: function() {
+      const activeFilterLength = this.activeFilters.length
+      return activeFilterLength ? `Filters (${activeFilterLength})` : `Filters`
     }
   },
 

--- a/pages/data/index.vue
+++ b/pages/data/index.vue
@@ -38,6 +38,26 @@
               </button>
             </div>
           </div>
+          <div class="mb-16">
+            <div class="active__filter__wrap">
+              <div
+                v-for="(filter, filterIdx) in filters"
+                :key="filter.category"
+                class="active__filter__wrap-category"
+              >
+                <template v-for="(item, itemIdx) in filter.filters">
+                  <el-tag
+                    v-if="item.value"
+                    :key="`${item.key}`"
+                    closable
+                    @close="clearFilter(filterIdx, itemIdx)"
+                  >
+                    {{ item.label }}
+                  </el-tag>
+                </template>
+              </div>
+            </div>
+          </div>
           <div v-loading="isLoadingSearch" class="table-wrap">
             <component :is="searchResultsComponent" :table-data="tableData" />
             <el-pagination
@@ -62,6 +82,7 @@
 
 <script>
 import {
+  assocPath,
   clone,
   compose,
   defaultTo,
@@ -417,6 +438,20 @@ export default {
       this.$router.replace({ query }).then(() => {
         this.fetchResults()
       })
+    },
+
+    /**
+     * Clear filter's value
+     * @param {Number} filterIdx
+     * @param {Number} itemIdx
+     */
+    clearFilter: function(filterIdx, itemIdx) {
+      const filters = assocPath(
+        [filterIdx, 'filters', itemIdx, 'value'],
+        false,
+        this.filters
+      )
+      this.filters = filters
     }
   }
 }
@@ -535,5 +570,12 @@ export default {
   .svg-icon {
     margin-right: 0.3125rem;
   }
+}
+.active__filter__wrap,
+.active__filter__wrap-category {
+  display: inline;
+}
+.active__filter__wrap .el-tag {
+  margin: 0.5em 1em 0.5em 0;
 }
 </style>


### PR DESCRIPTION
# Description

The purpose of this PR is to change where the active filters are displayed. This comes from the latest design changes.

## Type of change
- [x] New feature (non-breaking change which adds functionality)

# How Has This Been Tested?

- Go to the Find Data page

- Click on the Filters button. Dialog should open.
- Select two of the filters.
- Click "Apply"
- Dialog should be closed
- Active filters should be displays above the table
- Click on one of the filter tags' X icon at the top to deselect it.
- The filters list should be updated, including the number of filters in the Filters button's label
- Click on thee Filters button
- Checked filters should be updated to reflect the filters you removed on the main page.

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
