### PR TITLE
Dataset doi clickable #6af1vk

### DIFF
--- a/components/DatasetDetails/DatasetAboutInfo.vue
+++ b/components/DatasetDetails/DatasetAboutInfo.vue
@@ -4,9 +4,15 @@
       <h3>Last Updated</h3>
       <p>{{ updatedDate }}</p>
       <h3>Dataset DOI</h3>
-      <div class="dataset-about-info__container--doi-link mb-16">
-        <a :href="DOIlink" target="_blank">{{ doi }}</a>
-      </div>
+      <p>
+        <a
+          class="dataset-about-info__container--doi-link mb-16"
+          :href="DOIlink"
+          target="_blank"
+        >
+          {{ doi }}
+        </a>
+      </p>
       <el-row type="flex" justify="center" class="protocol-block">
         <el-col :span="24">
           <h3>
@@ -320,11 +326,8 @@ export default {
     }
 
     &--doi-link {
-      @extend p;
-      a {
-        color: black;
-        text-decoration: none;
-      }
+      color: black;
+      text-decoration: none;
     }
   }
 }

--- a/components/DatasetDetails/DatasetAboutInfo.vue
+++ b/components/DatasetDetails/DatasetAboutInfo.vue
@@ -4,11 +4,9 @@
       <h3>Last Updated</h3>
       <p>{{ updatedDate }}</p>
       <h3>Dataset DOI</h3>
-      <!-- <p> -->
       <div class="dataset-about-info__container--doi-link mb-16">
         <a :href="DOIlink" target="_blank">{{ doi }}</a>
       </div>
-      <!-- </p> -->
       <el-row type="flex" justify="center" class="protocol-block">
         <el-col :span="24">
           <h3>

--- a/components/DatasetDetails/DatasetAboutInfo.vue
+++ b/components/DatasetDetails/DatasetAboutInfo.vue
@@ -4,7 +4,11 @@
       <h3>Last Updated</h3>
       <p>{{ updatedDate }}</p>
       <h3>Dataset DOI</h3>
-      <p>{{ doi }}</p>
+      <!-- <p> -->
+      <div class="dataset-about-info__container--doi-link mb-16">
+        <a :href="DOIlink" target="_blank">{{ doi }}</a>
+      </div>
+      <!-- </p> -->
       <el-row type="flex" justify="center" class="protocol-block">
         <el-col :span="24">
           <h3>
@@ -315,6 +319,14 @@ export default {
 
     .protocol-block {
       margin-bottom: 1rem;
+    }
+
+    &--doi-link {
+      @extend p;
+      a {
+        color: black;
+        text-decoration: none;
+      }
     }
   }
 }


### PR DESCRIPTION
# Description

Made dataset DOI clickable.

Maintained same style as the links in the `Protocol Links` section.

**NOTE:** Originally, the ticket said to include a modal to alert the user that they are being brought to an external link. After further discussion on wrike, this was decided against.

## Tickets
[Wrike](https://www.wrike.com/workspace.htm?acc=3203588#path=folder&t=467396309&a=3203588&id=473707106&st=space-441356195)
[Clickup](https://app.clickup.com/t/6af1vk)


## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)


# How Has This Been Tested?

1. Navigate to the Find Data page.
2. Click on any dataset.
3. In the About section, the DOI link should be clickable and will open a new tab to the dataset's discover page.

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
