### PR TITLE
Add page hero to news and events page

### DIFF
--- a/components/footer/Footer.vue
+++ b/components/footer/Footer.vue
@@ -24,10 +24,6 @@
       </div>
       <div class="footer__info--copyright">
         <p>
-          <nuxt-link class="underline" :to="{ name: 'terms-of-service' }">
-            Terms of Service
-          </nuxt-link>
-          |
           <nuxt-link class="underline" :to="{ name: 'privacy' }">
             Privacy Policy
           </nuxt-link>
@@ -49,9 +45,7 @@
             </a>
           </li>
           <li>
-            <a href="https://commonfund.nih.gov/Sparc/" target="_blank"
-              >NIH SPARC</a
-            >
+            <a href="https://commonfund.nih.gov/Sparc/" target="_blank">NIH SPARC</a>
           </li>
         </ul>
         <h3>Help us Improve</h3>

--- a/nuxt.config.js
+++ b/nuxt.config.js
@@ -45,6 +45,7 @@ export default {
     ctf_about_page_id: '4VOSvJtgtFv1PS2lklMcnS',
     ctf_support_page_id: '59F0dM5goobqjw3TsqINRw',
     ctf_home_page_id: '4qJ9WUWXg09FAUvCnbGxBY',
+    ctf_news_and_events_page_id: '4IoMamTLRlN3OpxT1zgnU',
     ctf_project_id: 'sparcAward',
     ctf_organ_id: 'organ',
     ctf_filter_id: '6bya4tyw8399',

--- a/pages/news-and-events/index.vue
+++ b/pages/news-and-events/index.vue
@@ -1,6 +1,12 @@
 <template>
   <div class="events-page">
     <breadcrumb :breadcrumb="breadcrumb" :title="title" />
+    <page-hero>
+      <h1>{{ heroData.fields.page_title }}</h1>
+      <p>
+        {{ heroData.fields.heroCopy }}
+      </p>
+    </page-hero>
 
     <div class="page-wrap">
       <div class="container">
@@ -60,10 +66,11 @@ import TabNav from '@/components/TabNav/TabNav.vue'
 import EventListItem from '@/components/EventListItem/EventListItem.vue'
 import NewsListItem from '@/components/NewsListItem/NewsListItem.vue'
 import EventCard from '@/components/EventCard/EventCard.vue'
+import PageHero from '@/components/PageHero/PageHero.vue'
 
 import createClient from '@/plugins/contentful.js'
 
-import { EventsEntry, NewsEntry, Data, Computed, fetchData } from './model'
+import { EventsEntry, HeroDataEntry, NewsEntry, Data, Computed, fetchData } from './model'
 
 const client = createClient()
 
@@ -74,6 +81,7 @@ export default Vue.extend<Data, never, Computed, never>({
     Breadcrumb,
     EventCard,
     EventListItem,
+    PageHero,
     NewsListItem,
     TabNav
   },
@@ -103,7 +111,8 @@ export default Vue.extend<Data, never, Computed, never>({
       upcomingEvents: [],
       pastEvents: [],
       isShowingAllUpcomingEvents: false,
-      news: []
+      news: [],
+      heroData: {} as HeroDataEntry
     }
   },
 

--- a/pages/news-and-events/model.ts
+++ b/pages/news-and-events/model.ts
@@ -21,7 +21,7 @@ export const fetchData = async (client: ContentfulClientApi) : Promise<AsyncData
       order: '-fields.publishedDate'
     })
 
-    const heroData = await client.getEntry<HeroData>('4IoMamTLRlN3OpxT1zgnU')
+    const heroData = await client.getEntry<HeroData>(process.env.ctf_news_and_events_page_id ?? '')
 
     return {
       upcomingEvents: upcomingEvents.items,

--- a/pages/news-and-events/model.ts
+++ b/pages/news-and-events/model.ts
@@ -21,17 +21,29 @@ export const fetchData = async (client: ContentfulClientApi) : Promise<AsyncData
       order: '-fields.publishedDate'
     })
 
+    const heroData = await client.getEntry<HeroData>('4IoMamTLRlN3OpxT1zgnU')
+
     return {
       upcomingEvents: upcomingEvents.items,
       pastEvents: pastEvents.items,
-      news: news.items
+      news: news.items,
+      heroData
     }
   } catch (e) {
     console.error(e)
   }
 }
 
-export type AsyncData = Pick<Data, "upcomingEvents" | "pastEvents" | "news">
+export type AsyncData = Pick<Data, "upcomingEvents" | "pastEvents" | "news" | "heroData">
+
+export interface HeroData {
+  page_title?: string;
+  heroCopy?: string;
+  heroImage?: Asset;
+}
+
+export type HeroDataEntry = Entry<HeroData>
+
 
 export interface Event {
   endDate?: string;
@@ -75,7 +87,8 @@ export interface Data {
   upcomingEvents: EventsEntry[],
   pastEvents: EventsEntry[],
   isShowingAllUpcomingEvents: boolean,
-  news: NewsEntry[]
+  news: NewsEntry[],
+  heroData: HeroDataEntry
 }
 
 


### PR DESCRIPTION
# Description

The purpose of this PR is to add the page hero to the news and events page. In addition, I removed the TOS link from the footer.

## Type of change

- [x] New feature (non-breaking change which adds functionality)

# How Has This Been Tested?

- Go to the [News and events page](http://localhost:3000/news-and-events)
- There should be a page hero at the top

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas