### PR TITLE
Add redirect SSL middleware to force HTTPS

### DIFF
--- a/nuxt.config.js
+++ b/nuxt.config.js
@@ -61,6 +61,11 @@ export default {
     BL_SERVER_URL: 'https://sparc.biolucida.net/api/v1/'
   },
 
+  serverMiddleware: [
+    // Will register redirect-ssl npm package
+    'redirect-ssl'
+  ],
+
   /*
    ** Customize the progress-bar color
    */

--- a/package.json
+++ b/package.json
@@ -32,6 +32,7 @@
     "nuxt": "^2.11.0",
     "prettier": "^1.19.1",
     "ramda": "^0.26.1",
+    "redirect-ssl": "^1.4.1",
     "striptags": "^3.1.1",
     "vue": "^2.6.10",
     "vue-infinite-loading": "^2.4.4",

--- a/yarn.lock
+++ b/yarn.lock
@@ -6103,6 +6103,11 @@ is-glob@^4.0.0, is-glob@^4.0.1, is-glob@~4.0.1:
   dependencies:
     is-extglob "^2.1.1"
 
+is-https@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/is-https/-/is-https-1.0.0.tgz#9c1dde000dc7e7288edb983bef379e498e7cb1bf"
+  integrity sha512-1adLLwZT9XEXjzhQhZxd75uxf0l+xI9uTSFaZeSESjL3E1eXSPpO+u5RcgqtzeZ1KCaNvtEwZSTO2P4U5erVqQ==
+
 is-nan@^1.2.1:
   version "1.3.0"
   resolved "https://registry.yarnpkg.com/is-nan/-/is-nan-1.3.0.tgz#85d1f5482f7051c2019f5673ccebdb06f3b0db03"
@@ -8742,6 +8747,13 @@ redeyed@~0.4.0:
   integrity sha1-N+mQpvKyGyoRwuakj9QTVpjLqX8=
   dependencies:
     esprima "~1.0.4"
+
+redirect-ssl@^1.4.1:
+  version "1.4.1"
+  resolved "https://registry.yarnpkg.com/redirect-ssl/-/redirect-ssl-1.4.1.tgz#4d9a91ac4b4f2eb358272a8e4de3afaf44554ede"
+  integrity sha512-8Lg6swHUDPydPKRTV2faJMF2foKw8oUFE7cWoieRpoU57ZjM1cdFVp3YcBar1tM5L6GD9KMDNu6uc0qi/3zSHQ==
+  dependencies:
+    is-https "^1.0.0"
 
 regenerate-unicode-properties@^8.1.0:
   version "8.1.0"


### PR DESCRIPTION
# Description

The purpose of this PR is to force HTTPS for production. This was done with the [redirect-ssl](https://github.com/nuxt-community/redirect-ssl) middleware.

## Type of change

- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)

# How Has This Been Tested?

`yarn nuxt` should run the devserver as normal. Testing for SSL will need to happen when deployed.

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas