### PR TITLE
Add Pagination to Top of Result Tables #6af119

### DIFF
--- a/components/Pagination/PaginationMenu.vue
+++ b/components/Pagination/PaginationMenu.vue
@@ -1,0 +1,84 @@
+<template>
+  <el-dropdown
+    trigger="click"
+    placement="bottom-start"
+    @command="$emit('update-page-size', $event)"
+    @visible-change="isMenuOpen = $event"
+  >
+    <button class="dataset-filter-dropdown el-dropdown-link">
+      <span class="el-dropdown-text-link">
+        {{ paginationItemLabel }} per page {{ pageSize }}
+      </span>
+      <svg-icon
+        class="ml-8"
+        name="icon-arrow-up"
+        :dir="menuArrowDir"
+        height="10"
+        width="10"
+      />
+    </button>
+    <el-dropdown-menu
+      slot="dropdown"
+      class="bf-menu"
+    >
+      <el-dropdown-item
+        v-for="option in pageSizeOptions"
+        :key="option"
+        class="icon-item"
+        :command="option"
+      >
+        {{ option }}
+        <svg-icon
+          v-if="pageSize === option"
+          icon="icon-check"
+          class="item-icon-check"
+          width="20"
+          height="20"
+        />
+      </el-dropdown-item>
+    </el-dropdown-menu>
+  </el-dropdown>
+</template>
+
+<script>
+export default {
+  name: 'PaginationMenu',
+
+  props: {
+    paginationItemLabel: {
+      type: String,
+      default: 'Items'
+    },
+    pageSize: {
+      type: Number,
+      default: 25
+    },
+    pageSizeOptions: {
+      type: Array,
+      default: () => {
+        return [
+          25,
+          50,
+          100
+        ]
+      }
+    }
+  },
+
+  data: function() {
+    return {
+      isMenuOpen: false
+    }
+  },
+
+  computed: {
+    /**
+     * Compute dataset filter arrow direction
+     * @returns {String}
+     */
+    menuArrowDir: function() {
+      return this.isMenuOpen ? 'up' : 'down'
+    },
+  }
+}
+</script>

--- a/components/Pagination/PaginationMenu.vue
+++ b/components/Pagination/PaginationMenu.vue
@@ -5,22 +5,19 @@
     @command="$emit('update-page-size', $event)"
     @visible-change="isMenuOpen = $event"
   >
-    <button class="dataset-filter-dropdown el-dropdown-link">
+    <button class="filter-dropdown el-dropdown-link">
       <span class="el-dropdown-text-link">
-        {{ paginationItemLabel }} per page {{ pageSize }}
+        {{ pageSize }}
       </span>
       <svg-icon
-        class="ml-8"
-        name="icon-arrow-up"
+        class="ml-8 icon-arrow"
+        name="icon-arrow"
         :dir="menuArrowDir"
         height="10"
         width="10"
       />
     </button>
-    <el-dropdown-menu
-      slot="dropdown"
-      class="bf-menu"
-    >
+    <el-dropdown-menu slot="dropdown" class="bf-menu">
       <el-dropdown-item
         v-for="option in pageSizeOptions"
         :key="option"
@@ -51,16 +48,12 @@ export default {
     },
     pageSize: {
       type: Number,
-      default: 25
+      default: 10
     },
     pageSizeOptions: {
       type: Array,
       default: () => {
-        return [
-          25,
-          50,
-          100
-        ]
+        return [10, 20, 50, 'View All']
       }
     }
   },
@@ -78,7 +71,40 @@ export default {
      */
     menuArrowDir: function() {
       return this.isMenuOpen ? 'up' : 'down'
-    },
+    }
   }
 }
 </script>
+
+<style lang="scss" scoped>
+@import '../../assets/_variables.scss';
+
+.filter-dropdown {
+  display: flex;
+  align-items: center;
+  border-radius: 4px;
+  border: solid 1px $medium-gray;
+  background-color: transparent;
+  font-size: 14px;
+  font-weight: bold;
+  color: $median;
+  margin-left: 5px;
+}
+
+.icon-arrow {
+  color: $medium-gray;
+  height: 5px;
+  width: 8px;
+}
+
+.el-dropdown-link {
+  cursor: pointer;
+  outline: none;
+}
+
+.el-dropdown-text-link {
+  margin-right: -6px;
+  padding-top: 3px;
+  padding-bottom: 3px;
+}
+</style>

--- a/pages/data/index.vue
+++ b/pages/data/index.vue
@@ -33,7 +33,9 @@
         <el-col :span="24">
           <div class="search-heading">
             <p v-if="!isLoadingSearch && searchData.items.length">
