### PR TITLE
Project Details Header Image #4m8hjw

### DIFF
--- a/pages/projects/_projectId.vue
+++ b/pages/projects/_projectId.vue
@@ -6,7 +6,13 @@
       :description="fields.description"
       :breadcrumb="breadcrumb"
     >
-      <img slot="banner image" src="http://placehold.jp/368x368.png" />
+      <img
+        slot="banner image"
+        :src="getImageSrc"
+        :alt="getImageAlt"
+        height="368"
+        width="368"
+      />
       <div slot="meta content" class="details-header__container--content-meta">
         <div class="content-meta__item">
           <h3>Project Number</h3>
@@ -84,6 +90,28 @@ export default {
         type: 'sparcAward',
         parent: 'Teams and Projects'
       }
+    }
+  },
+
+  computed: {
+    /**
+     * Get image Source
+     * @returns {String}
+     */
+    getImageSrc: function() {
+      return this.fields.institution.image
+        ? this.fields.institution.image.fields.file.url
+        : ''
+    },
+
+    /**
+     * Get image source
+     * @returns {String}
+     */
+    getImageAlt: function() {
+      return this.fields.institution.image
+        ? this.fields.institution.image.fields.file.description
+        : ''
     }
   },
 

--- a/pages/projects/_projectId.vue
+++ b/pages/projects/_projectId.vue
@@ -112,9 +112,8 @@ export default {
       return this.fields.institution.image
         ? this.fields.institution.image.fields.file.description
         : ''
-     },
-     
-     /**
+    },
+    /**
      * Compute subtitle based on its project section
      * @returns {String}
      */


### PR DESCRIPTION
# Description

The purpose of this PR is to add the banner image to the project details page from contentful. Please note that no images are in contentful yet and so there will be no images displayed on the pages until then.

## Type of change

- [x] New feature (non-breaking change which adds functionality)

# How Has This Been Tested?

Verify that the placeholder image on the project details page is no longer present and that the image data should now be coming from contenful.

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
