### PR TITLE
SPARC QA #4yd5t2

### DIFF
--- a/components/Breadcrumb/Breadcrumb.vue
+++ b/components/Breadcrumb/Breadcrumb.vue
@@ -1,17 +1,13 @@
 <template>
   <div class="breadcrumb">
     <p>
-      <nuxt-link
-        :to="{
-          name: breadcrumb.name,
-          query: breadcrumb.type
-            ? { type: breadcrumb.type }
-            : []
-        }"
-      >
-        {{ breadcrumb.parent }}
-      </nuxt-link>
-      > {{ formatTitle(title) }}
+      <template v-for="item in breadcrumb">
+        <nuxt-link :key="item.label" :to="item.to">
+          {{ item.label }}
+        </nuxt-link>
+        >
+      </template>
+      {{ formatTitle(title) }}
     </p>
   </div>
 </template>
@@ -19,32 +15,15 @@
 <script lang="ts">
 import Vue from 'vue'
 
-interface Breadcrumb {
-  name: string
-  type: string
-  parent: string
-}
-
-interface Props {
-  breadcrumb: Breadcrumb
-  title: string
-}
-
-interface Methods {
-  formatTitle: (title: string) => string
-}
+import { Methods, Props } from './model'
 
 export default Vue.extend<never, Methods, never, Props>({
   name: 'Breadcrumb',
 
   props: {
     breadcrumb: {
-      type: Object,
-      default: () => ({
-        name: '',
-        type: '',
-        parent: ''
-      })
+      type: Array,
+      default: () => []
     },
     title: {
       type: String,

--- a/components/Breadcrumb/model.ts
+++ b/components/Breadcrumb/model.ts
@@ -1,0 +1,14 @@
+import { Location } from 'vue-router/types/router'
+
+export interface Breadcrumb {
+  to: Location;
+  label: string
+}
+
+export interface Props {
+  breadcrumb: Breadcrumb[]
+  title: string
+}
+export interface Methods {
+  formatTitle: (title: string) => string
+}

--- a/components/DetailsHeader/DetailsHeader.vue
+++ b/components/DetailsHeader/DetailsHeader.vue
@@ -40,8 +40,8 @@ export default {
 
   props: {
     breadcrumb: {
-      type: Object,
-      default: () => {}
+      type: Array,
+      default: () => []
     },
     subtitle: {
       type: String,

--- a/components/HomepageTwitter/HomepageTwitter.vue
+++ b/components/HomepageTwitter/HomepageTwitter.vue
@@ -3,14 +3,16 @@
     <div class="container">
       <el-row type="flex" justify="center">
         <el-col :xs="22" :sm="22" :md="12">
-          <a
-            class="twitter-timeline"
-            href="https://twitter.com/sparc_science?ref_src=twsrc%5Etfw"
-            data-height="500"
-            target="_blank"
-          >
-            Tweets by sparc_science
-          </a>
+          <div v-twitter-widgets>
+            <a
+              class="twitter-timeline"
+              href="https://twitter.com/sparc_science?ref_src=twsrc%5Etfw"
+              data-height="500"
+              target="_blank"
+            >
+              Tweets by sparc_science
+            </a>
+          </div>
         </el-col>
       </el-row>
     </div>
@@ -19,31 +21,7 @@
 
 <script>
 export default {
-  name: 'HomepageTwitter',
-
-  mounted() {
-    /**
-     * Load the Twitter widget library
-     * https://developer.twitter.com/en/docs/twitter-for-websites/javascript-api/guides/set-up-twitter-for-websites
-     */
-    window.twttr = (function(d, s, id) {
-      var js,
-        fjs = d.getElementsByTagName(s)[0],
-        t = window.twttr || {}
-      if (d.getElementById(id)) return t
-      js = d.createElement(s)
-      js.id = id
-      js.src = 'https://platform.twitter.com/widgets.js'
-      fjs.parentNode.insertBefore(js, fjs)
-
-      t._e = []
-      t.ready = function(f) {
-        t._e.push(f)
-      }
-
-      return t
-    })(document, 'script', 'twitter-wjs')
-  }
+  name: 'HomepageTwitter'
 }
 </script>
 

--- a/nuxt.config.js
+++ b/nuxt.config.js
@@ -96,7 +96,12 @@ export default {
   /*
    ** Nuxt.js modules
    */
-  modules: ['@nuxtjs/axios', '@nuxtjs/robots', 'cookie-universal-nuxt'],
+  modules: [
+    '@nuxtjs/axios',
+    '@nuxtjs/robots',
+    'cookie-universal-nuxt',
+    '@miyaoka/nuxt-twitter-widgets-module'
+  ],
   /*
    ** robots.txt
    */

--- a/package.json
+++ b/package.json
@@ -16,6 +16,7 @@
   "dependencies": {
     "@abi-software/flatmapvuer": "^0.1.3",
     "@abi-software/scaffoldvuer": "0.1.15",
+    "@miyaoka/nuxt-twitter-widgets-module": "^0.0.1",
     "@nuxtjs/axios": "^5.8.0",
     "@nuxtjs/robots": "^2.4.2",
     "babel-eslint": "^10.0.3",

--- a/pages/about/index.vue
+++ b/pages/about/index.vue
@@ -9,9 +9,7 @@
             {{ heroCopy }}
           </p>
           <button class="about-page-button">
-            <a href="https://commonfund.nih.gov/sparc/" target="_blank"
-              >More Info NIH Website</a
-            >
+            <a href="https://commonfund.nih.gov/sparc/" target="_blank">More Info NIH Website</a>
           </button>
         </div>
         <div class="col">
@@ -91,10 +89,14 @@ export default {
     return {
       heroCopy: '',
       copy: '',
-      breadcrumb: {
-        name: 'index',
-        parent: 'Home'
-      },
+      breadcrumb: [
+        {
+          to: {
+            name: 'index'
+          },
+          label: 'Home'
+        }
+      ],
       projectId: process.env.ctf_project_id
     }
   }

--- a/pages/data/index.vue
+++ b/pages/data/index.vue
@@ -207,10 +207,14 @@ export default {
       isLoadingFilters: false,
       isFiltersVisible: false,
       isSearchMapVisible: false,
-      breadcrumb: {
-        name: 'index',
-        parent: 'Home'
-      }
+      breadcrumb: [
+        {
+          to: {
+            name: 'index'
+          },
+          label: 'Home'
+        }
+      ]
     }
   },
 

--- a/pages/datasets/_datasetId.vue
+++ b/pages/datasets/_datasetId.vue
@@ -292,11 +292,23 @@ export default {
       isDownloadModalVisible: false,
       tabs: [],
       activeTab: 'about',
-      breadcrumb: {
-        name: 'data',
-        type: this.$route.query.type,
-        parent: 'Find Data'
-      },
+      breadcrumb: [
+        {
+          to: {
+            name: 'index'
+          },
+          label: 'Home'
+        },
+        {
+          to: {
+            name: 'data',
+            query: {
+              type: this.$route.query.type
+            }
+          },
+          label: 'Find Data'
+        }
+      ],
       subtitles: [],
       ctfDatasetFormatInfoPageId: process.env.ctf_dataset_format_info_page_id
     }

--- a/pages/help/_helpId.vue
+++ b/pages/help/_helpId.vue
@@ -52,10 +52,20 @@ export default {
         return {
           helpHeroData: allHelpData.fields,
           helpItem: helpItem,
-          breadcrumb: {
-            name: 'help',
-            parent: allHelpData.fields.title
-          }
+          breadcrumb: [
+            {
+              label: 'Home',
+              to: {
+                name: 'index'
+              }
+            },
+            {
+              label: allHelpData.fields.title,
+              to: {
+                name: 'help'
+              }
+            }
+          ]
         }
       })
       .catch(() => {

--- a/pages/help/index.vue
+++ b/pages/help/index.vue
@@ -55,10 +55,14 @@ export default Vue.extend<Data, Methods, never, never>({
       helpData: {},
       isLoadingSearch: false,
       searchTerms: '',
-      breadcrumb: {
-        name: 'index',
-        parent: 'Home'
-      }
+      breadcrumb: [
+        {
+          to: {
+            name: 'index'
+          },
+          label: 'Home'
+        }
+      ]
     }
   },
 

--- a/pages/index.vue
+++ b/pages/index.vue
@@ -27,9 +27,7 @@
 
     <homepage-testimonials :testimonials="testimonials" />
 
-    <client-only>
-      <homepage-twitter />
-    </client-only>
+    <homepage-twitter />
   </div>
 </template>
 

--- a/pages/news-and-events/index.vue
+++ b/pages/news-and-events/index.vue
@@ -117,7 +117,7 @@ export default Vue.extend<Data, never, Computed, never>({
       isShowingAllUpcomingEvents: false,
       news: [],
       heroData: {} as HeroDataEntry
-    } as Data
+    }
   },
 
   computed: {

--- a/pages/news-and-events/index.vue
+++ b/pages/news-and-events/index.vue
@@ -93,10 +93,14 @@ export default Vue.extend<Data, never, Computed, never>({
   data: function() {
     return {
       title: 'News & Events',
-      breadcrumb: {
-        name: 'index',
-        parent: 'Home'
-      },
+      breadcrumb: [
+        {
+          to: {
+            name: 'index'
+          },
+          label: 'Home'
+        }
+      ],
       activeTab: 'upcoming',
       eventsTabs: [
         {
@@ -113,7 +117,7 @@ export default Vue.extend<Data, never, Computed, never>({
       isShowingAllUpcomingEvents: false,
       news: [],
       heroData: {} as HeroDataEntry
-    }
+    } as Data
   },
 
   computed: {

--- a/pages/news-and-events/model.ts
+++ b/pages/news-and-events/model.ts
@@ -1,5 +1,8 @@
 import {Asset, Entry, ContentfulClientApi} from "contentful"
 
+import { Breadcrumb } from '@/components/Breadcrumb/model.ts'
+
+
 export const fetchData = async (client: ContentfulClientApi) : Promise<AsyncData | void> => {
   try {
     const todaysDate = new Date()
@@ -74,14 +77,9 @@ export interface Tab {
   type: string;
 }
 
-export interface Breadcrumb {
-  name: string;
-  parent: string;
-}
-
 export interface Data {
   title: string
-  breadcrumb: Breadcrumb,
+  breadcrumb: Breadcrumb[],
   activeTab: string,
   eventsTabs: Tab[],
   upcomingEvents: EventsEntry[],

--- a/pages/organs/_organId.vue
+++ b/pages/organs/_organId.vue
@@ -87,11 +87,23 @@ export default {
         }
       ],
       activeTab: 'datasets',
-      breadcrumb: {
-        name: 'data',
-        type: 'organ',
-        parent: 'Organs'
-      }
+      breadcrumb: [
+        {
+          to: {
+            name: 'index'
+          },
+          label: 'Home'
+        },
+        {
+          to: {
+            name: 'data',
+            query: {
+              type: 'organ'
+            }
+          },
+          label: 'Find Data'
+        }
+      ]
     }
   },
 

--- a/pages/projects/_projectId.vue
+++ b/pages/projects/_projectId.vue
@@ -100,11 +100,23 @@ export default {
         }
       ],
       activeTab: 'datasets',
-      breadcrumb: {
-        name: 'data',
-        type: 'sparcAward',
-        parent: 'Teams and Projects'
-      }
+      breadcrumb: [
+        {
+          to: {
+            name: 'index'
+          },
+          label: 'Home'
+        },
+        {
+          to: {
+            name: 'data',
+            query: {
+              type: 'sparcAward'
+            }
+          },
+          label: 'Find Data'
+        }
+      ]
     }
   },
 

--- a/pages/resources/index.vue
+++ b/pages/resources/index.vue
@@ -101,10 +101,14 @@ export default {
     return {
       resources: [],
       title: 'Resources',
-      breadcrumb: {
-        name: 'index',
-        parent: 'Home'
-      },
+      breadcrumb: [
+        {
+          to: {
+            name: 'index'
+          },
+          label: 'Home'
+        }
+      ],
       resourceData: clone(resourceData),
       tabTypes: tabTypes,
       platformItems: [],

--- a/yarn.lock
+++ b/yarn.lock
@@ -1724,6 +1724,11 @@
   resolved "https://registry.yarnpkg.com/@mapbox/whoots-js/-/whoots-js-3.1.0.tgz#497c67a1cef50d1a2459ba60f315e448d2ad87fe"
   integrity sha512-Es6WcD0nO5l+2BOQS4uLfNPYQaNDfbot3X1XUoloz+x0mPDS3eeORZJl06HXjwBG1fOGwCRnzK88LMdxKRrd6Q==
 
+"@miyaoka/nuxt-twitter-widgets-module@^0.0.1":
+  version "0.0.1"
+  resolved "https://registry.yarnpkg.com/@miyaoka/nuxt-twitter-widgets-module/-/nuxt-twitter-widgets-module-0.0.1.tgz#fdca759252e7496c783e69b926623551bf8a4a01"
+  integrity sha512-vYJkz9EemNS4Ur4uXI8R/tKFyXWrGypQwpFF/PSA/JZaGx19gpAfzTxHg0e7EQ1VIS+GTN2U6AUXz9MD05P+Nw==
+
 "@nuxt/babel-preset-app@2.11.0":
   version "2.11.0"
   resolved "https://registry.yarnpkg.com/@nuxt/babel-preset-app/-/babel-preset-app-2.11.0.tgz#e89fdb7ef5c08dce13532ccf63a7064399f67ab0"


### PR DESCRIPTION
# Description

The purpose of this PR is to address the following:
- Fix issue with homepage Twitter feed
- Account for `summary` or `award` model for NIH Award on a dataset page
- Allow breadcrumb to support multiple items 

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)

# How Has This Been Tested?

## Homepage Twitter
- Go to the homepage
- Scroll to the bottom to see the Twitter feed
- Go to any other page
- Go to the homepage
- Scroll to the bottom to see the Twitter feed

## NIH Award
- [Dataset with award model](http://localhost:3000/datasets/58?type=dataset)
- [Dataset with summary model](http://localhost:3000/datasets/26?type=dataset)

## Breadcrumbs

Breadcrumbs should work on every page. 

Pages multiple levels deep like an organ detail page should have multiple breadcrumbs.
- Go to an organ page
- Click on "Find Data" breadcrumb
- You should be taken to the Find Data page showing Organ results

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas