### PR TITLE
Dataset Details Sparc Award Id #4jczhk

### DIFF
--- a/components/DatasetDetails/DatasetAboutInfo.vue
+++ b/components/DatasetDetails/DatasetAboutInfo.vue
@@ -26,7 +26,7 @@
         </el-col>
       </el-row>
       <h3>Awards</h3>
-      <p>{{ sparcAwardNumber }}</p>
+      <p>{{ getSparcAwardNumber }}</p>
       <h3>Cite This Dataset</h3>
       <div class="dataset-about-info__container--citation">
         <el-row type="flex" justify="center">
@@ -135,6 +135,15 @@ export default {
   },
 
   computed: {
+
+    /**
+     * Gets the sparc award number
+     * @return {String}
+     */
+    getSparcAwardNumber: function() {
+      return this.sparcAwardNumber !== '' ? this.sparcAwardNumber : 'N/A'
+    },
+
     /**
      * Return DOI link
      * @returns {String}
@@ -183,7 +192,7 @@ export default {
         .then(response => {
           response.records.forEach(record => {
             if (record.model === 'summary') {
-              this.sparcAwardNumber = record.properties.hasAwardNumber
+              this.sparcAwardNumber = record.properties.hasAwardNumber || ''
             }
           })
         })

--- a/components/DatasetDetails/DatasetAboutInfo.vue
+++ b/components/DatasetDetails/DatasetAboutInfo.vue
@@ -26,7 +26,7 @@
         </el-col>
       </el-row>
       <h3>Awards</h3>
-      <p>Lorem ipsum text</p>
+      <p>{{ sparcAwardNumber }}</p>
       <h3>Cite This Dataset</h3>
       <div class="dataset-about-info__container--citation">
         <el-row type="flex" justify="center">
@@ -86,7 +86,6 @@
 
 <script>
 import TagList from '@/components/TagList/TagList.vue'
-import { propOr } from 'ramda'
 export default {
   name: 'DatasetAboutInfo',
 
@@ -95,6 +94,11 @@ export default {
   },
   props: {
     updatedDate: {
+      type: String,
+      default: ''
+    },
+
+    datasetId: {
       type: String,
       default: ''
     },
@@ -125,7 +129,8 @@ export default {
       citationLoading: false,
       citationText: '',
       activeCitation: '',
-      crosscite_host: process.env.crosscite_api_host
+      crosscite_host: process.env.crosscite_api_host,
+      sparcAwardNumber: ''
     }
   },
 
@@ -136,6 +141,14 @@ export default {
      */
     DOIlink: function() {
       return this.doiValue ? `https://doi.org/${this.doiValue}` : ''
+    },
+
+    /**
+     * Url to get records for model
+     * @returns {String}
+     */
+    getRecordsUrl: function() {
+      return `${process.env.discover_api_host}/search/records?datasetId=${this.datasetId}`
     }
   },
 
@@ -147,10 +160,39 @@ export default {
         }
       },
       immediate: true
+    },
+
+    getRecordsUrl: {
+      handler: function(val) {
+        if (val) {
+          this.getDatasetRecords()
+        }
+      },
+      immediate: true
     }
   },
 
   methods: {
+
+    /**
+     * Retrievs the metadata records for a dataset to get the sparc award number
+     */
+    getDatasetRecords: function() {
+       this.$axios
+        .$get(this.getRecordsUrl)
+        .then(response => {
+          response.records.forEach(record => {
+            if (record.model === 'summary') {
+              this.sparcAwardNumber = record.properties.hasAwardNumber
+            }
+          })
+        })
+        .catch(
+          // handle error
+          (this.errorLoading = true)
+        )
+    },
+
     /**
      * gets bibiolography based on citation type for current DOI
      * @param {String} citationType

--- a/pages/datasets/_datasetId.vue
+++ b/pages/datasets/_datasetId.vue
@@ -125,6 +125,7 @@
         <dataset-about-info
           v-show="activeTab === 'about'"
           :updated-date="lastUpdatedDate"
+          :dataset-id="datasetId"
           :doi="datasetDOI"
           :doi-value="datasetInfo.doi"
           :dataset-records="datasetRecords"
@@ -406,7 +407,6 @@ export default {
       const doi = propOr('', 'doi', this.datasetInfo)
       return `https://doi.org/${doi}`
     },
-
     /**
      * Get formatted originally published date
      * @return {String}


### PR DESCRIPTION
# Description

The purpose of this PR is to display the project Id associated with a dataset on the About tab of the dataset details page.

## Type of change

- [x] New feature (non-breaking change which adds functionality)

# How Has This Been Tested?

Navigate to a dataset details page. You should see the associated project Id/Sparc Award Id listed in the About Tab instead of the `Lorem Ipsum` text

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
