### PR TITLE
feat(find data - simulations): add logic to handle Simulations tab

### DIFF
--- a/pages/data/index.vue
+++ b/pages/data/index.vue
@@ -96,7 +96,8 @@ const searchResultsComponents = {
   sparcAward: ProjectSearchResults,
   event: EventSearchResults,
   file: FileSearchResults,
-  organ: OrganSearchResults
+  organ: OrganSearchResults,
+  simulation: DatasetSearchResults,
 }
 
 const searchTypes = [
@@ -128,7 +129,7 @@ const searchTypes = [
     label: 'Simulations',
     type: 'simulation',
     filterId: process.env.ctf_filters_simulation_id,
-    dataSource: 'contentful'
+    dataSource: 'blackfynn'
   }
 ]
 
@@ -203,7 +204,11 @@ export default {
      */
     blackfynnApiUrl: function() {
       const searchType = pathOr('', ['query', 'type'], this.$route)
-      let url = `${process.env.discover_api_host}/search/${searchType}s?offset=${this.searchData.skip}&limit=${this.searchData.limit}&organization=SPARC%20Consortium`
+      let url = `${process.env.discover_api_host}/search/${
+        searchType === 'simulation' ? 'dataset' : searchType
+      }s?offset=${this.searchData.skip}&limit=${this.searchData.limit}&${
+        searchType === 'simulation' ? 'tags=simcore' : 'organization=SPARC%20Consortium'
+      }`
 
       if (searchType === 'file') {
         url += '&fileType=tiff'
@@ -342,7 +347,7 @@ export default {
           const searchType = pathOr('', ['query', 'type'], this.$route)
           const searchData = {
             skip: response.offset,
-            items: response[`${searchType}s`],
+            items: response[`${searchType === 'simulation' ? 'dataset' : searchType}s`],
             total: response.totalCount
           }
           this.searchData = mergeLeft(searchData, this.searchData)


### PR DESCRIPTION
# Description

The simulations tab uses the same DatasetSearchResults component as the Datasets tab.  It adjusts
the search url to search for datasets with the simcore tag instead of datasets in the
SPARC Consortium organization.

Closes #4a7r4t

## Type of change

Delete those that don't apply.

- [x] New feature (non-breaking change which adds functionality)

# How Has This Been Tested?

The Find Data - Simulations tab should now work.

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
