### PR TITLE
fix(homepage): fix news & events link

### DIFF
--- a/components/HomepageNews/HomepageNews.vue
+++ b/components/HomepageNews/HomepageNews.vue
@@ -1,7 +1,7 @@
 <template>
   <div class="featured-datasets container">
     <div class="home-container">
-      <h2><a href="#">News &amp; Upcoming Events</a></h2>
+      <h2><nuxt-link to="/news-and-events">News &amp; Upcoming Events</nuxt-link></h2>
       <sparc-card
         v-for="(item, idx) in news"
         :key="item.sys.id"


### PR DESCRIPTION
## Type of change

Delete those that don't apply.

- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

The 'News & Events' link in the middle of the homepage should now link to news-and-events appropriately.

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
