### PR TITLE
Dataset details label #6af240

### DIFF
--- a/pages/datasets/_datasetId.vue
+++ b/pages/datasets/_datasetId.vue
@@ -116,7 +116,7 @@
             }"
             class="dataset-link"
           >
-            Learn about the SPARC data structure
+            SPARC data structure
           </nuxt-link>
         </div>
       </div>

--- a/pages/datasets/_datasetId.vue
+++ b/pages/datasets/_datasetId.vue
@@ -116,7 +116,7 @@
             }"
             class="dataset-link"
           >
-            Dataset Format Information
+            Learn about the SPARC data structure
           </nuxt-link>
         </div>
       </div>

--- a/pages/datasets/_datasetId.vue
+++ b/pages/datasets/_datasetId.vue
@@ -116,7 +116,7 @@
             }"
             class="dataset-link"
           >
-            SPARC data structure
+            SPARC Data Structure
           </nuxt-link>
         </div>
       </div>


### PR DESCRIPTION
# Description

Changed label on dataset details page to access the SPARC data structure documentation from "Dataset Format Information" to "SPARC Data Structure".

**NOTE**: The clickup ticket originally states to change it to "Learn about the SPARC data structure", but the more recent comments on the wrike ticket updated the criteria to "SPARC Data Structure". 


## Type of change

Delete those that don't apply.

- [x] Bug fix (non-breaking change which fixes an issue)

# Tickets

[Wrike](https://www.wrike.com/open.htm?id=472557178)
[Clickup](https://app.clickup.com/t/6af240)

# How Has This Been Tested?

1. Navigate to Find Data page.
2. Click on any dataset.
3. In the header of the dataset's detail page, next to the `GET DATASET` button, there will be a link labeled "SPARC Data Structure" that takes you to the SPARC data structure documentation page.


# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
