### PR TITLE
Show project section for project detail page

### DIFF
--- a/pages/projects/_projectId.vue
+++ b/pages/projects/_projectId.vue
@@ -1,7 +1,7 @@
 <template>
   <div class="project-details">
     <details-header
-      :subtitle="''"
+      :subtitle="projectSection"
       :title="fields.title"
       :description="fields.description"
       :breadcrumb="breadcrumb"
@@ -82,6 +82,18 @@ export default {
         type: 'sparcAward',
         parent: 'Teams and Projects'
       }
+    }
+  },
+
+  computed: {
+    /**
+     * Compute subtitle based on its project section
+     * @returns {String}
+     */
+    projectSection: function() {
+      return this.fields.projectSection
+        ? this.fields.projectSection.fields.title
+        : ''
     }
   },
 


### PR DESCRIPTION
# Description

The purpose of this PR is to fix the display issue with showing the organs on a project detail page. The way this content was stored on contentful was changed, and this PR addresses that.

## Type of change

- [x] New feature (non-breaking change which adds functionality)

# How Has This Been Tested?

- Go to the Find Data page
- Click on "Projects"
- Visit a few projects and ensure that the organs are shown above the project's title. If there is no organ, this area should be empty.

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