-              {{ searchHeading }}
+              Showing
+              <pagination-menu @update-page-size="updateDataSearchLimit" :page-size="searchData.limit" />
+              of {{ searchHeading }}
             </p>
             <el-pagination
               v-if="searchData.limit < searchData.total"
@@ -43,12 +45,6 @@
               layout="prev, pager, next"
               :total="searchData.total"
               @current-change="onPaginationPageChange"
-            />
-            <pagination-menu
-              class="mr-24"
-              pagination-item-label="Datasets"
-              :page-size="datasetSearchParams.limit"
-              @update-page-size="updateDatasetSearchLimit"
             />
           </div>
           <div class="mb-16">
@@ -80,6 +76,15 @@
           </div>
         </el-col>
       </el-row>
+      <el-pagination
+        v-if="searchData.limit < searchData.total"
+        :page-size="searchData.limit"
+        :pager-count="5"
+        :current-page="curSearchPage"
+        layout="prev, pager, next"
+        :total="searchData.total"
+        @current-change="onPaginationPageChange"
+      />
     </div>
     <search-filters
       v-model="filters"
@@ -317,7 +322,7 @@ export default {
         find(propEq('type', this.$route.query.type))
       )(this.searchTypes)
 
-      let searchHeading = `Showing ${start}-${end} of ${this.searchData.total} ${searchTypeLabel}`
+      let searchHeading = `${this.searchData.total} ${searchTypeLabel}`
 
       return query === '' ? searchHeading : `${searchHeading} for “${query}”`
     },
