### PR TITLE
feat(Homepage): Add video support  in hero

### DIFF
--- a/components/PageHero/PageHero.vue
+++ b/components/PageHero/PageHero.vue
@@ -55,7 +55,8 @@ export default {
       top: -2.5rem;
       width: auto;
     }
-    img {
+    img,
+    video {
       display: block;
       height: 100%;
       width: inherit;

--- a/pages/index.vue
+++ b/pages/index.vue
@@ -12,12 +12,16 @@
           {{ heroButtonLabel }}
         </el-button>
       </a>
-      <img
+      <video
         v-if="heroImage"
         slot="image"
-        class="page-hero-img"
-        :src="heroImage.fields.file.url"
-      />
+        class="page-hero-video"
+        autoplay
+        loop
+        muted
+      >
+        <source :src="heroImage.fields.file.url" type="video/mp4" />
+      </video>
     </page-hero>
 
     <featured-data :featured-data="featuredData" />
@@ -81,7 +85,8 @@ export default {
       meta: [
         {
           name: 'description',
-          content: 'Stimulating Peripheral Activity to Relieve Conditions (SPARC)'
+          content:
+            'Stimulating Peripheral Activity to Relieve Conditions (SPARC)'
         },
         {
           name: 'og:type',
@@ -93,7 +98,8 @@ export default {
         },
         {
           name: 'og:description',
-          content: 'Stimulating Peripheral Activity to Relieve Conditions (SPARC)'
+          content:
+            'Stimulating Peripheral Activity to Relieve Conditions (SPARC)'
         },
         {
           name: 'og:site_name',
@@ -109,7 +115,8 @@ export default {
         },
         {
           name: 'twitter:description',
-          content: 'Stimulating Peripheral Activity to Relieve Conditions (SPARC)'
+          content:
+            'Stimulating Peripheral Activity to Relieve Conditions (SPARC)'
         }
       ]
     }
@@ -132,5 +139,4 @@ export default {
 .page-hero-video {
   width: 406px;
 }
-
 </style>


### PR DESCRIPTION
# Description

The purpose of this PR is to add support for a video in the hero of the homepage. This was originally done in #105, but needed to be. reverted. #120 tried to put the changes back in, but it didn't work.

## Type of change

- [x] New feature (non-breaking change which adds functionality)

# How Has This Been Tested?

See screenshots below for it working on all supported browsers
## Firefox
<img width="1680" alt="firefox" src="https://user-images.githubusercontent.com/1493195/78399181-6cf01500-75c2-11ea-9efd-be69a4971bff.png">

## IE11
<img width="1678" alt="IE11" src="https://user-images.githubusercontent.com/1493195/78399184-6eb9d880-75c2-11ea-9f89-84b3429b8f47.png">

## Safari
<img width="1678" alt="safari" src="https://user-images.githubusercontent.com/1493195/78399190-724d5f80-75c2-11ea-9d5c-e297422f4119.png">

## Chrome
![chrome](https://user-images.githubusercontent.com/1493195/78399196-74afb980-75c2-11ea-9d6b-de1342310cbb.png)

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have added unit tests that prove my fix is effective or that my feature works
