### PR TITLE
Get Dataset Dialog #4wawjx

### DIFF
--- a/components/DownloadDataset/DownloadDataset.vue
+++ b/components/DownloadDataset/DownloadDataset.vue
@@ -3,26 +3,37 @@
     :visible="visible"
     :show-close="false"
     class="download-dataset-dialog"
-    :width="width"
-    height="448px"
+    width="768px"
+    :height="height"
     @close="closeDialog"
   >
     <div class="download-dataset-container">
       <div v-if="!isDatasetSizeLarge" class="download-block">
+        <button class="close-dialog" @click="closeDialog">
+          <svg-icon
+            name="icon-remove"
+            width="16"
+            height="16"
+            color="#71747c"
+            class="close-icon"
+          />
+        </button>
         <h1>Direct Download</h1>
         <p>
           You can download the raw files and metadata directly to your computer
           as a zip archive free of charge.
         </p>
+        <p class="dataset-size-text">
+          Dataset Size: {{ formatMetric(datasetDetails.size) }}
+        </p>
         <a :href="downloadUrl">
-          <bf-button class="download-button">Download Dataset</bf-button>
+          <bf-button class="download-dataset">Download Dataset</bf-button>
         </a>
-
-        <div class="size">
-          {{ formatMetric(datasetDetails.size) }}
-        </div>
+        <bf-button class="secondary button-spacing" @click="closeDialog">
+          Cancel
+        </bf-button>
       </div>
-      <div :class="[isDatasetSizeLarge ? 'aws-container' : 'aws-block']">
+      <div v-else class="aws-container">
         <button class="close-dialog" @click="closeDialog">
           <svg-icon
             name="icon-remove"
@@ -35,11 +46,9 @@
         <h1>Download from AWS</h1>
         <p>
           Raw files and metadata are stored in an AWS S3 Requester Pays bucket.
-          You can learn more about
-          <nuxt-link :to="{ name: 'help-helpId', params: { helpId: 'zQfzadwADutviJjT19hA5' }}">
-            downloading data from AWS
-          </nuxt-link>
-          in the Help Center.
+          You can learn more about downloading data from AWS on our
+          <nuxt-link :to="{ name: 'help' }">
+            Help Page.
           </nuxt-link>
         </p>
         <h2>Resource Type</h2>
@@ -49,16 +58,20 @@
           {{ datasetArn }}
         </div>
         <h2>AWS Region</h2>
-        <div class="text-block">
+        <div class="text-block aws">
           us-east-1
         </div>
+        <div class="buttons">
+          <a :href="downloadUrl">
+            <bf-button class="download-button">
+              Download to AWS Bucket
+            </bf-button>
+          </a>
+          <bf-button class="secondary button-spacing" @click="closeDialog">
+            Cancel
+          </bf-button>
+        </div>
       </div>
-    </div>
-    <div class="discover-banner">
-      For more information, visit the
-      <nuxt-link :to="{ name: 'help' }">
-        help page
-      </nuxt-link>
     </div>
   </el-dialog>
 </template>