@@ -391,6 +396,20 @@ export default {
   },
 
   methods: {
+    /**
+     * Update search limit based on pagination number selection
+     * @param {Number} limit
+     */
+    updateDataSearchLimit: function(limit) {
+      this.searchData.skip = 0
+      if (limit === 'View All') {
+        this.searchData.limit = this.searchData.total
+      } else {
+        this.searchData.limit = limit
+      }
+      this.fetchResults()
+    },
+
     /**
      * Set active filters based on the query params
      * @params {Array} filters

--- a/pages/data/index.vue
+++ b/pages/data/index.vue
@@ -33,24 +33,22 @@
         <el-col :span="24">
           <div class="search-heading">
             <p v-if="!isLoadingSearch && searchData.items.length">
-              Showing
+              {{ searchHeading }} | Showing
               <pagination-menu
                 :page-size="searchData.limit"
                 @update-page-size="updateDataSearchLimit"
               />
-              of {{ searchHeading }}
             </p>
+            <el-pagination
+              v-if="searchData.limit < searchData.total"
+              :page-size="searchData.limit"
+              :pager-count="5"
+              :current-page="curSearchPage"
+              layout="prev, pager, next"
+              :total="searchData.total"
+              @current-change="onPaginationPageChange"
+            />
           </div>
-          <el-pagination
-            v-if="searchData.limit < searchData.total"
-            class="test-pagination"
-            :page-size="searchData.limit"
-            :pager-count="5"
-            :current-page="curSearchPage"
-            layout="prev, pager, next"
-            :total="searchData.total"
-            @current-change="onPaginationPageChange"
-          />
           <div class="mb-16">
             <div class="active__filter__wrap">
               <div
@@ -80,23 +78,24 @@
           </div>
         </el-col>
       </el-row>
-      <p v-if="!isLoadingSearch && searchData.items.length">
-        Showing
-        <pagination-menu
+      <div class="search-heading">
+        <p v-if="!isLoadingSearch && searchData.items.length">
+          {{ searchHeading }} | Showing
+          <pagination-menu
+            :page-size="searchData.limit"
+            @update-page-size="updateDataSearchLimit"
+          />
+        </p>
+        <el-pagination
+          v-if="searchData.limit < searchData.total"
           :page-size="searchData.limit"
-          @update-page-size="updateDataSearchLimit"
+          :pager-count="5"
+          :current-page="curSearchPage"
+          layout="prev, pager, next"
+          :total="searchData.total"
+          @current-change="onPaginationPageChange"
         />
-        of {{ searchHeading }}
-      </p>
-      <el-pagination
-        v-if="searchData.limit < searchData.total"
-        :page-size="searchData.limit"
-        :pager-count="5"
-        :current-page="curSearchPage"
-        layout="prev, pager, next"
-        :total="searchData.total"
-        @current-change="onPaginationPageChange"
-      />
+      </div>
     </div>
     <search-filters
       v-model="filters"
@@ -724,26 +723,28 @@ export default {
   border: 1px solid rgb(228, 231, 237);
   padding: 16px;
 }
-.el-pagination {
+::v-deep .el-pagination {
   margin-top: 1.5em;
   text-align: right;
-}
-.test-pagination {
-  background-color: orange;
-  // &.el-pager {
-  //   li {
-  //     background-color: orange;
-  //   }
-  // }
+  background-color: transparent;
+  button {
+    background-color: transparent;
+  }
+  .el-pager {
+    li {
+      background-color: transparent;
+    }
+  }
 }
 .search-heading {
   align-items: center;
   display: flex;
   margin-bottom: 1em;
+  justify-content: space-between;
   p {
     font-size: 0.875em;
     flex-shrink: 0;
-    margin: 0 1em 0 0;
+    margin: 2em 1em 0 0;
   }
 }
 ::v-deep {

--- a/pages/data/index.vue
+++ b/pages/data/index.vue
@@ -3,7 +3,12 @@
     <breadcrumb :breadcrumb="breadcrumb" title="Find Data" />
 
     <page-hero>
-      <search-form v-model="searchQuery" @search="submitSearch" @clear="clearSearch" :q="q" />
+      <search-form
+        v-model="searchQuery"
+        :q="q"
+        @search="submitSearch"
+        @clear="clearSearch"
+      />
 
       <ul class="search-tabs">
         <li v-for="type in searchTypes" :key="type.label">
@@ -30,6 +35,21 @@
             <p v-if="!isLoadingSearch && searchData.items.length">
               {{ searchHeading }}
             </p>
+            <el-pagination
+              v-if="searchData.limit < searchData.total"
+              :page-size="searchData.limit"
+              :pager-count="5"
+              :current-page="curSearchPage"
+              layout="prev, pager, next"
+              :total="searchData.total"
+              @current-change="onPaginationPageChange"
+            />
+            <pagination-menu
+              class="mr-24"
+              pagination-item-label="Datasets"
+              :page-size="datasetSearchParams.limit"
+              @update-page-size="updateDatasetSearchLimit"
+            />
           </div>
           <div class="mb-16">
             <div class="active__filter__wrap">
@@ -52,15 +72,10 @@
             </div>
           </div>
           <div v-loading="isLoadingSearch" class="table-wrap">
-            <component :is="searchResultsComponent" :table-data="tableData" @sort-change="handleSortChange" />
-            <el-pagination
-              v-if="searchData.limit < searchData.total"
-              :page-size="searchData.limit"
-              :pager-count="5"
-              :current-page="curSearchPage"
-              layout="prev, pager, next"
-              :total="searchData.total"
-              @current-change="onPaginationPageChange"
+            <component
+              :is="searchResultsComponent"
+              :table-data="tableData"
+              @sort-change="handleSortChange"
             />
           </div>
         </el-col>
@@ -96,6 +111,7 @@ import {
 } from 'ramda'
 import Breadcrumb from '@/components/Breadcrumb/Breadcrumb.vue'
 import PageHero from '@/components/PageHero/PageHero.vue'
+import PaginationMenu from '@/components/Pagination/PaginationMenu.vue'
 import SearchFilters from '@/components/SearchFilters/SearchFilters.vue'
 import SearchForm from '@/components/SearchForm/SearchForm.vue'
 
@@ -148,7 +164,7 @@ const searchData = {
   skip: 0,
   items: [],
   order: undefined,
-  ascending: false,
+  ascending: false
 }
 
 import createClient from '@/plugins/contentful.js'
@@ -194,7 +210,8 @@ export default {
     Breadcrumb,
     PageHero,
     SearchFilters,
-    SearchForm
+    SearchForm,
+    PaginationMenu
   },
 
   mixins: [],
@@ -227,13 +244,11 @@ export default {
      */
     blackfynnApiUrl: function() {
       const searchType = pathOr('', ['query', 'type'], this.$route)
-      let url = `${
-        process.env.discover_api_host}/search/${
+      let url = `${process.env.discover_api_host}/search/${
         searchType === 'simulation' ? 'dataset' : searchType
-      }s?offset=${this.searchData.skip
-      }&limit=${this.searchData.limit
-      }&orderBy=${this.searchData.order || 'date'
-      }&orderDirection=${
+      }s?offset=${this.searchData.skip}&limit=${
+        this.searchData.limit
+      }&orderBy=${this.searchData.order || 'date'}&orderDirection=${
         this.searchData.ascending ? 'asc' : 'desc'
       }&${
         searchType === 'simulation'
@@ -413,7 +428,12 @@ export default {
     },
 
     handleSortChange: function(payload) {
-      handleSortChange(this.searchType.dataSource, this.searchData, this.fetchResults, payload)
+      handleSortChange(
+        this.searchType.dataSource,
+        this.searchData,
+        this.fetchResults,
+        payload
+      )
     },
 
     /**

--- a/pages/data/index.vue
+++ b/pages/data/index.vue
@@ -34,19 +34,23 @@
           <div class="search-heading">
             <p v-if="!isLoadingSearch && searchData.items.length">
               Showing
-              <pagination-menu @update-page-size="updateDataSearchLimit" :page-size="searchData.limit" />
+              <pagination-menu
+                :page-size="searchData.limit"
+                @update-page-size="updateDataSearchLimit"
+              />
               of {{ searchHeading }}
             </p>
-            <el-pagination
-              v-if="searchData.limit < searchData.total"
-              :page-size="searchData.limit"
-              :pager-count="5"
-              :current-page="curSearchPage"
-              layout="prev, pager, next"
-              :total="searchData.total"
-              @current-change="onPaginationPageChange"
-            />
           </div>
+          <el-pagination
+            v-if="searchData.limit < searchData.total"
+            class="test-pagination"
+            :page-size="searchData.limit"
+            :pager-count="5"
+            :current-page="curSearchPage"
+            layout="prev, pager, next"
+            :total="searchData.total"
+            @current-change="onPaginationPageChange"
+          />
           <div class="mb-16">
             <div class="active__filter__wrap">
               <div
@@ -76,6 +80,14 @@
           </div>
         </el-col>
       </el-row>
+      <p v-if="!isLoadingSearch && searchData.items.length">
+        Showing
+        <pagination-menu
+          :page-size="searchData.limit"
+          @update-page-size="updateDataSearchLimit"
+        />
+        of {{ searchHeading }}
+      </p>
       <el-pagination
         v-if="searchData.limit < searchData.total"
         :page-size="searchData.limit"
@@ -714,7 +726,15 @@ export default {
 }
 .el-pagination {
   margin-top: 1.5em;
-  text-align: center;
+  text-align: right;
+}
+.test-pagination {
+  background-color: orange;
+  // &.el-pager {
+  //   li {
+  //     background-color: orange;
+  //   }
+  // }
 }
 .search-heading {
   align-items: center;

--- a/pages/resources/index.vue
+++ b/pages/resources/index.vue
@@ -31,13 +31,33 @@
     </page-hero>
     <div class="page-wrap container">
       <div class="page-wrap__results">
-        <p>
-          Showing {{ currentResourceCount }} of
-          <strong>{{ totalResourceCount }}</strong>
-        </p>
+        <div class="resources-heading">
+          <p>
+            {{ currentResourceCount }} {{ resourceHeading }} | Showing
+            <pagination-menu
+              :page-size="resourceData.limit"
+              @update-page-size="updateDataSearchLimit"
+            />
+            <el-pagination
+              :page-size="resourceData.limit"
+              :pager-count="5"
+              :current-page="curSearchPage"
+              layout="prev, pager, next"
+              :total="resourceData.total"
+              @current-change="onPaginationPageChange"
+            />
+          </p>
+        </div>
       </div>
       <div v-loading="isLoadingResources" class="table-wrap">
         <resources-search-results :table-data="tableData" />
+      </div>
+      <div class="resources-heading">
+        {{ currentResourceCount }} {{ resourceHeading }} | Showing
+        <pagination-menu
+          :page-size="resourceData.limit"
+          @update-page-size="updateDataSearchLimit"
+        />
         <el-pagination
           :page-size="resourceData.limit"
           :pager-count="5"
@@ -52,10 +72,11 @@
 </template>
 
 <script>
-import { pathOr, propOr, clone, defaultTo, compose, head } from 'ramda'
+import { propOr, clone, compose, head } from 'ramda'
 import Breadcrumb from '@/components/Breadcrumb/Breadcrumb.vue'
 import ResourcesSearchResults from '@/components/Resources/ResourcesSearchResults.vue'
 import PageHero from '@/components/PageHero/PageHero.vue'
+import PaginationMenu from '@/components/Pagination/PaginationMenu.vue'
 import createClient from '@/plugins/contentful.js'
 
 const client = createClient()
@@ -87,7 +108,8 @@ export default {
   components: {
     Breadcrumb,
     ResourcesSearchResults,
-    PageHero
+    PageHero,
+    PaginationMenu
   },
 
   asyncData() {
@@ -119,7 +141,8 @@ export default {
       tabTypes: tabTypes,
       platformItems: [],
       toolItems: [],
-      isLoadingResources: false
+      isLoadingResources: false,
+      resourceHeading: ''
     }
   },
 
@@ -134,16 +157,6 @@ export default {
         : this.resourceData.skip !== 0
         ? this.resourceData.total - this.resourceData.limit
         : this.resourceData.limit
-    },
-
-    /**
-     * Returns total number of resources
-     * @returns {Number}
-     */
-    totalResourceCount: function() {
-      return this.resourceData.total > 1
-        ? `${this.resourceData.total} resources`
-        : `${this.resourceData.total} resource`
     },
 
     /**
@@ -184,9 +197,28 @@ export default {
     } else {
       this.fetchResults()
     }
+
+    if (this.currentResourceCount > 1) {
+      this.resourceHeading = 'resources'
+    } else {
+      this.resourceHeading = 'resource'
+    }
   },
 
   methods: {
+    /**
+     * Update search limit based on pagination number selection
+     * @param {Number} limit
+     */
+    updateDataSearchLimit: function(limit) {
+      this.resourceData.skip = 0
+      if (limit === 'View All') {
+        this.resourceData.limit = this.resourceData.total
+      } else {
+        this.resourceData.limit = limit
+      }
+      this.fetchResults()
+    },
     /**
      * Fetches resource results
      */
@@ -246,9 +278,22 @@ export default {
     padding: 16px;
   }
 
-  .el-pagination {
-    margin-top: 1.5em;
-    text-align: center;
+  .resources-heading {
+    margin-top: 1rem;
+  }
+
+  ::v-deep .el-pagination {
+    margin-top: -2.5em;
+    text-align: right;
+    background-color: transparent;
+    button {
+      background-color: transparent;
+    }
+    .el-pager {
+      li {
+        background-color: transparent;
+      }
+    }
   }
 
   .page-wrap {

--- a/static/icons-js/icon-arrow.js
+++ b/static/icons-js/icon-arrow.js
@@ -1,0 +1,10 @@
+/* eslint-disable */
+var icon = require('vue-svgicon')
+icon.register({
+  'icon-arrow': {
+    width: 16,
+    height: 16,
+    viewBox: '0 0 24 24',
+    data: '<path pid="0" _fill="#909399" d="M12 7.5l-8 8.6h16z"/>'
+  }
+})

--- a/static/icons-js/index.js
+++ b/static/icons-js/index.js
@@ -1,6 +1,7 @@
 /* eslint-disable */
 require('./icon-about')
 require('./icon-anatomy')
+require('./icon-arrow')
 require('./icon-calendar')
 require('./icon-clear')
 require('./icon-contact')

--- a/static/icons-svg/icon-arrow.svg
+++ b/static/icons-svg/icon-arrow.svg
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- Generator: Adobe Illustrator 24.1.2, SVG Export Plug-In . SVG Version: 6.00 Build 0)  -->
+<svg version="1.1" id="icons" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" x="0px" y="0px"
+	 viewBox="0 0 24 24" style="enable-background:new 0 0 24 24;" xml:space="preserve">
+<style type="text/css">
+	.st0{fill:#909399;}
+</style>
+<polygon class="st0" points="12,7.5 4,16.1 20,16.1 "/>
+</svg>


### PR DESCRIPTION
# Description

The purpose of this PR is to add pagination to the top of all result tables in SPARC. This includes all the tables in the Find Data page and Resources page.

Designs can be found [here](https://app.abstract.com/share/7fa2ddd1-8911-4517-8c3b-113cd8d81a5b?collectionId=3bba7620-56e8-47d1-87ad-177eb087a9c5&collectionLayerId=177f13f8-497a-4ad3-86ed-02d1c5b4e12f&mode=build&selected=root-B5703C95-FB1C-4118-AAC6-AA91E88A0AAE&sha=263e790f05e9614fc477588964b0f23a311e86ec). Note that the designs were altered slightly based on discussions regarding placement of the current number displayed and the dropdown count.

## Type of change

- [x] New feature (non-breaking change which adds functionality)

# How Has This Been Tested?

1. Navigate to the Find Data page on the portal.
2. You should see the pagination dropdown and ticker on both the top and bottom of the table as expected.
3. All pagination functionality should work as expected.
4. Results should repeat the same way for the Resources page. 

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added unit tests that prove my fix is effective or that my feature works
