### PR TITLE
fix(about): Change the button to NIH Website to a hyperlinked sentence

### DIFF
--- a/pages/about/index.vue
+++ b/pages/about/index.vue
@@ -6,11 +6,13 @@
       <p>
         {{ heroCopy }}
       </p>
-      <button class="about-page-button">
+      <p>
+        Visit the
         <a href="https://commonfund.nih.gov/sparc/" target="_blank">
-          More Info NIH Website
+          NIH SPARC program website
         </a>
-      </button>
+        to learn more.
+      </p>
       <img
         v-if="heroImage"
         slot="image"


### PR DESCRIPTION
# Description

Replaced the button with a sentence that says the following: 
"Visit the [NIH SPARC program website](https://commonfund.nih.gov/sparc/) to learn more."

Hyperlink: https://commonfund.nih.gov/sparc/

## Ticket

[Wrike](https://www.wrike.com/open.htm?id=473576238)
[Clickup](https://app.clickup.com/t/6af0b8)

## Type of change

Delete those that don't apply.

- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

1. Navigate to [About](https://sparc.science/about) page.
2. Under the `About SPARC`, the edited sentence will be displayed.
3. Click the hyperlink.
4. Redirected to https://commonfund.nih.gov/sparc/ on new tab.


# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
