### PR TITLE
Typescript, Help Docs Search, Footer Copy

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,3 +11,4 @@ env/
 *.pyc
 __pycache__/
 .idea
+*.iml

--- a/components/HelpCard/HelpCard.vue
+++ b/components/HelpCard/HelpCard.vue
@@ -1,7 +1,7 @@
 <template>
   <div class="help-card">
     <h3>
-      <nuxt-link
+      <nuxt-link class="help-link"
         :to="{ name: 'help-helpId', params: { helpId: helpItem.sys.id } }"
       >
         {{ helpItem.fields.title }}
@@ -33,4 +33,10 @@ export default Vue.extend<never, never, never, { helpItem: HelpDocument }>({
 
 <style lang="scss" scoped>
 @import '@/assets/_variables.scss';
+.help-link {
+  color: $median
+}
+.help-link:not(:hover) {
+  text-decoration: none;
+}
 </style>

--- a/components/HelpCard/HelpCard.vue
+++ b/components/HelpCard/HelpCard.vue
@@ -11,21 +11,24 @@
   </div>
 </template>
 
-<script>
-export default {
+<script lang="ts">
+import Vue from 'vue';
+import {HelpDocument} from "~/pages/help/model";
+
+export default Vue.extend<never, never, never, { helpItem: HelpDocument }>({
   name: 'HelpCard',
   props: {
     helpItem: {
       type: Object,
       default: () => {
         return {
-          title: ''
-        }
+          sys: {},
+          fields: {}
+        } as HelpDocument
       }
     }
-  },
-  methods: {}
-}
+  }
+})
 </script>
 
 <style lang="scss" scoped>

--- a/components/HelpSection/HelpSection.vue
+++ b/components/HelpSection/HelpSection.vue
@@ -1,14 +1,28 @@
 <template>
-  <div class="help-section">
-    <h2>
-      {{ section.fields.title }}
-    </h2>
-    <div class="section">
-      <help-card
-        v-for="(item, index) in section.fields.helpDocuments"
-        :key="`${item}-${index}`"
-        :help-item="item"
-      />
+  <div class="page-wrap container">
+    <div class="subpage">
+      <el-row type="flex" :gutter="32">
+        <el-col :xs="24" :md="22" :lg="18">
+          <div class="help-section">
+            <h2>
+              {{ section.fields.title }}
+            </h2>
+            <div class="section">
+              <div v-if="section.fields.helpDocuments.length === 0 && searchTerms.length > 0">
+                <div>
+                  No results found for <span class="search-term">"{{ searchTerms }}"</span>
+                </div>
+                <div>Please try entering another search term.</div>
+              </div>
+              <help-card
+                v-for="(item, index) in section.fields.helpDocuments"
+                :key="`${item}-${index}`"
+                :help-item="item"
+              />
+            </div>
+          </div>
+        </el-col>
+      </el-row>
     </div>
   </div>
 </template>
@@ -17,9 +31,8 @@
 import Vue from 'vue';
 import HelpCard from '@/components/HelpCard/HelpCard.vue'
 import {HelpSection} from "~/pages/help/model";
-import {Sys} from "contentful";
 
