### PR TITLE
Add Site Status Link to Footer #6af2ed 

### DIFF
--- a/components/footer/Footer.vue
+++ b/components/footer/Footer.vue
@@ -48,7 +48,7 @@
             <a href="https://commonfund.nih.gov/Sparc/" target="_blank">NIH SPARC</a>
           </li>
           <li>
-            <a href="http://status.sparc.science/" target="_blank">Site Status</a>
+            <a href="http://status.sparc.science/" target="_blank">SPARC.science Site Status</a>
           </li>
         </ul>
         <h3>Help us Improve</h3>


### PR DESCRIPTION
# Description

The purpose of this PR is to add the SPARC Portal Status page link to the footer. 

## Type of change

- [x] New feature (non-breaking change which adds functionality)

# How Has This Been Tested?

Navigate to the SPARC Portal and scroll down to the footer. You should see a `SPARC.science Site Status` link under the `Learn More` section in the footer. That link should take you to the status page.

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
