### PR TITLE
Update Files Table Endpoint To Get Packages or Files #4gd1hz

### DIFF
--- a/components/FilesTable/FilesTable.vue
+++ b/components/FilesTable/FilesTable.vue
@@ -57,11 +57,7 @@
             </div>
           </template>
         </el-table-column>
-        <el-table-column
-          prop="fileType"
-          label="File type"
-          width="360"
-        >
+        <el-table-column prop="fileType" label="File type" width="360">
           <template slot-scope="scope">
             <template v-if="scope.row.type === 'Directory'">
               Folder
@@ -81,7 +77,11 @@
         <el-table-column label="Operation" width="200">
           <template v-if="scope.row.type === 'File'" slot-scope="scope">
             <el-dropdown trigger="click" @command="onCommandClick">
-              <el-button icon="el-icon-more" size="small" class="operation-button" />
+              <el-button
+                icon="el-icon-more"
+                size="small"
+                class="operation-button"
+              />
               <el-dropdown-menu slot="dropdown">
                 <el-dropdown-item
                   :command="{
@@ -144,7 +144,8 @@ export default {
       data: [],
       isLoading: false,
       hasError: false,
-      limit: 500
+      limit: 500,
+      schemaVersion: ''
     }
   },
 
@@ -165,13 +166,23 @@ export default {
       return this.path
         ? `${url}?path=${this.path}&limit=${this.limit}`
         : `${url}?limit=${this.limit}`
+    },
+
+    /**
+     * Url to retrieve the dataset to get the version number
+     * @returns {String}
+     */
+    getFilesIdUrl: function() {
+      const id = pathOr('', ['params', 'datasetId'], this.$route)
+      const version = propOr(1, 'version', this.datasetDetails)
+      return `https://api.blackfynn.io/discover/datasets/${id}/versions/${version}`
     }
   },
 
   watch: {
-    getFilesurl: {
+    getFilesIdUrl: {
       handler: function() {
-        this.getFiles()
+        this.getDatasetVersionNumber()
       },
       immediate: true
     }
@@ -180,6 +191,24 @@ export default {
   mounted: function() {},
 
   methods: {
+    /**
+     * Gets the dataset version number to get the files for the dataset
+     */
+    getDatasetVersionNumber: function() {
+      this.isLoading = true
+      this.hasError = false
+
+      this.$axios
+        .$get(this.getFilesIdUrl)
+        .then(response => {
+          if (response.blackfynnSchemaVersion < '4.0') {
+            // add logic here
+          }
+        })
+        .catch(() => {
+          this.hasError = true
+        })
+    },
     /**
      * Checks if file is MS Word, MS Excel, or MS Powerpoint
      * @param {Object} scope

--- a/components/FilesTable/FilesTable.vue
+++ b/components/FilesTable/FilesTable.vue
@@ -206,7 +206,7 @@ export default {
      * @param {String} semverVersion
      */
     convertSchemaVersionToInteger: function(semverVersion) {
-      // split version number into three parts
+      // split version number into parts
       let parts = semverVersion.split('.')
       // make sure no part is larger than 1023 or else it won't fit
       // into 32-bit integer


### PR DESCRIPTION
# Description

The purpose of this PR is to update the endpoint calls for the files table on the dataset details page, so that the starting point for displaying files is not `Root` but either `packages` or `files` depending on the schema version.

## Type of change

- [x] New feature (non-breaking change which adds functionality)

# How Has This Been Tested?

1. Navigate to Find Data > Datasets and select a dataset.
2. Navigate to the files tab. You should no longer see `Root` as the parent directory but `packages` or `files`, depending on whether the dataset schema version is less than 4.0 (display packages) or greater than 4.0 (display files).
3. Navigate through multiple datasets and test out the path functionality in the files table, making sure that the path is updated with the correct folder structure and that each individual path routes directly back to the right position in the folder hierarchy. 

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