-export default Vue.extend<never, never, never, { section: HelpSection }>({
+export default Vue.extend<never, never, never, { section: HelpSection, searchTerms: string }>({
   name: 'HelpSection',
   components: {
     HelpCard
@@ -33,6 +46,10 @@ export default Vue.extend<never, never, never, { section: HelpSection }>({
           fields: {}
         } as HelpSection
       }
+    },
+    searchTerms: {
+      type: String,
+      default: ''
     }
   }
 })
@@ -40,4 +57,10 @@ export default Vue.extend<never, never, never, { section: HelpSection }>({
 
 <style lang="scss" scoped>
 @import '@/assets/_variables.scss';
+.help-section {
+  margin: 0 auto 2em auto;
+}
+.search-term {
+  font-weight: bold;
+}
 </style>

--- a/components/HelpSection/HelpSection.vue
+++ b/components/HelpSection/HelpSection.vue
@@ -13,10 +13,13 @@
   </div>
 </template>
 
-<script>
+<script lang="ts">
+import Vue from 'vue';
 import HelpCard from '@/components/HelpCard/HelpCard.vue'
+import {HelpSection} from "~/pages/help/model";
+import {Sys} from "contentful";
 
-export default {
+export default Vue.extend<never, never, never, { section: HelpSection }>({
   name: 'HelpSection',
   components: {
     HelpCard
@@ -26,15 +29,13 @@ export default {
       type: Object,
       default: () => {
         return {
-          title: '',
           sys: {},
-          summary: ''
-        }
+          fields: {}
+        } as HelpSection
       }
     }
-  },
-  methods: {}
-}
+  }
+})
 </script>
 
 <style lang="scss" scoped>

--- a/components/PageHero/PageHero.vue
+++ b/components/PageHero/PageHero.vue
@@ -1,7 +1,7 @@
 <template>
   <div class="page-hero">
     <div class="container">
-      <el-row type="flex" justify="center">
+      <el-row type="flex" :justify="justify">
         <el-col :xs="22" :sm="22" :md="22" :lg="20" :xl="18">
           <slot />
         </el-col>
@@ -12,7 +12,13 @@
 
 <script>
 export default {
-  name: 'PageHero'
+  name: 'PageHero',
+  props: {
+    justify: {
+      type: String,
+      default: 'center'
+    }
+  }
 }
 </script>
 

--- a/components/footer/Footer.vue
+++ b/components/footer/Footer.vue
@@ -8,12 +8,7 @@
       </div>
       <div class="footer__info--blurb">
         <p>
-          Lorem ipsum dolor sit amet, consectetur adipiscing sed do eiusmod
-          tempor incididunt ut labore et dolore eiusmod magna aliqua. Ut enim
-          minim veniam, quis anim exercitation ullamco laboris nis ut aliquip ex
-          commodo consequat. Dus aute irure dolor in consectetur reprehenderit
-          in voluptate velit esse cillum dolore fugiat nulla pariatur. Excepteur
-          sint occaecat cupidatat proident.
+          {{ footerData }}
         </p>
       </div>
       <div class="footer__info--social">
@@ -105,11 +100,18 @@
 
 <script>
 import SparcLogo from '@/components/logo/SparcLogo.vue'
+import { mapState } from 'vuex'
 
 export default {
   name: 'SparcFooter',
   components: {
     SparcLogo
+  },
+
+  computed: {
+    ...mapState({
+      footerData: 'footerData'
+    })
   }
 }
 </script>

--- a/components/help-search-controls/HelpSearchControls.vue
+++ b/components/help-search-controls/HelpSearchControls.vue
@@ -67,8 +67,8 @@ export default {
      * Clear search
      */
     clearSearch: function() {
-      // this.terms = ''
-      // this.submit()
+      this.terms = ''
+      this.submit()
     },
 
     /**

--- a/components/help-search-controls/HelpSearchControls.vue
+++ b/components/help-search-controls/HelpSearchControls.vue
@@ -1,29 +1,15 @@
 <template>
-  <div class="controls">
-    <div v-if="isSearchVisible" class="control control-search-input">
-      <el-input
-        v-model="terms"
-        placeholder="Search Documentation..."
-        suffix-icon="el-icon-search"
-        @keyup.native.enter="submit"
-      />
-    </div>
-    <div v-if="isSearchVisible" class="search-button">
-      <el-button
-        type="primary"
-        class="view-search-results"
-        @click.native="submit"
-      >
-        {{ submitText }}
-      </el-button>
-      <el-button
-        v-if="isClearSearchVisible"
-        class="btn-clear-search"
-        @click.native="clearSearch"
-      >
-        Clear search
-      </el-button>
-    </div>
+  <div class="search-form" @keyup.enter="submit">
+    <input
+      v-model="terms"
+      placeholder="Search help topics"
+      suffix-icon="el-icon-search"
+      @keyup.enter="submit"
+    />
+    <button title="Search" @click="submit">
+      <span class="visuallyhidden">Search</span>
+      <svg-icon name="icon-magnifying-glass" height="20" width="20" />
+    </button>
   </div>
 </template>
 
@@ -90,51 +76,31 @@ export default {
 </script>
 
 <style lang="scss" scoped>
-.controls {
-  align-items: center;
-  display: flex;
-  width: 100%;
-  display: flex;
-  max-width: 900px;
-}
-
-.control {
-  display: inline-block;
-
-  :selected {
-    color: red;
+  @import '@/assets/_variables.scss';
+  .search-form {
+    display: flex;
+    margin: 0 0 1rem;
   }
-}
-
-.search-control {
-  border: 0;
-  -webkit-appearance: none;
-  width: 100%;
-  height: 100%;
-}
-
-.control-search-type {
-  margin-right: 8px;
-  // width: 180px;
-}
-.control-search-input {
-  flex: 1;
-  margin-right: 16px;
-  width: 100%;
-}
-
-.search-button {
-  .view-search-results {
-    background: #24245b;
-    border: 0;
-    height: 40px;
+  input {
+    border: 1px solid #909399;
+    border-radius: 4px;
+    box-sizing: border-box;
+    color: #909399;
+    font-size: 0.875rem;
+    margin-right: 0.5rem;
+    outline: none;
+    padding: 0.5rem 0.8125rem;
+    width: 28.0625rem;
+    &:focus {
+      border-color: $median;
+    }
   }
-}
-
-.btn-clear-search {
-  background: none;
-  border: none;
-  color: #8300bf;
-  padding: 0;
-}
+  button {
+    background: #f9f2fc;
+    border: 1px solid $median;
+    border-radius: 4px;
+    cursor: pointer;
+    height: 2.5rem;
+    width: 2.5rem;
+  }
 </style>

--- a/nuxt.config.js
+++ b/nuxt.config.js
@@ -76,7 +76,7 @@ export default {
   /*
    ** Nuxt.js dev-modules
    */
-  buildModules: [],
+  buildModules: ['@nuxt/typescript-build'],
   /*
    ** Nuxt.js modules
    */

--- a/nuxt.config.js
+++ b/nuxt.config.js
@@ -49,6 +49,7 @@ export default {
     ctf_filters_organ_id: '5Hhlb7Lf4yijMQUSBai1fh',
     ctf_filters_image_id: '4R4zfdND13xLLGU9nPpNCD',
     ctf_filters_simulation_id: '6qMQRugMyzeaUrTIPQDdF1',
+    ctf_footer_copy_id: 'wpik0A2sDOy9IQEoKpkKG',
     CTF_SPACE_ID: process.env.CTF_SPACE_ID,
     CTF_CDA_ACCESS_TOKEN: process.env.CTF_CDA_ACCESS_TOKEN,
     CTF_API_HOST: process.env.CTF_API_HOST

--- a/package.json
+++ b/package.json
@@ -36,6 +36,8 @@
     "vue-svgicon": "^3.2.6"
   },
   "devDependencies": {
+    "@nuxt/typescript-build": "^0.5.6",
+    "@types/node": "^13.7.0",
     "sass": "^1.18.0",
     "sass-loader": "^7.1.0"
   },

--- a/pages/help/index.vue
+++ b/pages/help/index.vue
@@ -20,12 +20,14 @@
       <div class="subpage">
         <el-row type="flex" :gutter="32">
           <el-col :xs="24" :md="22" :lg="18">
-            <help-section
-              v-for="item in helpData.sections"
-              :key="item.sys.id"
-              class="help-section"
-              :section="item"
-            />
+            <div v-loading="isLoadingSearch">
+              <help-section
+                v-for="item in helpData.sections"
+                :key="item.sys.id"
+                class="help-section"
+                :section="item"
+              />
+            </div>
           </el-col>
         </el-row>
       </div>
@@ -68,11 +70,13 @@ export default Vue.extend<Data, Methods, never, never>({
     return {
       allHelpData: {},
       helpData: {},
+      isLoadingSearch: false,
     }
   },
 
   methods: {
     onSearchQuery: function(this: Data, terms) {
+      this.isLoadingSearch = true;
       client
         .getEntries<HelpDocument>({
           content_type: 'helpDocument',
@@ -91,6 +95,9 @@ export default Vue.extend<Data, Methods, never, never>({
           }
         })
         .catch(console.error)
+        .finally(() => {
+          this.isLoadingSearch = false;
+        })
     }
   }
 })

--- a/pages/help/index.vue
+++ b/pages/help/index.vue
@@ -1,12 +1,9 @@
 <template>
   <div class="help-page">
-    <page-hero>
+    <page-hero justify="left">
       <h2>{{ helpData.title }}</h2>
       <p>
         {{ helpData.summary }}
-      </p>
-      <p>
-        <!-- {{ heroCopy }} -->
       </p>
       <HelpSearchControls
         isClearSearchVisible
@@ -15,22 +12,14 @@
         @query="onSearchQuery"
       />
     </page-hero>
-
-    <div class="page-wrap container">
-      <div class="subpage">
-        <el-row type="flex" :gutter="32">
-          <el-col :xs="24" :md="22" :lg="18">
-            <div v-loading="isLoadingSearch">
-              <help-section
-                v-for="item in helpData.sections"
-                :key="item.sys.id"
-                class="help-section"
-                :section="item"
-              />
-            </div>
-          </el-col>
-        </el-row>
-      </div>
+    <div v-loading="isLoadingSearch">
+      <help-section
+        v-for="item in helpData.sections"
+        :key="item.sys.id"
+        class="help-section"
+        :section="item"
+        :searchTerms="searchTerms"
+      />
     </div>
   </div>
 </template>
@@ -42,6 +31,7 @@ import {Data, HelpData, HelpDocument, Methods} from "./model";
 import HelpSection from "@/components/HelpSection/HelpSection.vue";
 import HelpSearchControls from "@/components/help-search-controls/HelpSearchControls.vue";
 import PageHero from "@/components/PageHero/PageHero.vue";
+import SearchForm from '@/components/SearchForm/SearchForm.vue'
 
 const client = createClient()
 
@@ -52,7 +42,8 @@ export default Vue.extend<Data, Methods, never, never>({
   components: {
     HelpSection,
     HelpSearchControls,
-    PageHero
+    PageHero,
+    SearchForm
   },
 
   asyncData() {
@@ -71,12 +62,14 @@ export default Vue.extend<Data, Methods, never, never>({
       allHelpData: {},
       helpData: {},
       isLoadingSearch: false,
+      searchTerms: '',
     }
   },
 
   methods: {
     onSearchQuery: function(this: Data, terms) {
       this.isLoadingSearch = true;
+      this.searchTerms = terms;
       client
         .getEntries<HelpDocument>({
           content_type: 'helpDocument',
@@ -105,7 +98,8 @@ export default Vue.extend<Data, Methods, never, never>({
 
 <style lang="scss" scoped>
 @import '@/assets/_variables.scss';
-.help-section {
-  margin: 0 0 2em;
+.page-hero {
+  background-color: $navy;
+  background-image: none;
 }
 </style>

--- a/pages/help/model.ts
+++ b/pages/help/model.ts
@@ -23,6 +23,7 @@ export interface Data {
   allHelpData: Partial<HelpData>
   helpData: Partial<HelpData>;
   isLoadingSearch: boolean;
+  searchTerms: string;
 }
 
 export interface Methods {

--- a/pages/help/model.ts
+++ b/pages/help/model.ts
@@ -1,0 +1,29 @@
+import {Entry} from "contentful";
+
+export type HelpDocument = Entry<{
+  title?: string;
+  summary?: string;
+  helpContent?: string;
+  tags?: string[]
+}>
+
+
+export type HelpSection = Entry<{
+  title: string;
+  helpDocuments: HelpDocument[]
+}>
+
+export interface HelpData {
+  title: string;
+  summary: string;
+  sections: HelpSection[]
+}
+
+export interface Data {
+  allHelpData: Partial<HelpData>
+  helpData: Partial<HelpData>;
+}
+
+export interface Methods {
+  onSearchQuery: (terms: string) => void
+}

--- a/pages/help/model.ts
+++ b/pages/help/model.ts
@@ -22,6 +22,7 @@ export interface HelpData {
 export interface Data {
   allHelpData: Partial<HelpData>
   helpData: Partial<HelpData>;
+  isLoadingSearch: boolean;
 }
 
 export interface Methods {

--- a/store/index.js
+++ b/store/index.js
@@ -1,15 +1,30 @@
+import createClient from "~/plugins/contentful";
+
 export const state = () => ({
-  disableScrolling: false
+  disableScrolling: false,
+  footerData: {}
 })
 
 export const mutations = {
   UPDATE_DISABLED_SCROLLING(state, data) {
     state.disableScrolling = data
+  },
+  SET_FOOTER_DATA(state, data) {
+    state.footerData = data
   }
 }
 
 export const actions = {
   updateDisabledScrolling: ({ commit }, state) => {
     commit('UPDATE_DISABLED_SCROLLING', state)
+  },
+  async nuxtServerInit({ commit }) {
+    try {
+      const client = createClient()
+      const response = await client.getEntry(process.env.ctf_footer_copy_id)
+      commit('SET_FOOTER_DATA', response.fields.copy)
+    } catch (e) {
+      console.error(e)
+    }
   }
 }

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,0 +1,35 @@
+{
+  "compilerOptions": {
+    "target": "es2018",
+    "module": "esnext",
+    "moduleResolution": "node",
+    "lib": [
+      "esnext",
+      "esnext.asynciterable",
+      "dom"
+    ],
+    "esModuleInterop": true,
+    "allowJs": true,
+    "sourceMap": true,
+    "strict": true,
+    "noEmit": true,
+    "baseUrl": ".",
+    "paths": {
+      "~/*": [
+        "./*"
+      ],
+      "@/*": [
+        "./*"
+      ]
+    },
+    "types": [
+      "@types/node",
+      "@nuxt/types"
+    ],
+    // in addition to options recommended by nuxt
+    "skipLibCheck": true
+  },
+  "exclude": [
+    "node_modules"
+  ]
+}

--- a/vue-shim.d.ts
+++ b/vue-shim.d.ts
@@ -1,0 +1,19 @@
+import Vue, { ComponentOptions } from "vue";
+import { Store } from "vuex";
+import { Route } from 'vue-router';
+
+declare module "*.vue" {
+  export default Vue
+}
+
+declare module "vue/types/options" {
+  interface ComponentOptions<V extends Vue> {
+    asyncData?: (store: Store<any>, route: Route) => Promise<any>;
+  }
+}
+
+declare module "vue/types/vue" {
+  interface Vue {
+    asyncData?: (store: Store<any>, route: Route) => Promise<any>;
+  }
+}

--- a/yarn.lock
+++ b/yarn.lock
@@ -258,6 +258,11 @@
   resolved "https://registry.yarnpkg.com/@babel/parser/-/parser-7.8.3.tgz#790874091d2001c9be6ec426c2eed47bc7679081"
   integrity sha512-/V72F4Yp/qmHaTALizEm9Gf2eQHV3QyTL3K0cNfijwnMnb1L+LDlAubb/ZnSdGAVzVSWakujHYs1I26x66sMeQ==
 
+"@babel/parser@^7.1.0":
+  version "7.8.4"
+  resolved "https://registry.yarnpkg.com/@babel/parser/-/parser-7.8.4.tgz#d1dbe64691d60358a974295fa53da074dd2ce8e8"
+  integrity sha512-0fKu/QqildpXmPVaRBoXOlyBb3MC+J0A66x97qEfLOMkn3u6nfY5esWogQwi/K0BjASYy4DbnsEWnpNL6qT5Mw==
+
 "@babel/plugin-proposal-async-generator-functions@^7.8.3":
   version "7.8.3"
   resolved "https://registry.yarnpkg.com/@babel/plugin-proposal-async-generator-functions/-/plugin-proposal-async-generator-functions-7.8.3.tgz#bad329c670b382589721b27540c7d288601c6e6f"
@@ -759,7 +764,7 @@
     globals "^11.1.0"
     lodash "^4.17.13"
 
-"@babel/types@^7.0.0", "@babel/types@^7.8.3":
+"@babel/types@^7.0.0", "@babel/types@^7.3.0", "@babel/types@^7.8.3":
   version "7.8.3"
   resolved "https://registry.yarnpkg.com/@babel/types/-/types-7.8.3.tgz#5a383dffa5416db1b73dedffd311ffd0788fb31c"
   integrity sha512-jBD+G8+LWpMBBWvVcdr4QysjUE4mU/syrhN17o1u3gx0/WzJB1kwiVZAXRtWbsIPOwW8pF/YJV5+nmetPzepXg==
@@ -925,6 +930,41 @@
     serve-static "^1.14.1"
     server-destroy "^1.0.1"
 
+"@nuxt/types@0.6.1":
+  version "0.6.1"
+  resolved "https://registry.yarnpkg.com/@nuxt/types/-/types-0.6.1.tgz#f94601630367ba790e6ca320c30406a4e253599d"
+  integrity sha512-9qOjHgLfUSZOicDXbAh/jg9dSFDdE4MVVSQdMTtmwEpGUKLqawrUwkypRtn8jDcvAtf0EADo/1VunpuN5j7jTg==
+  dependencies:
+    "@types/autoprefixer" "^9.6.1"
+    "@types/babel__core" "^7.1.3"
+    "@types/compression" "^1.0.1"
+    "@types/connect" "^3.4.33"
+    "@types/etag" "^1.8.0"
+    "@types/file-loader" "^4.2.0"
+    "@types/html-minifier" "^3.5.3"
+    "@types/less" "^3.0.1"
+    "@types/node" "^12.12.24"
+    "@types/node-sass" "^4.11.0"
+    "@types/optimize-css-assets-webpack-plugin" "^5.0.1"
+    "@types/pug" "^2.0.4"
+    "@types/serve-static" "^1.13.3"
+    "@types/terser-webpack-plugin" "^2.2.0"
+    "@types/webpack" "^4.41.2"
+    "@types/webpack-bundle-analyzer" "^2.13.3"
+    "@types/webpack-dev-middleware" "^2.0.3"
+    "@types/webpack-hot-middleware" "^2.25.0"
+
+"@nuxt/typescript-build@^0.5.6":
+  version "0.5.6"
+  resolved "https://registry.yarnpkg.com/@nuxt/typescript-build/-/typescript-build-0.5.6.tgz#5276de2ef06f2534ae50f7d3f987a9d6f9f4c405"
+  integrity sha512-4ut0vug0lSNHPrTdZj98XPNCyMm4D/V/NzuoGc9p6abwAfyLapRfWZRZeLDoLYBaW/uAtVRcch09KCw7nM6cIg==
+  dependencies:
+    "@nuxt/types" "0.6.1"
+    consola "^2.11.3"
+    fork-ts-checker-webpack-plugin "^3.1.1"
+    ts-loader "^6.2.1"
+    typescript "~3.7"
+
 "@nuxt/utils@2.11.0":
   version "2.11.0"
   resolved "https://registry.yarnpkg.com/@nuxt/utils/-/utils-2.11.0.tgz#0185767fdb582b907d06a151d3e624a5ad7bede2"
@@ -1048,15 +1088,270 @@
     mustache "^2.3.0"
     stack-trace "0.0.10"
 
+"@types/anymatch@*":
+  version "1.3.1"
+  resolved "https://registry.yarnpkg.com/@types/anymatch/-/anymatch-1.3.1.tgz#336badc1beecb9dacc38bea2cf32adf627a8421a"
+  integrity sha512-/+CRPXpBDpo2RK9C68N3b2cOvO0Cf5B9aPijHsoDQTHivnGSObdOF2BRQOYjojWTDy6nQvMjmqRXIxH55VjxxA==
+
+"@types/autoprefixer@^9.6.1":
+  version "9.6.1"
+  resolved "https://registry.yarnpkg.com/@types/autoprefixer/-/autoprefixer-9.6.1.tgz#8bfaf43d18f5cd59a269b7a2364e690cadcdf210"
+  integrity sha512-9aofAxm/OWxzu/Fq7lU/m2rX03f9Sr1OXF/3kEp6FNFYRFLgFcIUjxhNGgWqc5KMpXbkqxlJmc7wfab7jFj2dw==
+  dependencies:
+    "@types/browserslist" "*"
+    postcss "7.x.x"
+
+"@types/babel__core@^7.1.3":
+  version "7.1.3"
+  resolved "https://registry.yarnpkg.com/@types/babel__core/-/babel__core-7.1.3.tgz#e441ea7df63cd080dfcd02ab199e6d16a735fc30"
+  integrity sha512-8fBo0UR2CcwWxeX7WIIgJ7lXjasFxoYgRnFHUj+hRvKkpiBJbxhdAPTCY6/ZKM0uxANFVzt4yObSLuTiTnazDA==
+  dependencies:
+    "@babel/parser" "^7.1.0"
+    "@babel/types" "^7.0.0"
+    "@types/babel__generator" "*"
+    "@types/babel__template" "*"
+    "@types/babel__traverse" "*"
+
+"@types/babel__generator@*":
+  version "7.6.1"
+  resolved "https://registry.yarnpkg.com/@types/babel__generator/-/babel__generator-7.6.1.tgz#4901767b397e8711aeb99df8d396d7ba7b7f0e04"
+  integrity sha512-bBKm+2VPJcMRVwNhxKu8W+5/zT7pwNEqeokFOmbvVSqGzFneNxYcEBro9Ac7/N9tlsaPYnZLK8J1LWKkMsLAew==
+  dependencies:
+    "@babel/types" "^7.0.0"
+
+"@types/babel__template@*":
+  version "7.0.2"
+  resolved "https://registry.yarnpkg.com/@types/babel__template/-/babel__template-7.0.2.tgz#4ff63d6b52eddac1de7b975a5223ed32ecea9307"
+  integrity sha512-/K6zCpeW7Imzgab2bLkLEbz0+1JlFSrUMdw7KoIIu+IUdu51GWaBZpd3y1VXGVXzynvGa4DaIaxNZHiON3GXUg==
+  dependencies:
+    "@babel/parser" "^7.1.0"
+    "@babel/types" "^7.0.0"
+
+"@types/babel__traverse@*":
+  version "7.0.8"
+  resolved "https://registry.yarnpkg.com/@types/babel__traverse/-/babel__traverse-7.0.8.tgz#479a4ee3e291a403a1096106013ec22cf9b64012"
+  integrity sha512-yGeB2dHEdvxjP0y4UbRtQaSkXJ9649fYCmIdRoul5kfAoGCwxuCbMhag0k3RPfnuh9kPGm8x89btcfDEXdVWGw==
+  dependencies:
+    "@babel/types" "^7.3.0"
+
+"@types/body-parser@*":
+  version "1.17.1"
+  resolved "https://registry.yarnpkg.com/@types/body-parser/-/body-parser-1.17.1.tgz#18fcf61768fb5c30ccc508c21d6fd2e8b3bf7897"
+  integrity sha512-RoX2EZjMiFMjZh9lmYrwgoP9RTpAjSHiJxdp4oidAQVO02T7HER3xj9UKue5534ULWeqVEkujhWcyvUce+d68w==
+  dependencies:
+    "@types/connect" "*"
+    "@types/node" "*"
+
+"@types/browserslist@*":
+  version "4.4.0"
+  resolved "https://registry.yarnpkg.com/@types/browserslist/-/browserslist-4.4.0.tgz#e2a5f7f8c7e97afb39f50812a77e5230d3ca2353"
+  integrity sha512-hrIjWSu7Hh96/rKlpChe58qHEwIZ0+F5Zf4QNdvSVP5LUXbaJM04g9tBjo702VTNqPZr5znEJeqNR3nAV3vJPg==
+
+"@types/clean-css@*":
+  version "4.2.1"
+  resolved "https://registry.yarnpkg.com/@types/clean-css/-/clean-css-4.2.1.tgz#cb0134241ec5e6ede1b5344bc829668fd9871a8d"
+  integrity sha512-A1HQhQ0hkvqqByJMgg+Wiv9p9XdoYEzuwm11SVo1mX2/4PSdhjcrUlilJQoqLscIheC51t1D5g+EFWCXZ2VTQQ==
+  dependencies:
+    "@types/node" "*"
+
 "@types/color-name@^1.1.1":
   version "1.1.1"
   resolved "https://registry.yarnpkg.com/@types/color-name/-/color-name-1.1.1.tgz#1c1261bbeaa10a8055bbc5d8ab84b7b2afc846a0"
   integrity sha512-rr+OQyAjxze7GgWrSaJwydHStIhHq2lvY3BOC2Mj7KnzI7XK0Uw1TOOdI9lDoajEbSWLiYgoo4f1R51erQfhPQ==
 
+"@types/compression@^1.0.1":
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/@types/compression/-/compression-1.0.1.tgz#f3682a6b3ce2dbd4aece48547153ebc592281fa7"
+  integrity sha512-GuoIYzD70h+4JUqUabsm31FGqvpCYHGKcLtor7nQ/YvUyNX0o9SJZ9boFI5HjFfbOda5Oe/XOvNK6FES8Y/79w==
+  dependencies:
+    "@types/express" "*"
+
+"@types/connect@*", "@types/connect@^3.4.33":
+  version "3.4.33"
+  resolved "https://registry.yarnpkg.com/@types/connect/-/connect-3.4.33.tgz#31610c901eca573b8713c3330abc6e6b9f588546"
+  integrity sha512-2+FrkXY4zllzTNfJth7jOqEHC+enpLeGslEhpnTAkg21GkRrWV4SsAtqchtT4YS9/nODBU2/ZfsBY2X4J/dX7A==
+  dependencies:
+    "@types/node" "*"
+
+"@types/etag@^1.8.0":
+  version "1.8.0"
+  resolved "https://registry.yarnpkg.com/@types/etag/-/etag-1.8.0.tgz#37f0b1f3ea46da7ae319bbedb607e375b4c99f7e"
+  integrity sha512-EdSN0x+Y0/lBv7YAb8IU4Jgm6DWM+Bqtz7o5qozl96fzaqdqbdfHS5qjdpFeIv7xQ8jSLyjMMNShgYtMajEHyQ==
+  dependencies:
+    "@types/node" "*"
+
+"@types/express-serve-static-core@*":
+  version "4.17.2"
+  resolved "https://registry.yarnpkg.com/@types/express-serve-static-core/-/express-serve-static-core-4.17.2.tgz#f6f41fa35d42e79dbf6610eccbb2637e6008a0cf"
+  integrity sha512-El9yMpctM6tORDAiBwZVLMcxoTMcqqRO9dVyYcn7ycLWbvR8klrDn8CAOwRfZujZtWD7yS/mshTdz43jMOejbg==
+  dependencies:
+    "@types/node" "*"
+    "@types/range-parser" "*"
+
+"@types/express@*":
+  version "4.17.2"
+  resolved "https://registry.yarnpkg.com/@types/express/-/express-4.17.2.tgz#a0fb7a23d8855bac31bc01d5a58cadd9b2173e6c"
+  integrity sha512-5mHFNyavtLoJmnusB8OKJ5bshSzw+qkMIBAobLrIM48HJvunFva9mOa6aBwh64lBFyNwBbs0xiEFuj4eU/NjCA==
+  dependencies:
+    "@types/body-parser" "*"
+    "@types/express-serve-static-core" "*"
+    "@types/serve-static" "*"
+
+"@types/file-loader@^4.2.0":
+  version "4.2.0"
+  resolved "https://registry.yarnpkg.com/@types/file-loader/-/file-loader-4.2.0.tgz#ec8e793e275b7f90cdec3ff286518c6bf7bb8fc3"
+  integrity sha512-N3GMqKiKSNd41q4/lZlkdvNXKKWVdOXrA8Rniu64+25X0K2U1mWmTSu1CIqXKKsZUCwfaFcaioviLQtQ+EowLg==
+  dependencies:
+    "@types/webpack" "*"
+
+"@types/html-minifier@^3.5.3":
+  version "3.5.3"
+  resolved "https://registry.yarnpkg.com/@types/html-minifier/-/html-minifier-3.5.3.tgz#5276845138db2cebc54c789e0aaf87621a21e84f"
+  integrity sha512-j1P/4PcWVVCPEy5lofcHnQ6BtXz9tHGiFPWzqm7TtGuWZEfCHEP446HlkSNc9fQgNJaJZ6ewPtp2aaFla/Uerg==
+  dependencies:
+    "@types/clean-css" "*"
+    "@types/relateurl" "*"
+    "@types/uglify-js" "*"
+
+"@types/less@^3.0.1":
+  version "3.0.1"
+  resolved "https://registry.yarnpkg.com/@types/less/-/less-3.0.1.tgz#625694093c72f8356c4042754e222407e50d6b08"
+  integrity sha512-dBp05MtWN/w1fGVjj5LVrDw6VrdYllpWczbUkCsrzBj08IHsSyRLOFvUrCFqZFVR+nsqkrRLNg6oOlvqMLPaSA==
+
+"@types/memory-fs@*":
+  version "0.3.2"
+  resolved "https://registry.yarnpkg.com/@types/memory-fs/-/memory-fs-0.3.2.tgz#5d4753f9b390cb077c8c8af97bc96463399ceccd"
+  integrity sha512-j5AcZo7dbMxHoOimcHEIh0JZe5e1b8q8AqGSpZJrYc7xOgCIP79cIjTdx5jSDLtySnQDwkDTqwlC7Xw7uXw7qg==
+  dependencies:
+    "@types/node" "*"
+
+"@types/mime@*":
+  version "2.0.1"
+  resolved "https://registry.yarnpkg.com/@types/mime/-/mime-2.0.1.tgz#dc488842312a7f075149312905b5e3c0b054c79d"
+  integrity sha512-FwI9gX75FgVBJ7ywgnq/P7tw+/o1GUbtP0KzbtusLigAOgIgNISRK0ZPl4qertvXSIE8YbsVJueQ90cDt9YYyw==
+
+"@types/node-sass@^4.11.0":
+  version "4.11.0"
+  resolved "https://registry.yarnpkg.com/@types/node-sass/-/node-sass-4.11.0.tgz#b0372075546e83f39df52bd37359eab00165a04d"
+  integrity sha512-uNpVWhwVmbB5luE7b8vxcJwu5np75YkVTBJS0O3ar+hrxqLfyhOKXg9NYBwJ6mMQX/V6/8d6mMZTB7x2r5x9Bw==
+  dependencies:
+    "@types/node" "*"
+
+"@types/node@*", "@types/node@^13.7.0":
+  version "13.7.0"
+  resolved "https://registry.yarnpkg.com/@types/node/-/node-13.7.0.tgz#b417deda18cf8400f278733499ad5547ed1abec4"
+  integrity sha512-GnZbirvmqZUzMgkFn70c74OQpTTUcCzlhQliTzYjQMqg+hVKcDnxdL19Ne3UdYzdMA/+W3eb646FWn/ZaT1NfQ==
+
+"@types/node@^12.12.24":
+  version "12.12.26"
+  resolved "https://registry.yarnpkg.com/@types/node/-/node-12.12.26.tgz#213e153babac0ed169d44a6d919501e68f59dea9"
+  integrity sha512-UmUm94/QZvU5xLcUlNR8hA7Ac+fGpO1EG/a8bcWVz0P0LqtxFmun9Y2bbtuckwGboWJIT70DoWq1r3hb56n3DA==
+
+"@types/optimize-css-assets-webpack-plugin@^5.0.1":
+  version "5.0.1"
+  resolved "https://registry.yarnpkg.com/@types/optimize-css-assets-webpack-plugin/-/optimize-css-assets-webpack-plugin-5.0.1.tgz#1f437ef9ef937b393687a8819be2d2fddc03b069"
+  integrity sha512-qyi5xmSl+DTmLFtVtelhso3VnNQYxltfgMa+Ed02xqNZCZBD0uYR6i64FmcwfieDzZRdwkJxt9o2JHq/5PBKQg==
+  dependencies:
+    "@types/webpack" "*"
+
+"@types/pug@^2.0.4":
+  version "2.0.4"
+  resolved "https://registry.yarnpkg.com/@types/pug/-/pug-2.0.4.tgz#8772fcd0418e3cd2cc171555d73007415051f4b2"
+  integrity sha1-h3L80EGOPNLMFxVV1zAHQVBR9LI=
+
 "@types/q@^1.5.1":
   version "1.5.2"
   resolved "https://registry.yarnpkg.com/@types/q/-/q-1.5.2.tgz#690a1475b84f2a884fd07cd797c00f5f31356ea8"
   integrity sha512-ce5d3q03Ex0sy4R14722Rmt6MT07Ua+k4FwDfdcToYJcMKNtRVQvJ6JCAPdAmAnbRb6CsX6aYb9m96NGod9uTw==
+
+"@types/range-parser@*":
+  version "1.2.3"
+  resolved "https://registry.yarnpkg.com/@types/range-parser/-/range-parser-1.2.3.tgz#7ee330ba7caafb98090bece86a5ee44115904c2c"
+  integrity sha512-ewFXqrQHlFsgc09MK5jP5iR7vumV/BYayNC6PgJO2LPe8vrnNFyjQjSppfEngITi0qvfKtzFvgKymGheFM9UOA==
+
+"@types/relateurl@*":
+  version "0.2.28"
+  resolved "https://registry.yarnpkg.com/@types/relateurl/-/relateurl-0.2.28.tgz#6bda7db8653fa62643f5ee69e9f69c11a392e3a6"
+  integrity sha1-a9p9uGU/piZD9e5p6facEaOS46Y=
+
+"@types/serve-static@*", "@types/serve-static@^1.13.3":
+  version "1.13.3"
+  resolved "https://registry.yarnpkg.com/@types/serve-static/-/serve-static-1.13.3.tgz#eb7e1c41c4468272557e897e9171ded5e2ded9d1"
+  integrity sha512-oprSwp094zOglVrXdlo/4bAHtKTAxX6VT8FOZlBKrmyLbNvE1zxZyJ6yikMVtHIvwP45+ZQGJn+FdXGKTozq0g==
+  dependencies:
+    "@types/express-serve-static-core" "*"
+    "@types/mime" "*"
+
+"@types/source-list-map@*":
+  version "0.1.2"
+  resolved "https://registry.yarnpkg.com/@types/source-list-map/-/source-list-map-0.1.2.tgz#0078836063ffaf17412349bba364087e0ac02ec9"
+  integrity sha512-K5K+yml8LTo9bWJI/rECfIPrGgxdpeNbj+d53lwN4QjW1MCwlkhUms+gtdzigTeUyBr09+u8BwOIY3MXvHdcsA==
+
+"@types/tapable@*":
+  version "1.0.5"
+  resolved "https://registry.yarnpkg.com/@types/tapable/-/tapable-1.0.5.tgz#9adbc12950582aa65ead76bffdf39fe0c27a3c02"
+  integrity sha512-/gG2M/Imw7cQFp8PGvz/SwocNrmKFjFsm5Pb8HdbHkZ1K8pmuPzOX4VeVoiEecFCVf4CsN1r3/BRvx+6sNqwtQ==
+
+"@types/terser-webpack-plugin@^2.2.0":
+  version "2.2.0"
+  resolved "https://registry.yarnpkg.com/@types/terser-webpack-plugin/-/terser-webpack-plugin-2.2.0.tgz#b1561e3118b9319d80ff65798c345877669b3e12"
+  integrity sha512-ywqEfTm7KdKoX9aYx0zYtiFU1z6IHrIYW9FJqeay2Ea58rTPML1J0hvoztGal2Jow3bkgGKcAmEZNL+8LqUVrA==
+  dependencies:
+    "@types/webpack" "*"
+    terser "^4.3.9"
+
+"@types/uglify-js@*":
+  version "3.0.4"
+  resolved "https://registry.yarnpkg.com/@types/uglify-js/-/uglify-js-3.0.4.tgz#96beae23df6f561862a830b4288a49e86baac082"
+  integrity sha512-SudIN9TRJ+v8g5pTG8RRCqfqTMNqgWCKKd3vtynhGzkIIjxaicNAMuY5TRadJ6tzDu3Dotf3ngaMILtmOdmWEQ==
+  dependencies:
+    source-map "^0.6.1"
+
+"@types/webpack-bundle-analyzer@^2.13.3":
+  version "2.13.3"
+  resolved "https://registry.yarnpkg.com/@types/webpack-bundle-analyzer/-/webpack-bundle-analyzer-2.13.3.tgz#820c8f734e171f081cbf02d889b9cda687cc89dd"
+  integrity sha512-p8EXyKfq311FFFfRuAR9tOHFFTQ9DqGrjRQYXbjjEMfl9pKGaTtRy1zFJtPMyZHfRoqh5rsYPVSVknkl004M7A==
+  dependencies:
+    "@types/webpack" "*"
+
+"@types/webpack-dev-middleware@^2.0.3":
+  version "2.0.3"
+  resolved "https://registry.yarnpkg.com/@types/webpack-dev-middleware/-/webpack-dev-middleware-2.0.3.tgz#aefb145281b3326a052325d583d2339debbf1be3"
+  integrity sha512-DzNJJ6ah/6t1n8sfAgQyEbZ/OMmFcF9j9P3aesnm7G6/iBFR/qiGin8K89J0RmaWIBzhTMdDg3I5PmKmSv7N9w==
+  dependencies:
+    "@types/connect" "*"
+    "@types/memory-fs" "*"
+    "@types/webpack" "*"
+    loglevel "^1.6.2"
+
+"@types/webpack-hot-middleware@^2.25.0":
+  version "2.25.0"
+  resolved "https://registry.yarnpkg.com/@types/webpack-hot-middleware/-/webpack-hot-middleware-2.25.0.tgz#ceb1e0fb43cbb9ec79c4a856c2060f161e12bf30"
+  integrity sha512-J+Zk7c99pMnPcxWpPY7CEdc4jhPFX1SVPrqXTzinoF8ea+OmIiHa+oOdVI7leMQFGZ6G9e9Yo1uNPhLVr/R8Uw==
+  dependencies:
+    "@types/connect" "*"
+    "@types/webpack" "*"
+
+"@types/webpack-sources@*":
+  version "0.1.6"
+  resolved "https://registry.yarnpkg.com/@types/webpack-sources/-/webpack-sources-0.1.6.tgz#3d21dfc2ec0ad0c77758e79362426a9ba7d7cbcb"
+  integrity sha512-FtAWR7wR5ocJ9+nP137DV81tveD/ZgB1sadnJ/axUGM3BUVfRPx8oQNMtv3JNfTeHx3VP7cXiyfR/jmtEsVHsQ==
+  dependencies:
+    "@types/node" "*"
+    "@types/source-list-map" "*"
+    source-map "^0.6.1"
+
+"@types/webpack@*", "@types/webpack@^4.41.2":
+  version "4.41.4"
+  resolved "https://registry.yarnpkg.com/@types/webpack/-/webpack-4.41.4.tgz#6cd2d651d214c344640cbab1c82037289b0154cd"
+  integrity sha512-PlqTNzHzZ1UpBXKkq2wHAM8+jeMojJGfBFXjGB3/N4F4ESGeivdKsJuaS79rtbSofvjbwBIMOHP254mIq0ujiQ==
+  dependencies:
+    "@types/anymatch" "*"
+    "@types/node" "*"
+    "@types/tapable" "*"
+    "@types/uglify-js" "*"
+    "@types/webpack-sources" "*"
+    source-map "^0.6.0"
 
 "@vue/babel-helper-vue-jsx-merge-props@^1.0.0":
   version "1.0.0"
@@ -1552,6 +1847,15 @@ axios@^0.19.1:
   dependencies:
     follow-redirects "1.5.10"
 
+babel-code-frame@^6.22.0:
+  version "6.26.0"
+  resolved "https://registry.yarnpkg.com/babel-code-frame/-/babel-code-frame-6.26.0.tgz#63fd43f7dc1e3bb7ce35947db8fe369a3f58c74b"
+  integrity sha1-Y/1D99weO7fONZR9uP42mj9Yx0s=
+  dependencies:
+    chalk "^1.1.3"
+    esutils "^2.0.2"
+    js-tokens "^3.0.2"
+
 babel-eslint@^10.0.3:
   version "10.0.3"
   resolved "https://registry.yarnpkg.com/babel-eslint/-/babel-eslint-10.0.3.tgz#81a2c669be0f205e19462fed2482d33e4687a88a"
@@ -1723,7 +2027,7 @@ braces@^2.3.1, braces@^2.3.2:
     split-string "^3.0.2"
     to-regex "^3.0.1"
 
-braces@~3.0.2:
+braces@^3.0.1, braces@~3.0.2:
   version "3.0.2"
   resolved "https://registry.yarnpkg.com/braces/-/braces-3.0.2.tgz#3454e1a462ee8d599e236df336cd9ea4f8afe107"
   integrity sha512-b8um+L1RzM3WDSzvhm6gIz1yfTbBt6YTlcEKAvsmqCZZFw46z626lVj9j1yEPW33H5H+lBQpZMP1k8l+78Ha0A==
@@ -2004,7 +2308,7 @@ check-types@^8.0.3:
   resolved "https://registry.yarnpkg.com/check-types/-/check-types-8.0.3.tgz#3356cca19c889544f2d7a95ed49ce508a0ecf552"
   integrity sha512-YpeKZngUmG65rLudJ4taU7VLkOCTMhNl/u4ctNC56LQS/zJTyNH0Lrtwm1tfTsbLlwvlfsA2d1c8vCf/Kh2KwQ==
 
-"chokidar@>=2.0.0 <4.0.0", chokidar@^3.3.1:
+"chokidar@>=2.0.0 <4.0.0", chokidar@^3.3.0, chokidar@^3.3.1:
   version "3.3.1"
   resolved "https://registry.yarnpkg.com/chokidar/-/chokidar-3.3.1.tgz#c84e5b3d18d9a4d77558fef466b1bf16bbeb3450"
   integrity sha512-4QYCEWOcK3OJrxwvyyAOxFuhpvOVCYkr33LPfFNBjAD/w3sEzWsp2BUOkI4l9bHvWioAd0rc6NlHUOEaWkTeqg==
@@ -2943,7 +3247,7 @@ end-of-stream@^1.0.0, end-of-stream@^1.1.0:
   dependencies:
     once "^1.4.0"
 
-enhanced-resolve@^4.1.0, enhanced-resolve@^4.1.1:
+enhanced-resolve@^4.0.0, enhanced-resolve@^4.1.0, enhanced-resolve@^4.1.1:
   version "4.1.1"
   resolved "https://registry.yarnpkg.com/enhanced-resolve/-/enhanced-resolve-4.1.1.tgz#2937e2b8066cd0fe7ce0990a98f0d71a35189f66"
   integrity sha512-98p2zE+rL7/g/DzMHMTF4zZlCgeVdJ7yr6xzEpJRYwFYrGi9ANdn5DnJURg6RpBkyk60XYDnWIv51VfIhfNGuA==
@@ -3508,6 +3812,20 @@ for-in@^1.0.2:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/for-in/-/for-in-1.0.2.tgz#81068d295a8142ec0ac726c6e2200c30fb6d5e80"
   integrity sha1-gQaNKVqBQuwKxybG4iAMMPttXoA=
+
+fork-ts-checker-webpack-plugin@^3.1.1:
+  version "3.1.1"
+  resolved "https://registry.yarnpkg.com/fork-ts-checker-webpack-plugin/-/fork-ts-checker-webpack-plugin-3.1.1.tgz#a1642c0d3e65f50c2cc1742e9c0a80f441f86b19"
+  integrity sha512-DuVkPNrM12jR41KM2e+N+styka0EgLkTnXmNcXdgOM37vtGeY+oCBK/Jx0hzSeEU6memFCtWb4htrHPMDfwwUQ==
+  dependencies:
+    babel-code-frame "^6.22.0"
+    chalk "^2.4.1"
+    chokidar "^3.3.0"
+    micromatch "^3.1.10"
+    minimatch "^3.0.4"
+    semver "^5.6.0"
+    tapable "^1.0.0"
+    worker-rpc "^0.1.0"
 
 forwarded@~0.1.2:
   version "0.1.2"
@@ -4368,6 +4686,11 @@ jest-worker@^24.9.0:
   resolved "https://registry.yarnpkg.com/js-tokens/-/js-tokens-4.0.0.tgz#19203fb59991df98e3a287050d4647cdeaf32499"
   integrity sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==
 
+js-tokens@^3.0.2:
+  version "3.0.2"
+  resolved "https://registry.yarnpkg.com/js-tokens/-/js-tokens-3.0.2.tgz#9866df395102130e38f7f996bceb65443209c25b"
+  integrity sha1-mGbfOVECEw449/mWvOtlRDIJwls=
+
 js-yaml@^3.13.1:
   version "3.13.1"
   resolved "https://registry.yarnpkg.com/js-yaml/-/js-yaml-3.13.1.tgz#aff151b30bfdfa8e49e05da22e7415e9dfa37847"
@@ -4598,6 +4921,11 @@ lodash@^4.15.0, lodash@^4.17.10, lodash@^4.17.11, lodash@^4.17.13, lodash@^4.17.
   resolved "https://registry.yarnpkg.com/lodash/-/lodash-4.17.15.tgz#b447f6670a0455bbfeedd11392eff330ea097548"
   integrity sha512-8xOcRHvCjnocdS5cpwXQXVzmmh5e5+saE2QGoeQmbKmRS6J3VQppPOIt0MnmE+4xlZoumy0GPG0D0MVIQbNA1A==
 
+loglevel@^1.6.2:
+  version "1.6.6"
+  resolved "https://registry.yarnpkg.com/loglevel/-/loglevel-1.6.6.tgz#0ee6300cc058db6b3551fa1c4bf73b83bb771312"
+  integrity sha512-Sgr5lbboAUBo3eXCSPL4/KoVz3ROKquOjcctxmHIt+vol2DrqTQe3SwkKKuYhEiWB5kYa13YyopJ69deJ1irzQ==
+
 loose-envify@^1.0.0:
   version "1.4.0"
   resolved "https://registry.yarnpkg.com/loose-envify/-/loose-envify-1.4.0.tgz#71ee51fa7be4caec1a63839f7e682d8132d30caf"
@@ -4742,6 +5070,11 @@ methods@~1.1.2:
   resolved "https://registry.yarnpkg.com/methods/-/methods-1.1.2.tgz#5529a4d67654134edcc5266656835b0f851afcee"
   integrity sha1-VSmk1nZUE07cxSZmVoNbD4Ua/O4=
 
+microevent.ts@~0.1.1:
+  version "0.1.1"
+  resolved "https://registry.yarnpkg.com/microevent.ts/-/microevent.ts-0.1.1.tgz#70b09b83f43df5172d0205a63025bce0f7357fa0"
+  integrity sha512-jo1OfR4TaEwd5HOrt5+tAZ9mqT4jmpNAusXtyfNzqVm9uiSYFZlKM1wYL4oU7azZW/PxQW53wM0S6OR1JHNa2g==
+
 micromatch@^3.1.10, micromatch@^3.1.4:
   version "3.1.10"
   resolved "https://registry.yarnpkg.com/micromatch/-/micromatch-3.1.10.tgz#70859bc95c9840952f359a068a3fc49f9ecfac23"
@@ -4760,6 +5093,14 @@ micromatch@^3.1.10, micromatch@^3.1.4:
     regex-not "^1.0.0"
     snapdragon "^0.8.1"
     to-regex "^3.0.2"
+
+micromatch@^4.0.0:
+  version "4.0.2"
+  resolved "https://registry.yarnpkg.com/micromatch/-/micromatch-4.0.2.tgz#4fcb0999bf9fbc2fcbdd212f6d629b9a56c39259"
+  integrity sha512-y7FpHSbMUMoyPbYUSzO6PaZ6FyRnQOpHuKwbo1G+Knck95XVU4QAiKdGEnj5wwoS7PlOgthX/09u5iFJ+aYf5Q==
+  dependencies:
+    braces "^3.0.1"
+    picomatch "^2.0.5"
 
 miller-rabin@^4.0.0:
   version "4.0.1"
@@ -5421,7 +5762,7 @@ pbkdf2@^3.0.3:
     safe-buffer "^5.0.1"
     sha.js "^2.4.8"
 
-picomatch@^2.0.4, picomatch@^2.0.7:
+picomatch@^2.0.4, picomatch@^2.0.5, picomatch@^2.0.7:
   version "2.2.1"
   resolved "https://registry.yarnpkg.com/picomatch/-/picomatch-2.2.1.tgz#21bac888b6ed8601f831ce7816e335bc779f0a4a"
   integrity sha512-ISBaA8xQNmwELC7eOjqFKMESB2VIqt4PPDD0nsS95b/9dZXvVKOlz9keMSnoGGKcOHXfTvDD6WMaRoSc9UuhRA==
@@ -6119,7 +6460,7 @@ postcss-values-parser@^2.0.0, postcss-values-parser@^2.0.1:
     indexes-of "^1.0.1"
     uniq "^1.0.1"
 
-postcss@^7.0.0, postcss@^7.0.1, postcss@^7.0.14, postcss@^7.0.16, postcss@^7.0.17, postcss@^7.0.2, postcss@^7.0.23, postcss@^7.0.25, postcss@^7.0.26, postcss@^7.0.5, postcss@^7.0.6:
+postcss@7.x.x, postcss@^7.0.0, postcss@^7.0.1, postcss@^7.0.14, postcss@^7.0.16, postcss@^7.0.17, postcss@^7.0.2, postcss@^7.0.23, postcss@^7.0.25, postcss@^7.0.26, postcss@^7.0.5, postcss@^7.0.6:
   version "7.0.26"
   resolved "https://registry.yarnpkg.com/postcss/-/postcss-7.0.26.tgz#5ed615cfcab35ba9bbb82414a4fa88ea10429587"
   integrity sha512-IY4oRjpXWYshuTDFxMVkJDtWIk2LhsTlu8bZnbEJA4+bYT16Lvpo8Qv6EvDumhYRgzjZl489pmsY3qVgJQ08nA==
@@ -7236,7 +7577,7 @@ terser-webpack-plugin@^2.3.0:
     terser "^4.4.3"
     webpack-sources "^1.4.3"
 
-terser@^4.1.2, terser@^4.4.3:
+terser@^4.1.2, terser@^4.3.9, terser@^4.4.3:
   version "4.6.3"
   resolved "https://registry.yarnpkg.com/terser/-/terser-4.6.3.tgz#e33aa42461ced5238d352d2df2a67f21921f8d87"
   integrity sha512-Lw+ieAXmY69d09IIc/yqeBqXpEQIpDGZqT34ui1QWXIUpR2RjbqEkT8X7Lgex19hslSqcWM5iMN2kM11eMsESQ==
@@ -7358,6 +7699,17 @@ tryer@^1.0.1:
   resolved "https://registry.yarnpkg.com/tryer/-/tryer-1.0.1.tgz#f2c85406800b9b0f74c9f7465b81eaad241252f8"
   integrity sha512-c3zayb8/kWWpycWYg87P71E1S1ZL6b6IJxfb5fvsUgsf0S2MVGaDhDXXjDMpdCpfWXqptc+4mXwmiy1ypXqRAA==
 
+ts-loader@^6.2.1:
+  version "6.2.1"
+  resolved "https://registry.yarnpkg.com/ts-loader/-/ts-loader-6.2.1.tgz#67939d5772e8a8c6bdaf6277ca023a4812da02ef"
+  integrity sha512-Dd9FekWuABGgjE1g0TlQJ+4dFUfYGbYcs52/HQObE0ZmUNjQlmLAS7xXsSzy23AMaMwipsx5sNHvoEpT2CZq1g==
+  dependencies:
+    chalk "^2.3.0"
+    enhanced-resolve "^4.0.0"
+    loader-utils "^1.0.2"
+    micromatch "^4.0.0"
+    semver "^6.0.0"
+
 tslib@^1.9.0, tslib@^1.9.3:
   version "1.10.0"
   resolved "https://registry.yarnpkg.com/tslib/-/tslib-1.10.0.tgz#c3c19f95973fb0a62973fb09d90d961ee43e5c8a"
@@ -7392,6 +7744,11 @@ typedarray@^0.0.6:
   version "0.0.6"
   resolved "https://registry.yarnpkg.com/typedarray/-/typedarray-0.0.6.tgz#867ac74e3864187b1d3d47d996a78ec5c8830777"
   integrity sha1-hnrHTjhkGHsdPUfZlqeOxciDB3c=
+
+typescript@~3.7:
+  version "3.7.5"
+  resolved "https://registry.yarnpkg.com/typescript/-/typescript-3.7.5.tgz#0692e21f65fd4108b9330238aac11dd2e177a1ae"
+  integrity sha512-/P5lkRXkWHNAbcJIiHPfRoKqyd7bsyCma1hZNUGfn20qm64T6ZBlrzprymeu918H+mB/0rIg2gGK/BXkhhYgBw==
 
 ua-parser-js@^0.7.20:
   version "0.7.21"
@@ -7889,6 +8246,13 @@ worker-farm@^1.7.0:
   integrity sha512-rvw3QTZc8lAxyVrqcSGVm5yP/IJ2UcB3U0graE3LCFoZ0Yn2x4EoVSqJKdB/T5M+FLcRPjz4TDacRf3OCfNUzw==
   dependencies:
     errno "~0.1.7"
+
+worker-rpc@^0.1.0:
+  version "0.1.1"
+  resolved "https://registry.yarnpkg.com/worker-rpc/-/worker-rpc-0.1.1.tgz#cb565bd6d7071a8f16660686051e969ad32f54d5"
+  integrity sha512-P1WjMrUB3qgJNI9jfmpZ/htmBEjFh//6l/5y8SD9hg1Ef5zTTVVoRjTrTEzPrNBQvmhMxkoTsjOXN10GWU7aCg==
+  dependencies:
+    microevent.ts "~0.1.1"
 
 wrap-ansi@^2.0.0:
   version "2.1.0"


### PR DESCRIPTION
# Description

This includes three commits, the first is a build change and the others are features.
1) Add typescript to the build process by following the nuxt documention.
2) Wire up the documentation search to filter all documentation based on the search term.
3) Wire up the footer to fetch copy from contentful.

## Type of change

Delete those that don't apply.
- [x] New feature (non-breaking change which adds functionality)

# How Has This Been Tested?

You should be able to search for documentation, for instance if you type "Frequently Asked Questions" and then click go, all items other than the FAQ article will show.  If you click "Clear search", all articles should then come back.

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
