### PR TITLE
Hide organs with no datasets #6af32m

### DIFF
--- a/pages/data/index.vue
+++ b/pages/data/index.vue
@@ -547,7 +547,7 @@ export default {
         .get(
           `${
             process.env.discover_api_host
-          }/search/datasets?query=${organType.toLowerCase()}&limit=100`
+          }/search/datasets?query=${organType.toLowerCase()}&limit=1`
         )
         .then(response => {
           return response.data

--- a/pages/data/index.vue
+++ b/pages/data/index.vue
@@ -560,7 +560,7 @@ export default {
      * @return {Boolean}
      */
     hasDatasets: function(organData) {
-      return organData.totalCount > 0 ? true : false
+      return organData.totalCount > 0
     },
 
     /**

--- a/pages/organs/_organId.vue
+++ b/pages/organs/_organId.vue
@@ -84,7 +84,7 @@ export default {
     const datasets = await $axios.$get(
       `${
         process.env.discover_api_host
-      }/search/datasets?tags=${organType.toLowerCase()}&limit=100`
+      }/search/datasets?query=${organType.toLowerCase()}&limit=100`
     )
 
     const tabsData = clone(tabs)


### PR DESCRIPTION
# Description

**Find Data Page (Organs):**
- Remove organs that do not have associated datasets.

**Organ Details Page:**
- Properly hit the endpoint to retrieve all organ datasets.

## Tickets
[Wrike](https://www.wrike.com/workspace.htm?acc=3203588#path=folder&t=473147058&a=3203588&id=441356195&st=space-441356195)
[Clickup](https://app.clickup.com/t/6af32m)

## Type of change

Delete those that don't apply.

- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?
1. Navigate to the Find Data page.
2. Click on the Organs tab.
3. Only organs with datasets will be displayed (currently there are 7).
4. Click on any organ.
5. Organ Details page will show all datasets associated with that organ.


# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
