### PR TITLE
fix(footer): Changed 'NIH SPARC' to 'NIH SPARC Program' in footer

### DIFF
--- a/components/footer/Footer.vue
+++ b/components/footer/Footer.vue
@@ -45,7 +45,9 @@
             </a>
           </li>
           <li>
-            <a href="https://commonfund.nih.gov/Sparc/" target="_blank">NIH SPARC</a>
+            <a href="https://commonfund.nih.gov/Sparc/" target="_blank">
+              NIH SPARC Program
+            </a>
           </li>
         </ul>
         <h3>Help us Improve</h3>


### PR DESCRIPTION
# Description

Changed "NIH SPARC" to "NIH SPARC Program" in footer.


## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

1. Navigate to any page across the SPARC Portal.
2. Scroll down to the footer.
3. On the right column under `Learn More`, clickable link is displayed as "NIH SPARC Program".
4. Click on it.
5. New tab will open at https://commonfund.nih.gov/Sparc/.


# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
