### PR TITLE
fix(dataset): First tab is Description

### DIFF
--- a/pages/datasets/_datasetId.vue
+++ b/pages/datasets/_datasetId.vue
@@ -127,6 +127,11 @@
         :active-tab="activeTab"
         @set-active-tab="setActiveTab"
       >
+        <dataset-description-info
+          v-show="activeTab === 'description'"
+          :markdown="markdown"
+          :loading-markdown="loadingMarkdown"
+        />
         <dataset-about-info
           v-show="activeTab === 'about'"
           :updated-date="lastUpdatedDate"
@@ -134,11 +139,6 @@
           :doi-value="datasetInfo.doi"
           :dataset-records="datasetRecords"
           :dataset-tags="datasetTags"
-        />
-        <dataset-description-info
-          v-show="activeTab === 'description'"
-          :markdown="markdown"
-          :loading-markdown="loadingMarkdown"
         />
         <dataset-files-info
           v-show="activeTab === 'files'"
@@ -201,12 +201,12 @@ marked.setOptions({
 
 const tabs = [
   {
-    label: 'About',
-    type: 'about'
-  },
-  {
     label: 'Description',
     type: 'description'
+  },
+  {
+    label: 'About',
+    type: 'about'
   },
   {
     label: 'Files',


### PR DESCRIPTION
# Description

The Description tab is now the first tab in a dataset's detail page.

## Tickets
[Clickup](https://app.clickup.com/t/6ygpyk)
[Wrike](https://www.wrike.com/workspace.htm?acc=3203588#path=folder&t=472085698&a=3203588&id=441356195&st=space-441356195)

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

1. Navigate to the Find Data page.
2. In the Datasets tab, click on any dataset.
3. The Description tab will be before the About tab.


# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
