### PR TITLE
feat(clear search results): add "Clear Search" link

### DIFF
--- a/components/DatasetDetails/DatasetAboutInfo.vue
+++ b/components/DatasetDetails/DatasetAboutInfo.vue
@@ -15,6 +15,7 @@
               v-for="(record, index) in datasetRecords"
               :key="`${record}-${index}`"
               :href="record.properties.url"
+              target="_blank"
               class="dataset-about-info__container--protocol-text"
             >
               {{ record.properties.url }}

--- a/components/DetailsHeader/DetailsHeader.vue
+++ b/components/DetailsHeader/DetailsHeader.vue
@@ -17,7 +17,7 @@
             {{ formatMobileTitle(title) }}
           </h2>
           <p class="details-header__container--content-description-default">
-            {{ formatDescription(description) }}
+            {{ fullDescription ? description : formatDescription(description) }}
           </p>
           <p class="details-header__container--content-description-mobile">
             {{ formatMobileDescription(description) }}
@@ -54,6 +54,10 @@ export default {
     description: {
       type: String,
       default: ''
+    },
+    fullDescription: {
+      type: Boolean,
+      default: false
     }
   },
 

--- a/components/SearchForm/SearchForm.vue
+++ b/components/SearchForm/SearchForm.vue
@@ -1,11 +1,11 @@
 <template>
   <div class="search-form" @keyup.enter="$emit('search')">
     <input :value="value" @input="$emit('input', $event.target.value)" />
-    <button class="mr-16" title="Search" @click="$emit('search')">
+    <button class="mr-8" title="Search" @click="$emit('search')">
       <span class="visuallyhidden">Search</span>
       <svg-icon name="icon-magnifying-glass" height="20" width="20" />
     </button>
-    <a v-if="q" class="clear-link" @click="$emit('clear')">Clear Search</a>
+    <button v-if="q" class="clear-search" @click="$emit('clear')">Clear Search</button>
   </div>
 </template>
 
@@ -31,7 +31,6 @@ export default {
 
 .search-form {
   display: flex;
-  align-items: center;
   margin: 0 0 1rem;
 }
 input {
@@ -43,9 +42,11 @@ input {
   margin-right: 0.5rem;
   outline: none;
   padding: 0.5rem 0.8125rem;
-  width: 28.0625rem;
   &:focus {
     border-color: $median;
+  }
+  @media (min-width: 768px) {
+    width: 28.0625rem;
   }
 }
 button {
@@ -57,7 +58,11 @@ button {
   width: 2.5rem;
 }
 
-.clear-link {
+.clear-search {
+  background-color: transparent;
+  display: inline-block;
+  border: none;
+  width: fit-content;
   color: $cochlear;
   font-size: 1rem
 }

--- a/components/SearchForm/SearchForm.vue
+++ b/components/SearchForm/SearchForm.vue
@@ -1,10 +1,11 @@
 <template>
   <div class="search-form" @keyup.enter="$emit('search')">
     <input :value="value" @input="$emit('input', $event.target.value)" />
-    <button title="Search" @click="$emit('search')">
+    <button class="mr-16" title="Search" @click="$emit('search')">
       <span class="visuallyhidden">Search</span>
       <svg-icon name="icon-magnifying-glass" height="20" width="20" />
     </button>
+    <a v-if="q" class="clear-link" @click="$emit('clear')">Clear Search</a>
   </div>
 </template>
 
@@ -14,6 +15,10 @@ export default {
 
   props: {
     value: {
+      type: String,
+      default: ''
+    },
+    q: {
       type: String,
       default: ''
     }
@@ -26,6 +31,7 @@ export default {
 
 .search-form {
   display: flex;
+  align-items: center;
   margin: 0 0 1rem;
 }
 input {
@@ -49,5 +55,10 @@ button {
   cursor: pointer;
   height: 2.5rem;
   width: 2.5rem;
+}
+
+.clear-link {
+  color: $cochlear;
+  font-size: 1rem
 }
 </style>

--- a/pages/data/index.vue
+++ b/pages/data/index.vue
@@ -3,7 +3,7 @@
     <breadcrumb :breadcrumb="breadcrumb" title="Find Data" />
 
     <page-hero>
-      <search-form v-model="searchQuery" @search="submitSearch" />
+      <search-form v-model="searchQuery" @search="submitSearch" @clear="clearSearch" :q="q" />
 
       <ul class="search-tabs">
         <li v-for="type in searchTypes" :key="type.label">
@@ -332,6 +332,10 @@ export default {
     activeFiltersLabel: function() {
       const activeFilterLength = this.activeFilters.length
       return activeFilterLength ? `Filters (${activeFilterLength})` : `Filters`
+    },
+
+    q: function() {
+      return this.$route.query.q || ''
     }
   },
 
@@ -495,6 +499,18 @@ export default {
       this.searchData.skip = 0
 
       const query = mergeLeft({ q: this.searchQuery }, this.$route.query)
+      this.$router.replace({ query }).then(() => {
+        this.fetchResults()
+      })
+    },
+
+    /**
+     * Submit search
+     */
+    clearSearch: function() {
+      this.searchData.skip = 0
+
+      const query = { ...this.$route.query, q: '' }
       this.$router.replace({ query }).then(() => {
         this.fetchResults()
       })

--- a/pages/organs/_organId.vue
+++ b/pages/organs/_organId.vue
@@ -5,6 +5,7 @@
       :title="pageData.fields.name"
       :description="pageData.fields.description"
       :breadcrumb="breadcrumb"
+      :full-description="true"
     >
       <img slot="banner image" :src="bannerImage" :alt="bannerImageAlt" />
     </details-header>


### PR DESCRIPTION
# Description

Add clickable element that clears a search and re-fetches the results.

Open Protocol Links in new tab.

Allow full Organ description.

Clickup: #5jbe0p, #5jbejq, #5jbe0p


## Type of change

- [x] New feature (non-breaking change which adds functionality)

# How Has This Been Tested?

- Organ details should not have their descriptions truncated, others should.

  - Should NOT be truncated: http://localhost:3000/organs/2cp3rRmSexg0aOOF4LtXy2
  - SHOULD be truncated: http://localhost:3000/projects/64KypKtpWOdxEqy9ZrTZ2W


- Protocol links should open in new tab.

- Go to the home page and execute a search in the top right corner.

- In the resulting search page, a "Clear Results" link should appear.

- Clicking the link should clear the search and re-execute

- After clearing search, the back button should go back to the home page (where you were prior to starting the first search)

- From the search page, the "Clear Search" button should only appear _after_ typing a search term _and_ executing the search.

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