@@ -104,8 +117,8 @@ export default {
      * Compute width based on isDatasetSizeLarge
      * @returns {String}
      */
-    width: function() {
-      return this.isDatasetSizeLarge ? '490px' : '772px'
+    height: function() {
+      return this.isDatasetSizeLarge ? '460px' : '284px'
     },
 
     /**
@@ -153,6 +166,8 @@ export default {
 </script>
 
 <style lang="scss" scoped>
+@import '@/assets/_variables.scss';
+
 .el-dialog__body {
   padding: 0;
 }
@@ -169,18 +184,10 @@ export default {
 .download-dataset-dialog {
   .download-dataset-container {
     display: flex;
-    height: 513px;
     word-break: normal;
   }
   .download-block {
-    box-sizing: border-box;
-    flex-shrink: 0;
-    height: 100%;
-    width: 316px;
-    overflow: hidden;
-    position: relative;
-    background-color: #24245b;
-    padding: 40px 40px 0px 40px;
+    padding: 40px;
 
     img {
       position: absolute;
@@ -191,17 +198,9 @@ export default {
       height: 402px;
     }
 
-    h1 {
-      line-height: 32px;
-      color: #ffffff;
-      font-size: 24px;
-      font-weight: 500;
-      margin: 0;
-    }
-
     p {
       line-height: 24px;
-      color: #cddaff;
+      color: #000;
       font-size: 16px;
       margin-top: 8px;
     }
@@ -225,6 +224,14 @@ export default {
       line-height: 24px;
       margin-top: 5px;
     }
+
+    .buttons {
+      .cancel-button {
+        color: $median;
+        border: solid 1px $median;
+        background: $light-purple !important;
+      }
+    }
   }
 
   a {
@@ -235,8 +242,12 @@ export default {
   }
 
   .aws-container {
-    margin: 21px 48px;
+    margin: 40px 48px;
     margin-top: 47px;
+
+    a {
+      font-weight: bold;
+    }
   }
 
   .close-dialog {
@@ -244,7 +255,7 @@ export default {
     border: none;
     cursor: pointer;
     float: right;
-    margin-top: -21px;
+    margin-top: -47px;
     padding: 0;
   }
 
@@ -254,10 +265,10 @@ export default {
   }
 
   h1 {
-    color: #000000;
-    font-size: 24px;
-    font-weight: 500;
-    line-height: 32px;
+    line-height: 36px;
+    color: $midnight;
+    font-size: 28px;
+    font-weight: normal;
     margin-bottom: 8px;
   }
 
@@ -265,25 +276,33 @@ export default {
     color: #000000;
     font-size: 16px;
     line-height: 24px;
-    margin-bottom: 16px;
+    margin-bottom: -4px;
   }
 
   h2 {
     color: #000000;
-    font-size: 16px;
-    font-weight: 600;
+    font-size: 18px;
+    font-weight: 500;
+    line-height: 24px;
     margin: 0 0 8px;
+    margin-top: 15px;
   }
 
   .text-block {
     border-radius: 2px;
-    background-color: #f1f1f3;
-    padding: 8px 8px 8px 8px;
+    background-color: #f5f7fa;
+    padding: 6px 6px 6px 6px;
     margin-bottom: 16px;
     font-family: monospace;
     font-size: 14px;
     display: flex;
     align-items: center;
+    border-radius: 4px;
+    color: #000;
+
+    &.aws {
+      margin-bottom: 36px;
+    }
   }
 
   .aws-block {
@@ -293,7 +312,7 @@ export default {
 
   ::v-deep .el-dialog {
     border-radius: 0;
-    width: var(--widthSmaller);
+    width: 768px;
     .el-dialog__body {
       padding: 0;
     }
@@ -301,12 +320,6 @@ export default {
     .el-dialog__header {
       padding: 0;
       border-bottom: none;
-    }
-  }
-
-  ::v-deep .bf-button {
-    &:focus {
-      background-color: #11369c;
     }
   }
 }

--- a/components/DownloadDataset/DownloadDataset.vue
+++ b/components/DownloadDataset/DownloadDataset.vue
@@ -120,7 +120,7 @@ export default {
     },
 
     /**
-     * Compute width based on isDatasetSizeLarge
+     * Compute height based on isDatasetSizeLarge
      * @returns {String}
      */
     height: function() {

--- a/components/DownloadDataset/DownloadDataset.vue
+++ b/components/DownloadDataset/DownloadDataset.vue
@@ -8,16 +8,16 @@
     @close="closeDialog"
   >
     <div class="download-dataset-container">
+      <button class="close-dialog" @click="closeDialog">
+        <svg-icon
+          name="icon-remove"
+          width="16"
+          height="16"
+          color="#71747c"
+          class="close-icon"
+        />
+      </button>
       <div v-if="!isDatasetSizeLarge" class="download-block">
-        <button class="close-dialog" @click="closeDialog">
-          <svg-icon
-            name="icon-remove"
-            width="16"
-            height="16"
-            color="#71747c"
-            class="close-icon"
-          />
-        </button>
         <h1>Direct Download</h1>
         <p>
           You can download the raw files and metadata directly to your computer
@@ -34,15 +34,6 @@
         </bf-button>
       </div>
       <div v-else class="aws-container">
-        <button class="close-dialog" @click="closeDialog">
-          <svg-icon
-            name="icon-remove"
-            width="16"
-            height="16"
-            color="#71747c"
-            class="close-icon"
-          />
-        </button>
         <h1>Download from AWS</h1>
         <p>
           Raw files and metadata are stored in an AWS S3 Requester Pays bucket.
@@ -269,9 +260,9 @@ export default {
     background: none;
     border: none;
     cursor: pointer;
-    float: right;
-    margin-top: -47px;
     padding: 0;
+    position: absolute;
+    right: 41px;
   }
 
   .close-icon {

--- a/components/DownloadDataset/DownloadDataset.vue
+++ b/components/DownloadDataset/DownloadDataset.vue
@@ -67,8 +67,8 @@
               <nuxt-link
                 :to="{
                   name: 'help-helpId',
-                  query: {
-                    type: process.env.ctf_help_aws_id
+                  params: {
+                    helpId: helpId
                   }
                 }"
               >
@@ -109,6 +109,12 @@ export default {
     datasetDetails: {
       type: Object,
       default: () => {}
+    }
+  },
+
+  data() {
+    return {
+      helpId: process.env.ctf_help_aws_id
     }
   },
 
@@ -255,7 +261,7 @@ export default {
     margin-top: 47px;
 
     a {
-      font-weight: bold;
+      color: #fff;
     }
   }
 

--- a/components/DownloadDataset/DownloadDataset.vue
+++ b/components/DownloadDataset/DownloadDataset.vue
@@ -27,7 +27,7 @@
           Dataset Size: {{ formatMetric(datasetDetails.size) }}
         </p>
         <a :href="downloadUrl">
-          <bf-button class="download-dataset">Download Dataset</bf-button>
+          <bf-button class="download-button">Download Dataset</bf-button>
         </a>
         <bf-button class="secondary button-spacing" @click="closeDialog">
           Cancel
@@ -64,7 +64,16 @@
         <div class="buttons">
           <a :href="downloadUrl">
             <bf-button class="download-button">
-              Download to AWS Bucket
+              <nuxt-link
+                :to="{
+                  name: 'help-helpId',
+                  query: {
+                    type: process.env.ctf_help_aws_id
+                  }
+                }"
+              >
+                Download to AWS Bucket
+              </nuxt-link>
             </bf-button>
           </a>
           <bf-button class="secondary button-spacing" @click="closeDialog">
@@ -203,6 +212,7 @@ export default {
       color: #000;
       font-size: 16px;
       margin-top: 8px;
+      margin-bottom: 16px;
     }
 
     .size {
@@ -214,15 +224,14 @@ export default {
     }
 
     .download-button {
-      height: 60px;
-      width: 236px;
-      border-radius: 3px;
-      background-color: #071540;
-      color: #ffffff;
-      font-size: 16px;
+      width: 178px;
+    }
+
+    .dataset-size-text {
+      font-size: 18px;
       font-weight: 500;
       line-height: 24px;
-      margin-top: 5px;
+      margin-bottom: 32px;
     }
 
     .buttons {

--- a/components/DownloadDataset/DownloadDataset.vue
+++ b/components/DownloadDataset/DownloadDataset.vue
@@ -3,7 +3,6 @@
     :visible="visible"
     :show-close="false"
     class="download-dataset-dialog"
-    width="768px"
     :height="height"
     @close="closeDialog"
   >
@@ -26,12 +25,14 @@
         <p class="dataset-size-text">
           Dataset Size: {{ formatMetric(datasetDetails.size) }}
         </p>
-        <a :href="downloadUrl">
-          <bf-button class="download-button">Download Dataset</bf-button>
-        </a>
-        <bf-button class="secondary button-spacing" @click="closeDialog">
-          Cancel
-        </bf-button>
+        <div class="buttons">
+          <a :href="downloadUrl">
+            <bf-button class="download-button">Download Dataset</bf-button>
+          </a>
+          <bf-button class="secondary button-spacing" @click="closeDialog">
+            Cancel
+          </bf-button>
+        </div>
       </div>
       <div v-else class="aws-container">
         <h1>Download from AWS</h1>
@@ -174,6 +175,11 @@ export default {
 <style lang="scss" scoped>
 @import '@/assets/_variables.scss';
 
+@media screen and (max-width: 767px) {
+  ::v-deep .el-dialog {
+    width: 93%;
+  }
+}
 .el-dialog__body {
   padding: 0;
 }
@@ -222,6 +228,9 @@ export default {
 
     .download-button {
       width: 178px;
+      @media screen and (max-width: 767px) {
+        width: 100%;
+      }
     }
 
     .dataset-size-text {
@@ -230,12 +239,19 @@ export default {
       line-height: 24px;
       margin-bottom: 32px;
     }
+  }
 
+  @media screen and (max-width: 767px) {
     .buttons {
-      .cancel-button {
-        color: $median;
-        border: solid 1px $median;
-        background: $light-purple !important;
+      display: flex;
+      flex-direction: row;
+    }
+  }
+
+  @media screen and (max-width: 767px) {
+    ::v-deep .bf-button {
+      &.secondary {
+        width: 30%;
       }
     }
   }
@@ -319,6 +335,9 @@ export default {
   ::v-deep .el-dialog {
     border-radius: 0;
     width: 768px;
+    @media screen and (max-width: 767px) {
+      width: 93%;
+    }
     .el-dialog__body {
       padding: 0;
     }

--- a/components/shared/BfButton/BfButton.vue
+++ b/components/shared/BfButton/BfButton.vue
@@ -81,7 +81,7 @@ export default {
   align-items: center;
   background: $median;
   border: 1px solid transparent;
-  border-radius: 3px;
+  border-radius: 4px;
   color: #fff;
   cursor: pointer;
   display: inline-flex;
@@ -151,6 +151,20 @@ export default {
       background: #fff;
     }
   }
+  &.secondary {
+    background-color: $light-purple;
+    border: solid 1px $median;
+    color: $median;
+    border-radius: 4px;
+    width: 178px;
+    &:hover {
+      background: $light-purple;
+    }
+  }
+  &.button-spacing {
+    margin-left: 16px;
+  }
+
   & iron-icon {
     margin-right: 5px;
   }

--- a/nuxt.config.js
+++ b/nuxt.config.js
@@ -41,6 +41,7 @@ export default {
     ctf_resource_hero_id: '3ImGx7UyDXPwM3oTag06nt',
     ctf_help_id: 'helpDocument',
     ctf_help_list_id: 'helpSection',
+    ctf_help_aws_id: 'zQfzadwADutviJjT19hA5',
     ctf_about_page_id: '4VOSvJtgtFv1PS2lklMcnS',
     ctf_support_page_id: '59F0dM5goobqjw3TsqINRw',
     ctf_home_page_id: '4qJ9WUWXg09FAUvCnbGxBY',


### PR DESCRIPTION
# Description

The purpose of this PR is to update the `Get Dataset` dialog according to the [designs](https://app.abstract.com/projects/e709ca90-5ba9-11e9-9eaa-59df656d954a/branches/600d2375-3dd1-4940-97a6-bbec7a21f97e/collections/5e983fd9-e489-4e1a-a226-5bcc6679150d)

## Type of change

- [x] New feature (non-breaking change which adds functionality)

# How Has This Been Tested?

1. Navigate to a dataset that is less than 5 GB. 
2. Click on the `Get Dataset` button. The dialog that requests you to download the dataset should appear with the new designs. Click on `Download Dataset`. Dataset should be downloaded as expected.
3. Navigate to a dataset that is greater than 5 GB. 
4. Click on the `Get Dataset` button. The AWS dialog should appear with the new designs. Clicking on `Download to AWS bucket` should direct you to the help documentation related to this functionality.

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
