### PR TITLE
Resources - Fix resources images to not stretch

### DIFF
--- a/components/Resources/ResourcesSearchResults.vue
+++ b/components/Resources/ResourcesSearchResults.vue
@@ -57,7 +57,7 @@ export default {
     display: flex;
     flex-direction: row;
     border-bottom: solid 1px $light-grey;
-    margin-bottom: 1.375rem;
+    padding: 1.25em 0;
     @media screen and (max-width: 768px) {
       height: 100%;
       display: block;
@@ -68,6 +68,7 @@ export default {
     h2 {
       font-size: 1em;
       color: $median;
+      margin-bottom: 0.375rem;
       line-height: 22px;
       font-weight: 500;
     }
@@ -80,9 +81,13 @@ export default {
 
     &--image {
       margin-right: 1rem;
-      img {
+      @media (min-width: 48em) {
+        flex-shrink: 0;
         width: 128px;
-        height: 128px;
+      }
+      img {
+        width: 100%;
+        height: auto;
       }
     }
     &--content-date {


### PR DESCRIPTION
# Description

The purpose of this PR is to fix the resources images to not stretch. In addition, I adjusted the bottom margin of the resource's heading to match the design.

## Type of change

- [x] New feature (non-breaking change which adds functionality)

# How Has This Been Tested?

- Go to the resources page
- All of the images should be a max of `128px` wide, with the height auto adjusting. The Protocols.io image was being stretched before.

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
