### PR TITLE
fix(projects): Removed logo column and expanded description column

### DIFF
--- a/components/SearchResults/ProjectSearchResults.vue
+++ b/components/SearchResults/ProjectSearchResults.vue
@@ -19,27 +19,9 @@
         </nuxt-link>
       </template>
     </el-table-column>
-    <el-table-column label="Image" width="148">
+    <el-table-column prop="fields.description" label="Description" width="648">
       <template slot-scope="scope">
-        <nuxt-link
-          :to="{
-            name: 'projects-projectId',
-            params: { projectId: scope.row.sys.id }
-          }"
-        >
-          <img
-            class="img-project"
-            :src="getImageSrc(scope)"
-            :alt="getImageAlt(scope)"
-            height="128"
-            width="128"
-          />
-        </nuxt-link>
-      </template>
-    </el-table-column>
-    <el-table-column prop="fields.description" label="Description" width="500">
-      <template slot-scope="scope">
-        {{ truncateField(scope.row.fields.description) }}
+        {{ truncateField(scope.row.fields.description, 500) }}
       </template>
     </el-table-column>
     <el-table-column


### PR DESCRIPTION
# Description

**Find Data Page (Projects):**
- Removed logo column.
- Expanded description column to take up the space of the removed logo column.
- Extended character count of description field.

Additionally, the required logo property in Contentful has been disabled to allow incomplete projects to be displayed on this page. 


## Tickets
[Wrike](https://www.wrike.com/workspace.htm?acc=3203588#path=folder&t=479529255&a=3203588&id=441356195&st=space-441356195)
[Clickup](https://app.clickup.com/t/6af2a2)

## Type of change

Delete those that don't apply.

- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

1. Navigate to the Find Data page.
2. Click on the Projects tab.
3. Logo column will not be displayed.
4. Description column will be wider and display more characters.

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
