### PR TITLE
News and Events page - News list

### DIFF
--- a/components/NewsListItem/NewsListItem.vue
+++ b/components/NewsListItem/NewsListItem.vue
@@ -1,0 +1,55 @@
+<template>
+  <div class="news-list-item">
+    <h3>
+      <a :href="item.fields.url" target="_blank">{{ item.fields.title }}</a>
+    </h3>
+    <p>{{ item.fields.summary }}</p>
+    <p class="news-list-item__date">
+      {{ publishedDate }}
+    </p>
+  </div>
+</template>
+
+<script>
+import FormatDate from '@/mixins/format-date'
+
+export default {
+  name: 'NewsListItem',
+
+  mixins: [FormatDate],
+
+  props: {
+    item: {
+      type: Object,
+      default: () => {}
+    }
+  },
+
+  computed: {
+    /**
+     * Compute and formate start date
+     * @returns {String}
+     */
+    publishedDate: function() {
+      return this.formatDate(this.item.fields.publishedDate)
+    }
+  }
+}
+</script>
+
+<style lang="scss" scoped>
+h3 {
+  font-size: 1em;
+  font-weight: 500;
+  line-height: 1.2;
+  margin-bottom: 0.5rem;
+}
+p {
+  margin-bottom: 0.5rem;
+}
+.news-list-item__date {
+  font-size: 0.875rem;
+  font-style: italic;
+  margin: 0;
+}
+</style>

--- a/pages/news-and-events/index.vue
+++ b/pages/news-and-events/index.vue
@@ -10,39 +10,44 @@
           :active-tab="activeTab"
           @set-active-tab="activeTab = $event"
         />
-        <template v-if="activeTab === 'upcoming'">
-          <div class="upcoming-events">
-            <event-card
-              v-for="event in displayedUpcomingEvents"
-              :key="event.sys.id"
+        <div class="events-wrap">
+          <template v-if="activeTab === 'upcoming'">
+            <div class="upcoming-events">
+              <event-card
+                v-for="event in displayedUpcomingEvents"
+                :key="event.sys.id"
+                :event="event"
+              />
+            </div>
+
+            <div class="show-all-upcoming-events">
+              <a
+                v-if="!isShowingAllUpcomingEvents"
+                class="show-all-upcoming-events__btn"
+                href="#"
+                @click.prevent="isShowingAllUpcomingEvents = true"
+              >
+                Show All ({{ upcomingEvents.length }}) Upcoming Events
+                <svg-icon name="icon-sort-desc" height="10" width="10" />
+              </a>
+            </div>
+          </template>
+
+          <div v-if="activeTab === 'past'" class="subpage">
+            <event-list-item
+              v-for="(event, index) in pastEvents"
+              :key="`${event}-${index}`"
               :event="event"
             />
           </div>
-
-          <div class="show-all-upcoming-events">
-            <a
-              v-if="!isShowingAllUpcomingEvents"
-              class="show-all-upcoming-events__btn"
-              href="#"
-              @click.prevent="isShowingAllUpcomingEvents = true"
-            >
-              Show All ({{ upcomingEvents.length }}) Upcoming Events
-              <svg-icon name="icon-sort-desc" height="10" width="10" />
-            </a>
-          </div>
-        </template>
-
-        <div v-if="activeTab === 'past'" class="subpage">
-          <event-list-item
-            v-for="(event, index) in pastEvents"
-            :key="`${event}-${index}`"
-            :event="event"
-          />
         </div>
-      </div>
 
-      <div class="subpage">
-        <div v-for="newsItem in news" :key="newsItem.sys.id" />
+        <h2>Latest News</h2>
+        <div class="subpage">
+          <div>
+            <news-list-item v-for="newsItem in news" :key="newsItem.sys.id" :item="newsItem" />
+          </div>
+        </div>
       </div>
     </div>
   </div>
@@ -53,6 +58,7 @@ import Vue from 'vue'
 import Breadcrumb from '@/components/Breadcrumb/Breadcrumb.vue'
 import TabNav from '@/components/TabNav/TabNav.vue'
 import EventListItem from '@/components/EventListItem/EventListItem.vue'
+import NewsListItem from '@/components/NewsListItem/NewsListItem.vue'
 import EventCard from '@/components/EventCard/EventCard.vue'
 
 import createClient from '@/plugins/contentful.js'
@@ -68,6 +74,7 @@ export default Vue.extend<Data, never, Computed, never>({
     Breadcrumb,
     EventCard,
     EventListItem,
+    NewsListItem,
     TabNav
   },
 
@@ -155,6 +162,16 @@ export default Vue.extend<Data, never, Computed, never>({
   }
   .svg-icon {
     margin-left: 0.5rem;
+  }
+}
+.events-wrap {
+  margin-bottom: 2.625em;
+}
+.news-list-item {
+  border-bottom: 2px solid #d8d8d8;
+  padding: 1.5em 0;
+  &:first-child {
+    padding-top: 0;
   }
 }
 </style>

--- a/pages/news-and-events/model.ts
+++ b/pages/news-and-events/model.ts
@@ -18,7 +18,7 @@ export const fetchData = async (client: ContentfulClientApi) : Promise<AsyncData
 
     const news = await client.getEntries<News>({
       content_type: process.env.ctf_news_id,
-      order: 'fields.publishedDate'
+      order: '-fields.publishedDate'
     })
 
     return {


### PR DESCRIPTION
# Description

The purpose of this PR is to add the news list to the News and Events page.

Note: I have a question out to Qian about what the "View All News" button in the designs does. I haven't heard from them yet, so I didn't add it to this. I will add this button and functionality in another PR when I get the answer.

## Type of change

- [x] New feature (non-breaking change which adds functionality)

# How Has This Been Tested?

- Go to the [news and events](http://localhost:3000/news-and-events) page
- Scroll to the bottom to see the news
- News should be ordered in chronological order starting with the most recent.

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
