### PR TITLE
Fix documentation detail header

### DIFF
--- a/components/Breadcrumb/Breadcrumb.vue
+++ b/components/Breadcrumb/Breadcrumb.vue
@@ -1,0 +1,90 @@
+<template>
+  <div class="breadcrumb">
+    <p>
+      <nuxt-link
+        :to="{
+            name: breadcrumb.name,
+            query: breadcrumb.type
+              ? { type: breadcrumb.type }
+              : []
+          }"
+      >
+        {{ breadcrumb.parent }}
+      </nuxt-link>
+      > {{ formatTitle(title) }}
+    </p>
+  </div>
+</template>
+
+<script lang="ts">
+import Vue from 'vue';
+
+interface Breadcrumb {
+  name: string,
+  type: string,
+  parent: string
+}
+
+interface Props {
+  breadcrumb: Breadcrumb,
+  title: string
+}
+
+interface Methods {
+  formatTitle: (title: string) => string
+}
+
+export default Vue.extend<never, Methods, never, Props>({
+  name: 'Breadcrumb',
+
+  props: {
+    breadcrumb: {
+      type: Object,
+      default: () => ({
+        name: '',
+        type: '',
+        parent: '',
+      })
+    },
+    title: {
+      type: String,
+      default: ''
+    },
+  },
+
+  methods: {
+    /**
+     * Formats breadcrumb length
+     * @param {String} breadcrumb
+     */
+    formatTitle: function(title) {
+      return title.length > 32
+        ? title.substring(0, 32) + '...'
+        : title
+    },
+  }
+})
+</script>
+
+<style lang="scss">
+@import '../../assets/_variables.scss';
+.breadcrumb {
+  background: $purple-gray;
+  height: 2.5rem;
+  margin-top: 0;
+  p {
+    font-size: 14px;
+    font-weight: 500;
+    line-height: 16px;
+    padding-left: 2rem;
+    padding-top: 0.75rem;
+    margin-top: 0;
+    color: $midnight;
+  }
+
+  a {
+    text-decoration: none;
+    color: $midnight;
+  }
+}
+</style>

--- a/components/DetailsHeader/DetailsHeader.vue
+++ b/components/DetailsHeader/DetailsHeader.vue
@@ -1,20 +1,6 @@
 <template>
   <div class="details-header">
-    <div class="details-header__page-route">
-      <p>
-        <nuxt-link
-          :to="{
-            name: breadcrumb.name,
-            query: {
-              type: breadcrumb.type
-            }
-          }"
-        >
-          {{ breadcrumb.parent }}
-        </nuxt-link>
-        > {{ formatBreadcrumb(title) }}
-      </p>
-    </div>
+    <breadcrumb :breadcrumb="breadcrumb" :title="title" />
     <div class="details-header__container container">
       <div class="details-header__container--image">
         <slot name="banner image" />
@@ -36,8 +22,13 @@
 </template>
 
 <script>
