### PR TITLE
Past event cards restructure #6af2w2

### DIFF
--- a/components/HomepageNews/HomepageNews.vue
+++ b/components/HomepageNews/HomepageNews.vue
@@ -15,6 +15,17 @@
               {{ item.fields.title }}
             </a>
           </h3>
+          <div class="sparc-card__detail">
+            <svg-icon name="icon-calendar" height="16" width="16" />
+            <p>{{ eventDate(item) }}</p>
+            <svg-icon
+              class="sparc-card__detail--location"
+              name="icon-map"
+              height="16"
+              width="16"
+            />
+            <p>{{ item.fields.location }}</p>
+          </div>
           <!-- eslint-disable vue/no-v-html -->
           <!-- marked will sanitize the HTML injected -->
           <div v-html="parseMarkdown(item.fields.summary)" />
@@ -36,6 +47,8 @@ import SparcCard from '@/components/SparcCard/SparcCard.vue'
 
 import MarkedMixin from '@/mixins/marked'
 
+import FormatDate from '@/mixins/format-date'
+
 export default {
   name: 'HomepageNews',
 
@@ -43,7 +56,7 @@ export default {
     SparcCard
   },
 
-  mixins: [MarkedMixin],
+  mixins: [MarkedMixin, FormatDate],
 
   props: {
     news: {
@@ -72,6 +85,15 @@ export default {
         ['fields', 'image', 'fields', 'file', 'description'],
         item
       )
+    },
+    /**
+     * Get event date range
+     * @returns {String}
+     */
+    eventDate: function(event) {
+      const startDate = this.formatDate(event.fields.startDate)
+      const endDate = this.formatDate(event.fields.endDate)
+      return `${startDate} - ${endDate}`
     }
   }
 }
@@ -98,6 +120,21 @@ h2 a:not(:hover) {
   }
   h3 {
     font-size: 1.333333333em;
+  }
+  &__detail {
+    align-items: baseline;
+    display: flex;
+    margin-bottom: 0.625rem;
+    .svg-icon {
+      flex-shrink: 0;
+      margin-right: 0.5rem;
+    }
+    p {
+      margin-bottom: 0rem;
+    }
+    &--location {
+      margin-left: 1.25rem;
+    }
   }
 }
 </style>

