### PR TITLE
Details Page Fixes #6af1mu

### DIFF
--- a/pages/datasets/_datasetId.vue
+++ b/pages/datasets/_datasetId.vue
@@ -201,12 +201,12 @@ marked.setOptions({
 
 const tabs = [
   {
-    label: 'Description',
-    type: 'description'
-  },
-  {
     label: 'About',
     type: 'about'
+  },
+  {
+    label: 'Description',
+    type: 'description'
   },
   {
     label: 'Files',
@@ -314,7 +314,6 @@ export default {
   },
 
   computed: {
-
     /**
      * Returns active tab based on details page displayed
      * @returns {String}
@@ -653,7 +652,7 @@ export default {
         name: this.organizationName
       }
     ]
-    const contributors = this.datasetContributors.map((contributor) => {
+    const contributors = this.datasetContributors.map(contributor => {
       const sameAs = contributor.orcid
         ? `http://orcid.org/${contributor.orcid}`
         : null
@@ -787,7 +786,7 @@ export default {
           },
           type: 'application/ld+json'
         }
-      ],
+      ]
     }
   }
 }

--- a/pages/datasets/_datasetId.vue
+++ b/pages/datasets/_datasetId.vue
@@ -201,12 +201,12 @@ marked.setOptions({
 
 const tabs = [
   {
-    label: 'About',
-    type: 'about'
-  },
-  {
     label: 'Description',
     type: 'description'
+  },
+  {
+    label: 'About',
+    type: 'about'
   },
   {
     label: 'Files',
@@ -291,7 +291,6 @@ export default {
       isContributorListVisible: true,
       isDownloadModalVisible: false,
       tabs: [],
-      activeTab: 'about',
       breadcrumb: [
         {
           to: {
@@ -315,6 +314,15 @@ export default {
   },
 
   computed: {
+
+    /**
+     * Returns active tab based on details page displayed
+     * @returns {String}
+     */
+    activeTab: function() {
+      return this.datasetType === 'simulation' ? 'about' : 'description'
+    },
+
     /**
      * Returns simulation id for run simulation button
      * @returns {String}

--- a/pages/datasets/_datasetId.vue
+++ b/pages/datasets/_datasetId.vue
@@ -54,7 +54,7 @@
               </template>
             </div>
           </div>
-          <div class="header-stats-block">
+          <div v-if="datasetType !== 'simulation'" class="header-stats-block">
             <svg-icon class="mr-8" name="icon-storage" height="20" width="20" />
             <div>
               <strong>{{ datasetStorage.number }}</strong>

--- a/pages/datasets/_datasetId.vue
+++ b/pages/datasets/_datasetId.vue
@@ -286,6 +286,7 @@ export default {
       errorLoading: false,
       loadingMarkdown: false,
       markdown: '',
+      activeTab: 'about',
       datasetRecords: [],
       discover_host: process.env.discover_api_host,
       isContributorListVisible: true,
@@ -314,14 +315,6 @@ export default {
   },
 
   computed: {
-    /**
-     * Returns active tab based on details page displayed
-     * @returns {String}
-     */
-    activeTab: function() {
-      return this.datasetType === 'simulation' ? 'about' : 'description'
-    },
-
     /**
      * Returns simulation id for run simulation button
      * @returns {String}
@@ -586,6 +579,12 @@ export default {
         }
       },
       immediate: true
+    }
+  },
+
+  mounted() {
+    if (this.datasetType !== 'simulation') {
+      this.activeTab = 'description'
     }
   },
 

--- a/static/images/sparc-logo.svg
+++ b/static/images/sparc-logo.svg
@@ -1,4 +1,4 @@
-<svg viewBox="0 0 652 164" version="1.1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+ <svg viewBox="0 0 652 164" version="1.1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
     <defs>
         <linearGradient x1="-0.0269541779%" y1="50.0191536%" x2="99.9730458%" y2="50.0191536%" id="linearGradient-1">
             <stop stop-color="#C600FF" offset="0%"></stop>


### PR DESCRIPTION
# Description

The purpose of this PR is to add fixes to the following details pages:
- Remove size from Simulations Detail Page
- Have the `Description` tab be the default active tab on the Dataset Details Page

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

## Remove Size from Simulations Details Page
1. Navigate to a Simulations Detail Page
2. The size attribute should no longer be displayed in the header

## Set Description as Active Tab for Dataset Details Page
1. Navigate to a Dataset Detail Page
2. The `Description` tab should be the active tab displayed on the page.

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
