### PR TITLE
Update pagination limit to 10

### DIFF
--- a/components/SearchResults/OrganSearchResults.vue
+++ b/components/SearchResults/OrganSearchResults.vue
@@ -19,12 +19,19 @@
     </el-table-column>
     <el-table-column :fixed="true" prop="fields.title" label="Banner">
       <template slot-scope="scope">
-        <img
-          :src="getImageSrc(scope)"
-          :alt="getImageAlt(scope)"
-          height="128"
-          width="128"
-        />
+        <nuxt-link
+          :to="{
+            name: 'organs-organId',
+            params: { organId: scope.row.sys.id }
+          }"
+        >
+          <img
+            :src="getImageSrc(scope)"
+            :alt="getImageAlt(scope)"
+            height="128"
+            width="128"
+          />
+        </nuxt-link>
       </template>
     </el-table-column>
   </el-table>

--- a/components/header/Header.vue
+++ b/components/header/Header.vue
@@ -165,7 +165,7 @@ const links = [
   {
     title: 'resources',
     displayTitle: 'Resources',
-    href: '/resources'
+    href: '/resources?type=sparcPartners'
   },
   {
     title: 'news-and-events',

--- a/components/header/Header.vue
+++ b/components/header/Header.vue
@@ -165,7 +165,7 @@ const links = [
   {
     title: 'resources',
     displayTitle: 'Resources',
-    href: '/resources?type=sparcPartners'
+    href: `/resources?type=${process.env.ctf_resource_id}`
   },
   {
     title: 'news-and-events',

--- a/pages/data/index.vue
+++ b/pages/data/index.vue
@@ -144,7 +144,7 @@ const searchTypes = [
 ]
 
 const searchData = {
-  limit: 12,
+  limit: 10,
   skip: 0,
   items: []
 }

--- a/pages/resources/index.vue
+++ b/pages/resources/index.vue
@@ -55,7 +55,7 @@ import createClient from '@/plugins/contentful.js'
 const client = createClient()
 
 const resourceData = {
-  limit: 12,
+  limit: 10,
   skip: 0,
   items: []
 }


### PR DESCRIPTION
# Description

The purpose of this PR is to update the pagination limit to 10 for all search types on Find Data and for the Resources page.

## Type of change

- [x] New feature (non-breaking change which adds functionality)

# How Has This Been Tested?

- Go to Find Data
- Pages should be returning 10 results per page, for all types
- Go to Resources
- Pages should be returning 10 results per page, for all resource types. 

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas