### PR TITLE
Fetch and render images

### DIFF
--- a/components/ImagesTable/ImagesTable.vue
+++ b/components/ImagesTable/ImagesTable.vue
@@ -1,20 +1,22 @@
 <template>
   <el-table :data="tableData" empty-text="No Results">
-    <el-table-column :fixed="true" prop="image_id" label="ID" width="300">
+    <el-table-column :fixed="true" prop="image_id" label="ID">
       <template slot-scope="scope">
-        <!-- <nuxt-link
+        <nuxt-link
           :to="{
-            name: 'file-datasetId-datasetVersion-path,
+            name: 'datasets-viewer-id',
             params: {
-              datasetId
-             }
+              id: scope.row.image_id
+            },
+            query: {
+              viewer: viewerId(scope.row.share_link)
+            }
           }"
-        > -->
-        {{ scope.row.image_id }}
-        <!-- </nuxt-link> -->
+        >
+          {{ scope.row.image_id }}
+        </nuxt-link>
       </template>
     </el-table-column>
-    <el-table-column prop="share_link" label="Link" />
   </el-table>
 </template>
 
@@ -29,7 +31,18 @@ export default {
     }
   },
 
-  methods: {}
+  methods: {
+    /**
+     * Get the viewer ID from the share link
+     * @param {String} shareLink
+     * @returns {String}
+     */
+    viewerId: function(shareLink) {
+      const linkParts = shareLink.split(process.env.BL_SHARE_LINK_PREFIX)
+
+      return linkParts[1]
+    }
+  }
 }
 </script>
 

--- a/components/ImagesTable/ImagesTable.vue
+++ b/components/ImagesTable/ImagesTable.vue
@@ -1,0 +1,44 @@
+<template>
+  <el-table :data="tableData" empty-text="No Results">
+    <el-table-column :fixed="true" prop="image_id" label="ID" width="300">
+      <template slot-scope="scope">
+        <!-- <nuxt-link
+          :to="{
+            name: 'file-datasetId-datasetVersion-path,
+            params: {
+              datasetId
+             }
+          }"
+        > -->
+        {{ scope.row.image_id }}
+        <!-- </nuxt-link> -->
+      </template>
+    </el-table-column>
+    <el-table-column prop="share_link" label="Link" />
+  </el-table>
+</template>
+
+<script>
+export default {
+  name: 'ImagesTable',
+
+  props: {
+    tableData: {
+      type: Array,
+      default: () => []
+    }
+  },
+
+  methods: {}
+}
+</script>
+
+<style lang="scss" scoped>
+.el-table {
+  width: 100%;
+}
+.img-image {
+  height: auto;
+  width: 100%;
+}
+</style>

--- a/nuxt.config.js
+++ b/nuxt.config.js
@@ -59,7 +59,8 @@ export default {
     CTF_SPACE_ID: process.env.CTF_SPACE_ID,
     CTF_CDA_ACCESS_TOKEN: process.env.CTF_CDA_ACCESS_TOKEN,
     CTF_API_HOST: process.env.CTF_API_HOST,
-    BL_SERVER_URL: 'https://sparc.biolucida.net/api/v1/'
+    BL_SERVER_URL: 'https://sparc.biolucida.net/api/v1/',
+    BL_SHARE_LINK_PREFIX: 'https://sparc.biolucida.net/image?c='
   },
 
   serverMiddleware: [

--- a/pages/datasets/viewer/_id.vue
+++ b/pages/datasets/viewer/_id.vue
@@ -1,0 +1,108 @@
+<template>
+  <div class="file-detail-page">
+    <div class="page-wrap">
+      <detail-tabs
+        :tabs="tabs"
+        :active-tab="activeTab"
+        class="container"
+        @set-active-tab="activeTab = $event"
+      >
+        <biolucida-viewer
+          v-show="activeTab === 'viewer'"
+          :data="biolucidaData"
+        />
+      </detail-tabs>
+    </div>
+  </div>
+  </div>
+</template>
+
+<script>
+import BiolucidaViewer from '@/components/BiolucidaViewer/BiolucidaViewer'
+import DetailTabs from '@/components/DetailTabs/DetailTabs.vue'
+
+export default {
+  name: 'FileDetailPage',
+
+  components: {
+    BiolucidaViewer,
+    DetailTabs
+  },
+
+  data: () => {
+    return {
+      tabs: [
+        {
+          label: 'Viewer',
+          type: 'viewer'
+        }
+      ],
+      activeTab: 'viewer',
+      file: {}
+    }
+  },
+
+  computed: {
+    /**
+     * Compute biolucida data
+     * @returns {Object}
+     */
+    biolucidaData: function() {
+      return  {
+        biolucida_image_id: '',
+        share_link: process.env.BL_SHARE_LINK_PREFIX + this.$route.query.viewer,
+        status: ''
+      }
+    }
+  }
+}
+</script>
+
+<style scoped lang="scss">
+.page {
+  display: flex;
+  margin-top: 7rem;
+
+  p {
+    color: #606266;
+  }
+}
+
+.about {
+  text-align: center;
+  min-height: 50vh;
+  margin-top: 9rem;
+}
+
+h1 {
+  flex: 1;
+  font-size: 1.5em;
+  line-height: 2rem;
+}
+.page-heading {
+  display: flex;
+  flex-direction: column;
+  margin-bottom: 1.375rem;
+  @media (min-width: 48em) {
+    flex-direction: row;
+  }
+}
+.page-heading__button {
+  flex-shrink: 0;
+}
+
+
+.file-detail {
+  border-bottom: 1px solid #dbdfe6;
+  flex-direction: column;
+  font-size: 0.875em;
+  display: flex;
+  padding: 1rem 0.625rem;
+  @media (min-width: 48em) {
+    flex-direction: row;
+  }
+}
+.file-detail__column {
+  flex: 1;
+}
+</style>


### PR DESCRIPTION
# Description

The purpose of this PR is to add the images tab to a dataset's page, as well as the new route for the image viewer.

Please note the following at in progress, and will be addressed in future PRs pending work that MBF will do:

- Show thumbnails of each image in the images tab on the dataset page
- Show more data on the image viewer page
- Have a combined route for file details and image viewer

## Type of change

- [x] New feature (non-breaking change which adds functionality)

# How Has This Been Tested?

- Open [a dataset that has images](http://localhost:3000/datasets/43?type=dataset)
- Go to the Images tab
- Click on one of the image's IDs
- You should be taken to a page that display that image's viewer
- Open [a dataset that does not have images](http://localhost:3000/datasets/24?type=dataset)
- You should not see the images tab

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas