### PR TITLE
Fix Download Dataset Buttons for AWS

### DIFF
--- a/components/DownloadDataset/DownloadDataset.vue
+++ b/components/DownloadDataset/DownloadDataset.vue
@@ -64,12 +64,12 @@
                   }
                 }"
               >
-                Download to AWS Bucket
+                More Information
               </nuxt-link>
             </bf-button>
           </a>
           <bf-button class="secondary button-spacing" @click="closeDialog">
-            Cancel
+            Okay
           </bf-button>
         </div>
       </div>

--- a/components/shared/BfButton/BfButton.vue
+++ b/components/shared/BfButton/BfButton.vue
@@ -156,7 +156,7 @@ export default {
     border: solid 1px $median;
     color: $median;
     border-radius: 4px;
-    width: 178px;
+    width: 140px;
     &:hover {
       background: $light-purple;
     }


### PR DESCRIPTION
# Description

The purpose of this PR is to change the button language for the AWS version of the Download Dataset modal from `Download to AWS Bucket` and `Cancel` to `More Information` and `Okay`

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

Navigate to a dataset that is greater than 5GB. Click on the `Get Dataset` button. The buttons on the modal should reflect the changes above.

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added unit tests that prove my fix is effective or that my feature works
