### PR TITLE
Clearer filter transforms

### DIFF
--- a/pages/data/index.vue
+++ b/pages/data/index.vue
@@ -177,7 +177,8 @@ const searchData = {
 }
 
 import createClient from '@/plugins/contentful.js'
-import SearchMapPopup from "../../components/SearchMapPopup/SearchMapPopup"
+import SearchMapPopup from "../../components/SearchMapPopup/SearchMapPopup";
+import {transformFilters} from "./utils";
 
 const client = createClient()
 
@@ -185,7 +186,7 @@ const client = createClient()
  * Transform indidivual filter
  * @param {Object} filter
  */
-const transformIndividualFilter = filter => {
+/*const transformIndividualFilter = filter => {
   const category = propOr('', 'category', filter)
   const filters = propOr([], 'tags', filter)
 
@@ -199,18 +200,18 @@ const transformIndividualFilter = filter => {
   })
 
   return mergeLeft({ filters: transformedFilters }, filter)
-}
+}*/
 
 /**
  * Transform filter response
  * @param {Object} filters
  */
-const transformFilters = compose(
+/*const transformFilters = compose(
   flatten,
   map(transformIndividualFilter),
   pluck('fields'),
   propOr([], 'filters')
-)
+)*/
 
 export default {
   name: 'DataPage',
@@ -498,6 +499,7 @@ export default {
         .getEntry(this.searchType.filterId, { include: 2 })
         .then(response => {
           const filters = transformFilters(response.fields)
+          debugger;
           this.filters = this.setActiveFilters(filters)
         })
         .catch(() => {

--- a/pages/data/index.vue
+++ b/pages/data/index.vue
@@ -499,7 +499,6 @@ export default {
         .getEntry(this.searchType.filterId, { include: 2 })
         .then(response => {
           const filters = transformFilters(response.fields)
-          debugger;
           this.filters = this.setActiveFilters(filters)
         })
         .catch(() => {

--- a/pages/data/utils.ts
+++ b/pages/data/utils.ts
@@ -1,0 +1,87 @@
+import { Entry } from "contentful";
+
+interface Tag {
+  name: string;
+  slug: string
+}
+
+/**
+ *
+ * this utility type is provided by contentful, and demonstrates basic generics:
+ *
+ * export interface Entry<T> {
+ *   sys: Sys;
+ *   fields: T;
+ *   toPlainObject(): object;
+ *   update(): Promise<Entry<T>>;
+ * }
+ *
+ * in english: "take the type argument: T, and make that the fields key in the object"
+ *
+ * the result:
+ * {
+ *   sys: Sys;
+ *   fields: Tag
+ * }
+ */
+type TagEntry = Entry<Tag>
+
+interface Filter {
+  category: string
+  tags?: TagEntry[]
+}
+
+interface TransformedInnerFilter {
+  label: string;
+  category: string;
+  key: string
+  value: boolean;
+}
+
+type TransformedFilter = Filter & {
+  filters: TransformedInnerFilter[]
+}
+
+/**
+ * this is the type signature for the function below.  It takes a Filter, and returns a TransformedFilter
+ */
+type FilterTransform = (filter: Filter) => TransformedFilter
+
+/**
+ * since you know the shape of the thing you are dealing with, and the shape of the thing you want to return,
+ * you end up with a function that is much easier to read and understand, IMHO
+ */
+export const transformIndividualFilter: FilterTransform = outerFilter => ({
+  ...outerFilter,
+  filters: (outerFilter.tags ?? []).map(t => ({
+    label: t.fields.name,
+    category: outerFilter.category,
+    key: t.fields.slug,
+    value: false
+  }))
+})
+
+
+interface OuterFilter {
+  type: string;
+  filters?: Entry<Filter>[]
+}
+
+/**
+ * here we see the generics at work again.  We're able to concisely express
+ * the complicated nesting of { sys, fields } objects that occurs when we
+ * model things in contentful
+ */
+type FilterResponse = Entry<OuterFilter>
+
+type TransformFilters = (fields: FilterResponse['fields']) => TransformedFilter[]
+
+/**
+ * and now the function is much more readable
+ * the type system made it immediately apparent that the original function's 'flatten' operation
+ * was actually an unnecessary no-op
+ */
+export const transformFilters: TransformFilters = fields =>
+  (fields.filters ?? [])
+    .map(f => transformIndividualFilter(f.fields))
+


### PR DESCRIPTION
# Description

Refactors the filter transforms in typescript.  There are also lots of comments in the utils.ts file explaining some of the TS syntax which we can remove if we want.  I also left the original code commented out for comparison purposes.

## Type of change

Delete those that don't apply.

- [x] New feature (non-breaking change which adds functionality)

# How Has This Been Tested?

The functionality should be exactly the same in all the Find Data pages.

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
