### PR TITLE
fix(Find Data): Make the Find Data table more readable on mobile

### DIFF
--- a/components/SearchResults/DatasetSearchResults.vue
+++ b/components/SearchResults/DatasetSearchResults.vue
@@ -5,7 +5,7 @@
       sortable="custom"
       prop="name"
       label="Title"
-      width="300"
+      :width="titleColumnWidth"
     >
       <template slot-scope="scope">
         <nuxt-link
@@ -69,6 +69,10 @@ export default {
     tableData: {
       type: Array,
       default: () => []
+    },
+    titleColumnWidth: {
+      type: Number,
+      default: () => 300
     }
   },
 

--- a/components/SearchResults/OrganSearchResults.vue
+++ b/components/SearchResults/OrganSearchResults.vue
@@ -5,7 +5,7 @@
       sortable="custom"
       prop="fields.name"
       label="Title"
-      width="300"
+      :width="titleColumnWidth"
     >
       <template slot-scope="scope">
         <nuxt-link
@@ -49,6 +49,10 @@ export default {
     tableData: {
       type: Array,
       default: () => []
+    },
+    titleColumnWidth: {
+      type: Number,
+      default: () => 300
     }
   },
 

--- a/components/SearchResults/ProjectSearchResults.vue
+++ b/components/SearchResults/ProjectSearchResults.vue
@@ -5,7 +5,7 @@
       sortable="custom"
       prop="fields.title"
       label="Title"
-      width="300"
+      :width="titleColumnWidth"
     >
       <template slot-scope="scope">
         <nuxt-link
@@ -53,6 +53,10 @@ export default {
     tableData: {
       type: Array,
       default: () => []
+    },
+    titleColumnWidth: {
+      type: Number,
+      default: () => 300
     }
   },
 

--- a/pages/data/index.vue
+++ b/pages/data/index.vue
@@ -407,7 +407,12 @@ export default {
     } else {
       this.fetchResults()
     }
-    window.innerWidth <= 768 ? (this.titleColumnWidth = 150) : ''
+    if (window.innerWidth <= 768) this.titleColumnWidth = 150
+    window.onresize = () => {
+      window.innerWidth <= 768
+        ? (this.titleColumnWidth = 150)
+        : (this.titleColumnWidth = 300)
+    }
   },
 
   methods: {

--- a/pages/data/index.vue
+++ b/pages/data/index.vue
@@ -73,6 +73,7 @@
             <component
               :is="searchResultsComponent"
               :table-data="tableData"
+              :title-column-width="titleColumnWidth"
               @sort-change="handleSortChange"
             />
           </div>
@@ -249,7 +250,8 @@ export default {
           },
           label: 'Home'
         }
-      ]
+      ],
+      titleColumnWidth: 300
     }
   },
 
@@ -395,6 +397,7 @@ export default {
   },
   /**
    * Check the searchType param in the route and set it if it doesn't exist
+   * Shrink the title column width if on mobile
    */
   mounted: function() {
     if (!this.$route.query.type) {
@@ -404,6 +407,7 @@ export default {
     } else {
       this.fetchResults()
     }
+    window.innerWidth <= 768 ? (this.titleColumnWidth = 150) : ''
   },
 
   methods: {


### PR DESCRIPTION
# Description
When the user is on mobile (or very small browser size) the title column in the Find Data tables is too large and does not allow for the other columns to be visible. This fix conditionally changes the size of the column based on the browser size.

## Tickets
[Clickup](https://app.clickup.com/t/6af36y)
[Wrike](https://www.wrike.com/workspace.htm?acc=3203588#path=folder&t=489276548&a=3203588&id=441356195&st=space-441356195)

## Type of change

Delete those that don't apply.

- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

**Mobile**
1. In Chrome Dev Tools, click the Mobile View button on the top left, so that the browser renders the SPARC Portal in a mobile layout.
2. Navigate to the Find Data page.
3. For all the tabs, the title column should be smaller and allow for the other columns to be visible and scrollable.

**Desktop**
1. Navigate to the Find Data page.
2. For all the tabs, the title column should be as it normally is.


# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
