### PR TITLE
fix(homepage): Remove past events from homepage

### DIFF
--- a/components/HomepageNews/HomepageNews.vue
+++ b/components/HomepageNews/HomepageNews.vue
@@ -3,7 +3,7 @@
     <div class="home-container">
       <h2><nuxt-link to="/news-and-events">News &amp; Upcoming Events</nuxt-link></h2>
       <sparc-card
-        v-for="(item, idx) in news"
+        v-for="(item, idx) in upcomingNews"
         :key="item.sys.id"
         :image="getImageSrc(item)"
         :image-alt="getImageAlt(item)"
@@ -65,6 +65,22 @@ export default {
     }
   },
 
+  computed: {
+    /**
+     * Filter news to remove past events
+     * @returns {Array}
+     */
+    upcomingNews: function() {
+      const newsToFilter = [...this.news]
+      newsToFilter.forEach(event => {
+        this.isUpcoming(event)
+          ? ''
+          : newsToFilter.splice(newsToFilter.indexOf(event), 1)
+      })
+      return newsToFilter
+    }
+  },
+
   methods: {
     /**
      * Get image source
@@ -94,6 +110,16 @@ export default {
       const startDate = this.formatDate(event.fields.startDate)
       const endDate = this.formatDate(event.fields.endDate)
       return `${startDate} - ${endDate}`
+    },
+    /**
+     * Check if an event is upcoming
+     * @param {Object} item
+     * @returns {Boolean}
+     */
+    isUpcoming: function(item) {
+      const today = new Date()
+      const eventEndDate = pathOr('', ['fields', 'endDate'], item)
+      return Date.parse(eventEndDate) > Date.parse(today) ? true : false
     }
   }
 }

--- a/components/HomepageNews/HomepageNews.vue
+++ b/components/HomepageNews/HomepageNews.vue
@@ -71,13 +71,7 @@ export default {
      * @returns {Array}
      */
     upcomingNews: function() {
-      const newsToFilter = [...this.news]
-      newsToFilter.forEach(event => {
-        this.isUpcoming(event)
-          ? ''
-          : newsToFilter.splice(newsToFilter.indexOf(event), 1)
-      })
-      return newsToFilter
+      return this.news.filter(event => this.isUpcoming(event))
     }
   },
 


### PR DESCRIPTION
# Description

Extends this PR: [#117](https://github.com/nih-sparc/sparc-app/pull/117)

Remove past events from homepage based on whether or not they are upcoming.

## Tickets
[Wrike](https://www.wrike.com/workspace.htm?acc=3203588#path=folder&id=473707106&a=3203588&c=list&t=477619428&so=2&bso=10&sd=0&f=&st=space-441356195)
[Clickup](https://app.clickup.com/t/6af2w2)

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

1. Navigate to the homepage.
2. Past events will not be displayed. 
3. Only events where the end date is still in the future will be displayed.


# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
