### PR TITLE
bugfix: cookie notice z-index

### DIFF
--- a/components/CookieNotice/CookieNotice.vue
+++ b/components/CookieNotice/CookieNotice.vue
@@ -61,6 +61,7 @@ export default {
   right: 0;
   padding: 1.625em 0;
   position: fixed;
+  z-index: 9;
 }
 .cookie-notice__content {
   max-width: 80%;


### PR DESCRIPTION
# Description

The purpose of this PR is to fix a bug where the cookie notice wouldn't be overlaying the Find Data table.

## Bug
![localhost_3000_organs_2MyjbZVNRrJjLtRrpQ8DXc(Laptop with HiDPI screen)](https://user-images.githubusercontent.com/1493195/74780468-a7e5f580-526d-11ea-9ac5-a9259038c8b7.png)


## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

- Delete the `GDPR:accepted` cookie
- Refresh the app and ensure the Cookie Notice is visible
- Go to Find Data
- The cookie notice should be overlaying all columns on the table
- Resize the viewport to go to the mobile version
- Open the mobile menu
- The mobile menu should overlay the cookie notice

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