+import Breadcrumb from "../Breadcrumb/Breadcrumb";
 export default {
   name: 'DetailsHeader',
+
+  components: {
+    Breadcrumb
+  },
 
   props: {
     breadcrumb: {
@@ -59,16 +50,6 @@ export default {
   },
 
   methods: {
-    /**
-     * Formats breadcrumb length
-     * @param {String} breadcrumb
-     */
-    formatBreadcrumb: function(breadcrumb) {
-      return breadcrumb.length > 32
-        ? breadcrumb.substring(0, 32) + '...'
-        : breadcrumb
-    },
-
     /**
      * Formats title length
      * @param {String} title
@@ -93,25 +74,6 @@ export default {
 <style lang="scss" scoped>
 @import '../../assets/_variables.scss';
 .details-header {
-  &__page-route {
-    background: $purple-gray;
-    height: 2.5rem;
-    margin-top: 0;
-    p {
-      font-size: 14px;
-      font-weight: 500;
-      line-height: 16px;
-      padding-left: 2rem;
-      padding-top: 0.75rem;
-      margin-top: 0;
-      color: $midnight;
-    }
-
-    a {
-      text-decoration: none;
-      color: $midnight;
-    }
-  }
   &__container {
     display: flex;
     flex-direction: row;

--- a/components/HelpCard/HelpCard.vue
+++ b/components/HelpCard/HelpCard.vue
@@ -33,8 +33,14 @@ export default Vue.extend<never, never, never, { helpItem: HelpDocument }>({
 
 <style lang="scss" scoped>
 @import '@/assets/_variables.scss';
+.help-card {
+  h3 {
+    margin-bottom: 0;
+  }
+}
 .help-link {
-  color: $median
+  color: $median;
+  font-size: 24px;
 }
 .help-link:not(:hover) {
   text-decoration: none;

--- a/components/HelpHero/HelpHero.vue
+++ b/components/HelpHero/HelpHero.vue
@@ -1,0 +1,58 @@
+<template>
+  <page-hero justify="left">
+    <h2>{{ title }}</h2>
+    <p>
+      {{ summary }}
+    </p>
+    <HelpSearchControls />
+  </page-hero>
+</template>
+
+<script lang="ts">
+import Vue from 'vue';
+import HelpSearchControls from "~/components/help-search-controls/HelpSearchControls.vue";
+import PageHero from "~/components/PageHero/PageHero.vue";
+
+export default Vue.extend<never, never, never, { title: string, summary: string }>({
+  name: 'HelpHero',
+
+  props: {
+    title: {
+      type: String,
+      default: ''
+    },
+    summary: {
+      type: String,
+      default: ''
+    },
+  },
+
+  components: {
+    HelpSearchControls,
+    PageHero
+  }
+})
+</script>
+
+<style lang="scss" scoped>
+@import '@/assets/_variables.scss';
+.page-hero {
+  background-color: $navy;
+  background-image: none;
+  h2 {
+    font-size: 2rem;
+    font-weight: 500;
+    margin-bottom: 1rem;
+  }
+}
+::v-deep h2 {
+  font-size: 1.5em;
+  font-weight: 500;
+  line-height: 2rem;
+  margin-bottom: 2rem;
+  @media (min-width: 768px) {
+    font-size: 1.5em;
+    margin-bottom: 2rem;
+  }
+}
+</style>

--- a/components/help-search-controls/HelpSearchControls.vue
+++ b/components/help-search-controls/HelpSearchControls.vue
@@ -15,61 +15,22 @@
 
 <script>
 export default {
-  props: {
-    searchOnLoad: {
-      type: Boolean,
-      default: false
-    },
-    submitText: {
-      type: String,
-      default: 'View Results'
-    },
-    isClearSearchVisible: {
-      type: Boolean,
-      default: false
-    },
-    isSearchVisible: {
-      type: Boolean,
-      default: true
-    }
-  },
-
   data() {
     return {
       loading: false,
-      terms: null
+      terms: this.$route.query.search
     }
   },
-  watch: {},
 
-  mounted: function() {
-    if (this.searchOnLoad) {
-      // this.setSearchOnLoad()
+  watch: {
+    '$route.query.search': function() {
+      this.terms = this.$route.query.search
     }
   },
 
   methods: {
-    /**
-     * Clear search
-     */
-    clearSearch: function() {
-      this.terms = ''
-      this.submit()
-    },
-
-    /**
-     * Set search and execute search
-     */
-    setSearchOnLoad: function() {
-      // const terms = pathOr('', ['query', 'searchTerms'], this.$route)
-      // const type = pathOr('datasets', ['query', 'searchType'], this.$route)
-      // this.selectedType = type
-      // this.terms = terms
-      // this.submit()
-    },
-
     submit() {
-      this.$emit('query', this.terms)
+      this.$router.push({ path: '/help',  query: { search: this.terms }})
     }
   }
 }

--- a/pages/help/_helpId.vue
+++ b/pages/help/_helpId.vue
@@ -1,6 +1,7 @@
 <template>
   <div class="events-page">
-    <HelpHero :title="helpHeroData.title" :summary="helpHeroData.summary" />
+    <help-hero :title="helpHeroData.title" :summary="helpHeroData.summary" />
+    <breadcrumb :breadcrumb="breadcrumb" :title="helpItem.fields.title" />
     <div class="page-wrap container">
       <div class="subpage">
         <div class="header">
@@ -26,6 +27,7 @@ import { pathOr } from 'ramda'
 
 import HelpHero from "@/components/HelpHero/HelpHero";
 import MarkedMixin from '@/mixins/marked'
+import Breadcrumb from "../../components/Breadcrumb/Breadcrumb";
 
 import createClient from '@/plugins/contentful.js'
 
@@ -36,6 +38,7 @@ export default {
 
   components: {
     HelpHero,
+    Breadcrumb,
   },
 
   mixins: [MarkedMixin],
@@ -48,7 +51,11 @@ export default {
       .then(([allHelpData, helpItem]) => {
         return {
           helpHeroData: allHelpData.fields,
-          helpItem: helpItem
+          helpItem: helpItem,
+          breadcrumb: {
+            name: 'help',
+            parent: allHelpData.fields.title
+          }
         }
       })
       .catch(() => {

--- a/pages/help/_helpId.vue
+++ b/pages/help/_helpId.vue
@@ -1,12 +1,6 @@
 <template>
   <div class="events-page">
-    <page-hero>
-      <HelpSearchControls
-        :search-on-load="true"
-        submit-text="Go"
-        @query="onSearchQuery"
-      />
-    </page-hero>
+    <HelpHero :title="helpHeroData.title" :summary="helpHeroData.summary" />
     <div class="page-wrap container">
       <div class="subpage">
         <div class="header">
@@ -30,8 +24,7 @@
 import { format, parseISO } from 'date-fns'
 import { pathOr } from 'ramda'
 
-import HelpSearchControls from '@/components/help-search-controls/HelpSearchControls.vue'
-import PageHero from '@/components/PageHero/PageHero.vue'
+import HelpHero from "@/components/HelpHero/HelpHero";
 import MarkedMixin from '@/mixins/marked'
 
 import createClient from '@/plugins/contentful.js'
@@ -42,16 +35,19 @@ export default {
   name: 'EventPage',
 
   components: {
-    HelpSearchControls,
-    PageHero
+    HelpHero,
   },
 
   mixins: [MarkedMixin],
 
   asyncData(env) {
-    return Promise.all([client.getEntry(env.params.helpId)])
-      .then(([helpItem]) => {
+    return Promise.all([
+      client.getEntry(process.env.ctf_support_page_id, { include: 2 }),
+      client.getEntry(env.params.helpId)
+    ])
+      .then(([allHelpData, helpItem]) => {
         return {
+          helpHeroData: allHelpData.fields,
           helpItem: helpItem
         }
       })
@@ -75,12 +71,6 @@ export default {
      */
     updateDate: function() {
       return format(parseISO(this.helpItem.sys.updatedAt), 'MM/dd/yyyy')
-    }
-  },
-
-  methods: {
-    onSearchQuery: function() {
-      return 0
     }
   }
 }

--- a/pages/help/index.vue
+++ b/pages/help/index.vue
@@ -1,17 +1,6 @@
 <template>
   <div class="help-page">
-    <page-hero justify="left">
-      <h2>{{ helpData.title }}</h2>
-      <p>
-        {{ helpData.summary }}
-      </p>
-      <HelpSearchControls
-        isClearSearchVisible
-        :search-on-load="true"
-        submit-text="Go"
-        @query="onSearchQuery"
-      />
-    </page-hero>
+    <HelpHero :title="allHelpData.title" :summary="allHelpData.summary" />
     <div v-loading="isLoadingSearch">
       <help-section
         v-for="item in helpData.sections"
@@ -26,12 +15,11 @@
 
 <script lang="ts">
 import Vue from 'vue';
+import { Route } from 'vue-router';
 import createClient from '@/plugins/contentful.js'
 import {Data, HelpData, HelpDocument, Methods} from "./model";
 import HelpSection from "@/components/HelpSection/HelpSection.vue";
-import HelpSearchControls from "@/components/help-search-controls/HelpSearchControls.vue";
-import PageHero from "@/components/PageHero/PageHero.vue";
-import SearchForm from '@/components/SearchForm/SearchForm.vue'
+import HelpHero from "@/components/HelpHero/HelpHero.vue";
 
 const client = createClient()
 
@@ -41,20 +29,21 @@ export default Vue.extend<Data, Methods, never, never>({
 
   components: {
     HelpSection,
-    HelpSearchControls,
-    PageHero,
-    SearchForm
+    HelpHero
   },
 
-  asyncData() {
-    return client.getEntry<HelpData>(process.env.ctf_support_page_id as string, { include: 2 })
-      .then((resp) => {
-        return {
-          allHelpData: resp.fields,
-          helpData: resp.fields
-        }
-      })
-      .catch(console.error)
+  mounted: function(this: Methods & { $route: Route }) {
+    this.doSearch(this.$route.query.search as string | undefined)
+  },
+
+  watch: {
+    '$route.query.search': function(this: Methods & { $route: Route }) {
+      /**
+       * Clear table data so the new table that is rendered can
+       * properly render data and account for any missing data
+       */
+      this.doSearch(this.$route.query.search as string | undefined)
+    }
   },
 
   data() {
@@ -66,33 +55,52 @@ export default Vue.extend<Data, Methods, never, never>({
     }
   },
 
+  async asyncData() {
+    const { fields } = await client.getEntry<HelpData>(process.env.ctf_support_page_id as string, { include: 2 })
+    return {
+      allHelpData: fields,
+      helpData: {},
+      isLoadingSearch: false,
+      searchTerms: '',
+    }
+  },
+
   methods: {
-    onSearchQuery: function(this: Data, terms) {
+    doSearch: async function(this: Data, terms) {
       this.isLoadingSearch = true;
       this.searchTerms = terms;
-      client
-        .getEntries<HelpDocument>({
-          content_type: 'helpDocument',
-          query: terms
-        })
-        .then(resp => {
+      try {
+        if (terms) {
+          const { items } = await client
+            .getEntries<HelpDocument>({
+              content_type: 'helpDocument',
+              query: terms
+            })
+
           this.helpData = {
             ...this.allHelpData,
             sections: (this.allHelpData.sections ?? []).map(section => ({
               ...section,
               fields: {
                 ...section.fields,
-                helpDocuments: section.fields.helpDocuments.filter(hd => resp.items.find(r => r.sys.id === hd.sys.id))
+                helpDocuments: section.fields.helpDocuments
+                  .filter(hd => items.find(r => r.sys.id === hd.sys.id))
               }
             }))
           }
-        })
-        .catch(console.error)
-        .finally(() => {
-          this.isLoadingSearch = false;
-        })
+
+        } else {
+          this.helpData = this.allHelpData
+        }
+      } catch (e) {
+        console.error(e)
+      } finally {
+        this.isLoadingSearch = false
+      }
     }
   }
+
+
 })
 </script>
 
@@ -101,5 +109,20 @@ export default Vue.extend<Data, Methods, never, never>({
 .page-hero {
   background-color: $navy;
   background-image: none;
+  h2 {
+    font-size: 2rem;
+    font-weight: 500;
+    margin-bottom: 1rem;
+  }
+}
+::v-deep h2 {
+  font-size: 1.5em;
+  font-weight: 500;
+  line-height: 2rem;
+  margin-bottom: 2rem;
+  @media (min-width: 768px) {
+    font-size: 1.5em;
+    margin-bottom: 2rem;
+  }
 }
 </style>

--- a/pages/help/index.vue
+++ b/pages/help/index.vue
@@ -1,6 +1,6 @@
 <template>
   <div class="help-page">
-    <HelpHero :title="allHelpData.title" :summary="allHelpData.summary" />
+    <help-hero :title="allHelpData.title" :summary="allHelpData.summary" />
     <div v-loading="isLoadingSearch">
       <help-section
         v-for="item in helpData.sections"

--- a/pages/help/model.ts
+++ b/pages/help/model.ts
@@ -23,9 +23,9 @@ export interface Data {
   allHelpData: Partial<HelpData>
   helpData: Partial<HelpData>;
   isLoadingSearch: boolean;
-  searchTerms: string;
+  searchTerms?: string;
 }
 
 export interface Methods {
-  onSearchQuery: (terms: string) => void
+  doSearch: (terms: string | undefined) => void
 }

--- a/pages/organs/_organId.vue
+++ b/pages/organs/_organId.vue
@@ -97,7 +97,7 @@ export default {
       breadcrumb: {
         name: 'data',
         type: 'organ',
-        parent: 'Teams and Projects'
+        parent: 'Organs'
       }
     }
   },

--- a/pages/privacy/index.vue
+++ b/pages/privacy/index.vue
@@ -1,5 +1,5 @@
 <template>
-  <MarkdownPage :header="header" :body="body" />
+  <markdown-page :header="header" :body="body" />
 </template>
 
 <script lang="ts">

--- a/pages/terms-of-service/index.vue
+++ b/pages/terms-of-service/index.vue
@@ -1,5 +1,5 @@
 <template>
-  <MarkdownPage :header="header" :body="body" />
+  <markdown-page :header="header" :body="body" />
 </template>
 
 <script lang="ts">


### PR DESCRIPTION
# Description

The documentation detail page did not match the designs.  It was missing the page hero for searching documentation as well as a breadcrumb.

This PR creates a common Breadcrumb component to share with the Dataset detail page, and a common HelpHero component to share between the main help page and the documentation detail page.

For the HelpHero component, searches are executed by passing route query parameters instead of mutating component state.

## Type of change

Delete those that don't apply.

- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

The breadcrumb on the dataset detail page should still work.  The title for the Organ detail page should be fixed.

The documentation home page and detail pages should all have a functional search feature.  Please try navigating back/forward and make sure the content of the search box continues to match the route.

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
