### PR TITLE
Remove Atlas from main menu

### DIFF
--- a/components/header/Header.vue
+++ b/components/header/Header.vue
@@ -155,11 +155,6 @@ const links = [
     href: '/data'
   },
   {
-    title: 'atlas',
-    displayTitle: 'Atlas',
-    href: '/atlas'
-  },
-  {
     title: 'resources',
     displayTitle: 'Resources',
     href: '/resources'
@@ -310,7 +305,7 @@ export default {
     width: 100%;
     height: 100%;
     z-index: 10;
-    background-color: rgba(0,0,0,0.5);
+    background-color: rgba(0, 0, 0, 0.5);
   }
 }
 
@@ -322,7 +317,7 @@ export default {
     width: 100%;
     height: 100%;
     z-index: 10;
-    background-color: rgba(0,0,0,0.5);
+    background-color: rgba(0, 0, 0, 0.5);
   }
 }
 


### PR DESCRIPTION
# Description

The purpose of this PR is to remove the Atlas link from the main menu.

## Type of change

- [x] New feature (non-breaking change which adds functionality)

# How Has This Been Tested?

- Atlas should not be in the main menu on all viewports

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