--- a/pages/news-and-events/index.vue
+++ b/pages/news-and-events/index.vue
@@ -154,16 +154,9 @@ export default Vue.extend<Data, never, Computed, never>({
         : this.upcomingEvents.slice(0, 4)
     },
 
-    // /**
-    //  * Reverse past events array
-    //  * @returns {Array}
-    //  */
-    // pastEventsReversed: function(this: Data) {
-    //   return this.pastEvents.slice().reverse()
-    // },
-
     /**
      * Compute chunk size for "View More" button
+     * to display up to 8 more events on click
      * @returns {Number}
      */
     pastEventsChunkSize: function(this: Data) {
@@ -172,7 +165,7 @@ export default Vue.extend<Data, never, Computed, never>({
 
     /**
      * Compute past events to display based on
-     * current chunk amount
+     * current chunk value
      * @returns {Array}
      */
     displayedPastEvents: function (this: Data & Computed) {

--- a/pages/news-and-events/index.vue
+++ b/pages/news-and-events/index.vue
@@ -56,7 +56,7 @@
 
             <div class="show-more-past-events">
               <a
-                v-if="!isShowingAllPastEvents && pastEventsChunkSize > 1"
+                v-if="!isShowingAllPastEvents && pastEventsChunkMax > 1"
                 class="show-more-past-events__btn"
                 href="#"
                 @click.prevent="pastEventChunk += 1"
@@ -155,11 +155,10 @@ export default Vue.extend<Data, never, Computed, never>({
     },
 
     /**
-     * Compute chunk size for "View More" button
-     * to display up to 8 more events on click
+     * Compute maximum chunk value
      * @returns {Number}
      */
-    pastEventsChunkSize: function(this: Data) {
+    pastEventsChunkMax: function(this: Data) {
       return Math.ceil(this.pastEvents.length / MAX_PAST_EVENTS)
     },
 
@@ -169,7 +168,7 @@ export default Vue.extend<Data, never, Computed, never>({
      * @returns {Array}
      */
     displayedPastEvents: function (this: Data & Computed) {
-      if (this.pastEventChunk === this.pastEventsChunkSize) this.isShowingAllPastEvents = true;
+      if (this.pastEventChunk === this.pastEventsChunkMax) this.isShowingAllPastEvents = true;
       const endChunk = this.pastEventChunk * MAX_PAST_EVENTS
       return this.pastEvents.slice().reverse().slice(0, endChunk)
     }

--- a/pages/news-and-events/index.vue
+++ b/pages/news-and-events/index.vue
@@ -154,13 +154,13 @@ export default Vue.extend<Data, never, Computed, never>({
         : this.upcomingEvents.slice(0, 4)
     },
 
-    /**
-     * Reverse past events array
-     * @returns {Array}
-     */
-    pastEventsReversed: function(this: Data) {
-      return this.pastEvents.slice().reverse()
-    },
+    // /**
+    //  * Reverse past events array
+    //  * @returns {Array}
+    //  */
+    // pastEventsReversed: function(this: Data) {
+    //   return this.pastEvents.slice().reverse()
+    // },
 
     /**
      * Compute chunk size for "View More" button
@@ -178,7 +178,7 @@ export default Vue.extend<Data, never, Computed, never>({
     displayedPastEvents: function (this: Data & Computed) {
       if (this.pastEventChunk === this.pastEventsChunkSize) this.isShowingAllPastEvents = true;
       const endChunk = this.pastEventChunk * MAX_PAST_EVENTS
-      return this.pastEventsReversed.slice(0, endChunk)
+      return this.pastEvents.slice().reverse().slice(0, endChunk)
     }
   }
 })

--- a/pages/news-and-events/index.vue
+++ b/pages/news-and-events/index.vue
@@ -45,13 +45,26 @@
             </div>
           </template>
 
-          <div v-if="activeTab === 'past'" class="subpage">
-            <event-list-item
-              v-for="(event, index) in pastEvents"
-              :key="`${event}-${index}`"
-              :event="event"
-            />
-          </div>
+          <template v-if="activeTab === 'past'">
+            <div class="past-events">
+              <event-card
+                v-for="event in displayedPastEvents"
+                :key="event.sys.id"
+                :event="event"
+              />
+            </div>
+
+            <div class="show-more-past-events">
+              <a
+                v-if="!isShowingAllPastEvents && pastEventsChunkSize > 1"
+                class="show-more-past-events__btn"
+                href="#"
+                @click.prevent="pastEventChunk += 1"
+              >
+                View More
+              </a>
+            </div>
+          </template>
         </div>
 
         <h2>Latest News</h2>
@@ -79,6 +92,7 @@ import createClient from '@/plugins/contentful.js'
 import { EventsEntry, HeroDataEntry, NewsEntry, Data, Computed, fetchData } from './model'
 
 const client = createClient()
+const MAX_PAST_EVENTS = 8
 
 export default Vue.extend<Data, never, Computed, never>({
   name: 'EventPage',
@@ -121,8 +135,10 @@ export default Vue.extend<Data, never, Computed, never>({
       upcomingEvents: [],
       pastEvents: [],
       isShowingAllUpcomingEvents: false,
+      isShowingAllPastEvents: false,
       news: [],
-      heroData: {} as HeroDataEntry
+      heroData: {} as HeroDataEntry,
+      pastEventChunk: 1
     }
   },
 
@@ -136,6 +152,33 @@ export default Vue.extend<Data, never, Computed, never>({
       return this.isShowingAllUpcomingEvents
         ? this.upcomingEvents
         : this.upcomingEvents.slice(0, 4)
+    },
+
+    /**
+     * Reverse past events array
+     * @returns {Array}
+     */
+    pastEventsReversed: function(this: Data) {
+      return this.pastEvents.slice().reverse()
+    },
+
+    /**
+     * Compute chunk size for "View More" button
+     * @returns {Number}
+     */
+    pastEventsChunkSize: function(this: Data) {
+      return Math.ceil(this.pastEvents.length / MAX_PAST_EVENTS)
+    },
+
+    /**
+     * Compute past events to display based on
+     * current chunk amount
+     * @returns {Array}
+     */
+    displayedPastEvents: function (this: Data & Computed) {
+      if (this.pastEventChunk === this.pastEventsChunkSize) this.isShowingAllPastEvents = true;
+      const endChunk = this.pastEventChunk * MAX_PAST_EVENTS
+      return this.pastEventsReversed.slice(0, endChunk)
     }
   }
 })
@@ -152,7 +195,7 @@ export default Vue.extend<Data, never, Computed, never>({
   margin: 1em 0;
   padding: 0;
 }
-.upcoming-events {
+.upcoming-events, .past-events {
   display: flex;
   flex-wrap: wrap;
   margin: 0 -1em;
@@ -181,6 +224,20 @@ export default Vue.extend<Data, never, Computed, never>({
   }
   .svg-icon {
     margin-left: 0.5rem;
+  }
+}
+
+.show-more-past-events {
+  text-align: center;
+  &__btn {
+    display: inline-flex;
+    border: 1px solid $dark-gray;
+    border-radius: 5px;
+    text-decoration: none;
+    padding: 8px 10px;
+    font-size: 11pt;
+    font-weight: bold;
+    color: $dark-gray;
   }
 }
 .events-wrap {

--- a/pages/news-and-events/model.ts
+++ b/pages/news-and-events/model.ts
@@ -94,7 +94,6 @@ export interface Data {
 
 export interface Computed {
   displayedUpcomingEvents: EventsEntry[],
-  // pastEventsReversed: EventsEntry[],
   pastEventsChunkSize: number,
   displayedPastEvents: EventsEntry[]
 }

--- a/pages/news-and-events/model.ts
+++ b/pages/news-and-events/model.ts
@@ -94,6 +94,6 @@ export interface Data {
 
 export interface Computed {
   displayedUpcomingEvents: EventsEntry[],
-  pastEventsChunkSize: number,
+  pastEventsChunkMax: number,
   displayedPastEvents: EventsEntry[]
 }

--- a/pages/news-and-events/model.ts
+++ b/pages/news-and-events/model.ts
@@ -85,11 +85,16 @@ export interface Data {
   upcomingEvents: EventsEntry[],
   pastEvents: EventsEntry[],
   isShowingAllUpcomingEvents: boolean,
+  isShowingAllPastEvents: boolean,
   news: NewsEntry[],
-  heroData: HeroDataEntry
+  heroData: HeroDataEntry,
+  pastEventChunk: number
 }
 
 
 export interface Computed {
-  displayedUpcomingEvents: EventsEntry[]
+  displayedUpcomingEvents: EventsEntry[],
+  pastEventsReversed: EventsEntry[],
+  pastEventsChunkSize: number,
+  displayedPastEvents: EventsEntry[]
 }

--- a/pages/news-and-events/model.ts
+++ b/pages/news-and-events/model.ts
@@ -94,7 +94,7 @@ export interface Data {
 
 export interface Computed {
   displayedUpcomingEvents: EventsEntry[],
-  pastEventsReversed: EventsEntry[],
+  // pastEventsReversed: EventsEntry[],
   pastEventsChunkSize: number,
   displayedPastEvents: EventsEntry[]
 }


### PR DESCRIPTION
# Description

**News & Events Page:**
- Updated Past Events event card structure to reflect that of Upcoming Events.
- Added View More button that displays up to 8 more past events on click.

**Homepage:**
- Added date & location to upcoming events event cards.

**NOTE:**
Wrike ticket says to move certain events to the Past Events tab, but they are already there except for Neurotech Investing and Partnering, which should automatically move to the Past Events tab after the end date (May 6).

[List of events that were asked to be moved](https://docs.google.com/document/d/1wXr8SXKQPlrAIavifpEIqOivCb9g7gSUNbltu-cTzLU/edit)

**Designs:**
[Past Events event cards](https://app.abstract.com/share/88fb27c6-7c6e-454a-bd1e-5ac041bb0ddc?collectionId=b9aec151-2fab-4840-bbad-c938d6291535&sha=b783c948ffd791406d4f4ebcd43865874e2f5088)
[Homepage event cards](https://app.abstract.com/share/1dfcfe4d-03ee-4716-b606-cfbd9f8ad65f?sha=b783c948ffd791406d4f4ebcd43865874e2f5088)

## Tickets
[Wrike](https://www.wrike.com/workspace.htm?acc=3203588#path=folder&t=467368706&a=3203588&id=473707106&st=space-441356195)
[Clickup](https://app.clickup.com/t/6af2w2)

## Type of change

Delete those that don't apply.

- [x] New feature (non-breaking change which adds functionality)

# How Has This Been Tested?

**Past Events:**
- Navigate to the New & Events page.
- Click on the Past Events tab.
- The past event event cards will be the same as the upcoming events.
- Since there are exactly 8 past events at the moment, the View More button will not appear. To test it's functionality, change the value of `MAX_PAST_EVENTS` directly in `pages/news-and-events/index.vue` (line 95) to a number less than 8.
- On reload, the Past Events tab will only display that many past events and the View More button will appear.
- Click the View More button.
- Each time it is clicked, a number of past event cards will be additionally displayed based on the `MAX_PAST_EVENTS` value.

**i.e.** If `MAX_PAST_EVENTS` is set to 2, initially 2 past events will be displayed. Once the View More button is clicked, 2 more past events will be displayed. The button can be continually pressed until the list of past events is exhausted, at which point, the View More button will be hidden.


**Homepage:**
- Navigate to the homepage.
- Scroll down to the News & Upcoming Events section.
- On each event card, the date & location will be displayed.

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
