### PR TITLE
add z-index to menu links in case search bar overlays on tablet sizes

### DIFF
--- a/components/header/Header.vue
+++ b/components/header/Header.vue
@@ -65,7 +65,7 @@
           <div :class="[menuOpen ? 'overlay' : '']">
             <div class="mobile-navigation" :class="[menuOpen ? 'open' : '']">
               <ul>
-                <li v-for="link in links" :key="link.href">
+                <li v-for="link in links" :key="link.href" style="z-index: 100;">
                   <nuxt-link
                     :to="{ name: link.title }"
                     :class="{ active: activeLink(link.href) }"


### PR DESCRIPTION
# Description

Adds an inline z-index to the `li` elements on the menu.  This isn't the most "correct" fix but it gets the job done.

## Type of change

Delete those that don't apply.

- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

Open the main page on a tablet screen width (1024px).  Make sure the "Events" part of the "News & Events" link is clickable.

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
