### PR TITLE
fix(resources): Added conditional to hide pager for one page

### DIFF
--- a/pages/resources/index.vue
+++ b/pages/resources/index.vue
@@ -39,6 +39,7 @@
               @update-page-size="updateDataSearchLimit"
             />
             <el-pagination
+              v-if="resourceData.limit < resourceData.total"
               :page-size="resourceData.limit"
               :pager-count="5"
               :current-page="curSearchPage"


### PR DESCRIPTION
# Description

Added conditional to hide the pager when there is only one page of results in the resources page. Fixes issue with underline not appearing.


## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

1. Navigate to the resources page.
2. Click on the Tools tab.
3. Pager should not be displayed.
4. For both the All Resources and Platforms tab, the underline should properly display under the active page.


# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
