### PR TITLE
QA #4yd5t2

### DIFF
--- a/pages/data/index.vue
+++ b/pages/data/index.vue
@@ -22,12 +22,6 @@
           </nuxt-link>
         </li>
       </ul>
-      <img
-        v-if="heroImage"
-        slot="image"
-        class="page-hero-img"
-        :src="heroImage.fields.file.url"
-      />
     </page-hero>
     <div class="page-wrap container">
       <el-row :gutter="32" type="flex">

--- a/pages/news-and-events/index.vue
+++ b/pages/news-and-events/index.vue
@@ -7,10 +7,10 @@
         {{ heroData.fields.heroCopy }}
       </p>
       <img
-        v-if="heroImage"
+        v-if="heroData.fields.heroImage"
         slot="image"
         class="page-hero-img"
-        :src="heroImage.fields.file.url"
+        :src="heroData.fields.heroImage.fields.file.url"
       />
     </page-hero>
 

--- a/pages/organs/_organId.vue
+++ b/pages/organs/_organId.vue
@@ -60,9 +60,11 @@ export default {
     // Get page content
     const pageData = await client.getEntry(route.params.organId, { include: 3 })
 
-    const projectTableData = pageData.fields.projectSection
-      ? pageData.fields.projectSection.fields.awards
-      : []
+    const projectTableData = pathOr(
+      [],
+      ['fields', 'projectSection', 'fields', 'awards'],
+      pageData
+    )
 
     // Get related datasets
     const organType = pathOr('', ['fields', 'name'], pageData)

--- a/pages/organs/_organId.vue
+++ b/pages/organs/_organId.vue
@@ -27,7 +27,7 @@
 </template>
 
 <script>
-import { clone, pathOr } from 'ramda'
+import { clone, path, pathOr, propOr } from 'ramda'
 
 import DetailsHeader from '@/components/DetailsHeader/DetailsHeader.vue'
 import DetailTabs from '@/components/DetailTabs/DetailTabs.vue'
@@ -58,13 +58,25 @@ export default {
 
   async asyncData({ route, $axios }) {
     // Get page content
-    const pageData = await client.getEntry(route.params.organId, { include: 3 })
+    const pageData = await client.getEntry(route.params.organId)
 
-    const projectTableData = pathOr(
-      [],
-      ['fields', 'projectSection', 'fields', 'awards'],
+    const projectSectionId = path(
+      ['fields', 'projectSection', 'sys', 'id'],
       pageData
     )
+
+    // Get related projects
+    let projects = []
+    if (projectSectionId) {
+      projects = await client
+        .getEntries({
+          content_type: process.env.ctf_project_id,
+          links_to_entry: projectSectionId
+        })
+        .catch(() => {
+          return []
+        })
+    }
 
     // Get related datasets
     const organType = pathOr('', ['fields', 'name'], pageData)
@@ -76,12 +88,14 @@ export default {
 
     const tabsData = clone(tabs)
 
-    if (projectTableData.length) {
+    if (projects.total > 0) {
       tabsData.push({
         label: 'Projects',
         type: 'projects'
       })
     }
+
+    const projectTableData = propOr([], 'items', projects)
 
     return {
       pageData,


### PR DESCRIPTION
# Description

The purpose of this PR is to address the following QA issues:
- Fix issue with projects being empty
  - Contentful doesn't return a field if it has no value, and the app logic wasn't accounting for this properly
- Remove hero image on Find Data
- Fix issue with missing hero image on news and events 
  - This was using the incorrect field. There is currently no data in Contentful for this, but we are no longer seeing the error.
- Fix issue on organ page where projects aren't being displayed
  - This was an issue with pulling the contentful data in a different way than it ultimately ended up being stored.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
# How Has This Been Tested?

## Fix issue with projects being empty
- Go to Find Data
- Go to Organ
- Go to Heart
- Projects tab should be visible, if that organ has projects
- Go to Find Data/Organ
- Projects tab should be visible, if that organ has projects
## Remove hero image on Find Data
- Go to Find Data
- You should not see a console error about a missing field
## Fix issue with missing hero image on news and events 
- Go to News and Events
- You should not see a console error about a missing field

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas