### PR TITLE
Add Image To Homepage Hero #4ydgdg

### DIFF
--- a/pages/index.vue
+++ b/pages/index.vue
@@ -88,16 +88,17 @@ export default {
   }
 
   h1 {
-    margin-top: 2.3125rem;
+    margin-top: 2rem;
   }
 
   @media screen and (min-width: 768px) and (max-width: 1023px) {
     p {
       position: absolute;
       background-color: rgba(36, 36, 91, 0.75);
+      top: 167px;
     }
     .btn-link {
-      margin-top: 7rem;
+      margin-top: 12rem;
     }
 
     .row {
@@ -105,12 +106,26 @@ export default {
         position: absolute;
       }
     }
+
+    h1 {
+      font-size: 1.45rem;
+      position: absolute;
+    }
+  }
+
+  @media screen and (max-width: 767px) {
+    h1 {
+      font-size: 1.45rem;
+    }
   }
 
   .page-hero-img {
     height: 19rem;
     @media screen and (max-width: 767px) {
       display: none;
+    }
+    @media screen and (min-width: 768px) and (max-width: 1023px) {
+      margin-left: 14rem;
     }
   }
 

--- a/pages/index.vue
+++ b/pages/index.vue
@@ -1,17 +1,24 @@
 <template>
   <div>
     <page-hero class="large">
-      <h1 v-if="heroHeading">
-        {{ heroHeading }}
-      </h1>
-      <p>
-        {{ heroCopy }}
-      </p>
-      <a v-if="heroButtonLink" class="btn-link" :href="heroButtonLink">
-        <el-button class="uppercase">
-          {{ heroButtonLabel }}
-        </el-button>
-      </a>
+      <div class="row">
+        <div class="col">
+          <h1 v-if="heroHeading">
+            {{ heroHeading }}
+          </h1>
+          <p>
+            {{ heroCopy }}
+          </p>
+          <a v-if="heroButtonLink" class="btn-link" :href="heroButtonLink">
+            <el-button class="uppercase">
+              {{ heroButtonLabel }}
+            </el-button>
+          </a>
+        </div>
+        <div class="col">
+          <img class="page-hero-img" src="@/static/images/about-hero.png" />
+        </div>
+      </div>
     </page-hero>
 
     <featured-data :featured-data="featuredData" />
@@ -72,10 +79,43 @@ export default {
 
 <style lang="scss" scoped>
 .page-hero {
+  padding: 0;
+  height: 19rem;
   h2 {
     font-size: 2rem;
     font-weight: 500;
     margin-bottom: 1rem;
+  }
+
+  h1 {
+    margin-top: 2.3125rem;
+  }
+
+  @media screen and (min-width: 768px) and (max-width: 1023px) {
+    p {
+      position: absolute;
+      background-color: rgba(36, 36, 91, 0.75);
+    }
+    .btn-link {
+      margin-top: 7rem;
+    }
+
+    .row {
+      &.col {
+        position: absolute;
+      }
+    }
+  }
+
+  .page-hero-img {
+    height: 19rem;
+    @media screen and (max-width: 767px) {
+      display: none;
+    }
+  }
+
+  .row {
+    display: flex;
   }
 }
 ::v-deep h2 {


### PR DESCRIPTION
# Description

The purpose of this PR is to add the image to the homepage hero and adjust design styles according to tablet and mobile viewports. The PageHero component will be adjusted to default to this design in a separate PR.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

Navigate to the homepage. The PageHero component should now contain the image from the About page and styles should be adjusted for mobile and tablet viewports.

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
