### PR TITLE
feat(sort tables): support sorting of various lists throughout the app

### DIFF
--- a/components/SearchForm/SearchForm.vue
+++ b/components/SearchForm/SearchForm.vue
@@ -64,6 +64,7 @@ button {
   border: none;
   width: fit-content;
   color: $cochlear;
-  font-size: 1rem
+  font-size: 1rem;
+  font-family: $font-family;
 }
 </style>

--- a/components/SearchResults/DatasetSearchResults.vue
+++ b/components/SearchResults/DatasetSearchResults.vue
@@ -42,7 +42,7 @@
       </template>
     </el-table-column>
     <el-table-column prop="description" label="Description" width="400" />
-    <el-table-column prop="updatedAt" label="Last Updated" width="200" sortable="custom">
+    <el-table-column prop="createdAt" label="Last Published" width="200" sortable="custom">
       <template slot-scope="scope">
         {{ formatDate(scope.row.updatedAt) }}
       </template>

--- a/components/SearchResults/DatasetSearchResults.vue
+++ b/components/SearchResults/DatasetSearchResults.vue
@@ -1,8 +1,9 @@
 <template>
-  <el-table :data="tableData" empty-text="No Results">
+  <el-table :data="tableData" empty-text="No Results" @sort-change="onSortChange">
     <el-table-column
       :fixed="true"
-      prop="fields.title"
+      sortable="custom"
+      prop="name"
       label="Title"
       width="300"
     >
@@ -41,12 +42,12 @@
       </template>
     </el-table-column>
     <el-table-column prop="description" label="Description" width="400" />
-    <el-table-column prop="updatedAt" label="Last Updated" width="200">
+    <el-table-column prop="updatedAt" label="Last Updated" width="200" sortable="custom">
       <template slot-scope="scope">
         {{ formatDate(scope.row.updatedAt) }}
       </template>
     </el-table-column>
-    <el-table-column prop="size" label="Size" width="150">
+    <el-table-column prop="size" label="Size" width="150" sortable="custom">
       <template slot-scope="scope">
         {{ formatMetric(scope.row.size) }}
       </template>
@@ -57,6 +58,7 @@
 <script>
 import FormatDate from '@/mixins/format-date'
 import StorageMetrics from '@/mixins/bf-storage-metrics'
+import { onSortChange } from '@/pages/data/utils'
 
 export default {
   name: 'DatasetSearchResults',
@@ -67,6 +69,12 @@ export default {
     tableData: {
       type: Array,
       default: () => []
+    }
+  },
+
+  methods: {
+    onSortChange: function(payload) {
+      onSortChange(this, payload)
     }
   }
 }

--- a/components/SearchResults/OrganSearchResults.vue
+++ b/components/SearchResults/OrganSearchResults.vue
@@ -1,8 +1,9 @@
 <template>
-  <el-table :data="tableData" empty-text="No Results">
+  <el-table :data="tableData" empty-text="No Results" @sort-change="onSortChange">
     <el-table-column
       :fixed="true"
-      prop="fields.title"
+      sortable="custom"
+      prop="fields.name"
       label="Title"
       width="300"
     >
@@ -39,6 +40,7 @@
 
 <script>
 import { pathOr } from 'ramda'
+import { onSortChange } from '../../pages/data/utils'
 
 export default {
   name: 'OrganSearchResults',
@@ -74,6 +76,10 @@ export default {
         ['row', 'fields', 'bannerImage', 'fields', 'file', 'description'],
         scope
       )
+    },
+
+    onSortChange: function(payload) {
+      onSortChange(this, payload)
     }
   }
 }

--- a/components/SearchResults/ProjectSearchResults.vue
+++ b/components/SearchResults/ProjectSearchResults.vue
@@ -1,7 +1,8 @@
 <template>
-  <el-table :data="tableData" empty-text="No Results">
+  <el-table :data="tableData" empty-text="No Results" @sort-change="onSortChange">
     <el-table-column
       :fixed="true"
+      sortable="custom"
       prop="fields.title"
       label="Title"
       width="300"
@@ -46,9 +47,10 @@
       label="Institution"
       width="200"
     />
-    <el-table-column prop="fields.awardId" label="NIH Award" width="150" />
+    <el-table-column sortable="custom" prop="fields.awardId" label="NIH Award" width="150" />
 
     <el-table-column
+      sortable="custom"
       prop="fields.principleInvestigator"
       label="Principal Investigator"
       width="250"
@@ -58,6 +60,7 @@
 
 <script>
 import Truncate from '@/mixins/truncate'
+import { onSortChange } from '../../pages/data/utils'
 
 export default {
   name: 'ProjectSearchResults',
@@ -91,6 +94,10 @@ export default {
       return scope.row.fields.institution.fields.logo
         ? scope.row.fields.institution.fields.logo.fields.file.description
         : ''
+    },
+
+    onSortChange: function(payload) {
+      onSortChange(this, payload)
     }
   }
 }

--- a/pages/data/utils.ts
+++ b/pages/data/utils.ts
@@ -123,7 +123,9 @@ export const handleSortChange = (
 ): void => {
   searchData.skip = 0
   if (dataSource === 'blackfynn') {
-    searchData.order = payload.order === null ? 'date' : payload.prop
+    searchData.order = payload.order === null || payload.prop === 'createdAt'
+      ? 'date'
+      : payload.prop
     searchData.ascending = payload.order === 'ascending'
   } else {
     searchData.order = payload.order === null

--- a/pages/resources/index.vue
+++ b/pages/resources/index.vue
@@ -196,6 +196,7 @@ export default {
         content_type: this.$route.query.type,
         limit: this.resourceData.limit,
         skip: this.resourceData.skip,
+        order: 'fields.name',
         include: 2
       }
 


### PR DESCRIPTION
# Description

Support sorting for all of the Find Data pages as well as the Resources listings.

Clickup: #5jbe4g,#5jbe6k

## Type of change

- [x] New feature (non-breaking change which adds functionality)

# How Has This Been Tested?

You should be able to sort all pages of Find Data by various columns.  Test sorting ascending, descending, as well as that the page number resets to 1 if you change a sort order.  NOTE: sorting by size will not work until changes to `discover-service` are merged to prod.

The Resources page should now list resources in ascending alphabetical order.

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
