### PR TITLE
Find Data - preserve search query

### DIFF
--- a/pages/data/index.vue
+++ b/pages/data/index.vue
@@ -11,7 +11,8 @@
             :to="{
               name: 'data',
               query: {
-                type: type.type
+                type: type.type,
+                q: $route.query.q
               }
             }"
           >


### PR DESCRIPTION
# Description

The purpose of this PR is to preserve the search query when changing search types.

## Type of change

- [x] New feature (non-breaking change which adds functionality)

# How Has This Been Tested?

- Go to Find Data
- Search "heart"
- You should be seeing dataset results for "heart"
- Click on Filters
- Select a filter and apply filters
- Click on "Organs"
- You should be seeing organ results for "heart", and the filters should have been removed

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas