### PR TITLE
Add search bar #70e8ut

### DIFF
--- a/components/header/Header.vue
+++ b/components/header/Header.vue
@@ -120,14 +120,23 @@
               </div>
             </div>
           </div>
-          <div v-if="shouldShowSearch" class="nav-main-container__search">
-            <input
+          <div class="nav-main-container__search">
+            <el-input
               v-model="searchQuery"
               type="text"
-              class="nav-main-container__search-input"
-              placeholder="Search Datasets"
-              @keyup.enter="executeSearch"
-            />
+              class="input-with-select nav-main-container__search-input"
+              placeholder="Search"
+              @keyup.native.enter="executeSearch"
+            >
+              <el-select slot="prepend" v-model="searchSelect">
+                <el-option
+                  v-for="option in searchSelectOptions"
+                  :key="option"
+                  :label="option"
+                  :value="option"
+                />
+              </el-select>
+            </el-input>
             <button
               class="nav-main-container__search-button"
               @click="executeSearch"
@@ -183,7 +192,9 @@ export default {
     links,
     menuOpen: false,
     searchOpen: false,
-    searchQuery: ''
+    searchQuery: '',
+    searchSelect: 'Datasets',
+    searchSelectOptions: ['Datasets', 'Support Center']
   }),
 
   computed: {
@@ -271,18 +282,31 @@ export default {
     },
 
     /**
-     * Executes a search query
+     * Executes a search query based on selected
+     * option and query
      */
     executeSearch: function() {
-      this.$router.push({
-        name: 'data',
-        query: {
-          q: this.searchQuery,
-          type: 'dataset'
-        }
-      })
-
+      console.log(this.searchSelect)
+      console.log(this.$route)
+      if (this.searchSelect === 'Datasets') {
+        console.log('FINDING DATASETS')
+        this.$router.push({
+          name: 'data',
+          query: {
+            type: 'dataset',
+            q: this.searchQuery
+          }
+        })
+      } else if (this.searchSelect === 'Support Center') {
+        this.$router.push({
+          name: 'help',
+          query: {
+            search: this.searchQuery
+          }
+        })
+      }
       this.searchQuery = ''
+      this.searchSelect = 'Datasets'
     }
   }
 }
@@ -487,10 +511,11 @@ export default {
   height: 34px;
   border-radius: 4px;
   border: solid 1px $dark-gray;
-  margin-top: 2px;
-  padding-left: 0.5rem;
   @media screen and (max-width: 1023px) {
     display: none;
+  }
+  .el-select {
+    width: 100px;
   }
 }
 
@@ -500,6 +525,7 @@ export default {
   height: 40px;
   border-radius: 4px;
   margin-left: 9px;
+  margin-top: 1px;
   border: none;
   @media screen and (max-width: 1023px) {
     display: none;

--- a/components/header/Header.vue
+++ b/components/header/Header.vue
@@ -286,10 +286,7 @@ export default {
      * option and query
      */
     executeSearch: function() {
-      console.log(this.searchSelect)
-      console.log(this.$route)
       if (this.searchSelect === 'Datasets') {
-        console.log('FINDING DATASETS')
         this.$router.push({
           name: 'data',
           query: {

--- a/pages/data/index.vue
+++ b/pages/data/index.vue
@@ -390,7 +390,6 @@ export default {
 
     '$route.query.q': {
       handler: function() {
-        console.log('QUERY CHANGED')
         this.searchQuery = this.$route.query.q
         this.fetchResults()
       },
@@ -625,10 +624,7 @@ export default {
     submitSearch: function() {
       this.searchData.skip = 0
 
-      console.log(this.searchQuery, this.$route.query.q)
       const query = mergeLeft({ q: this.searchQuery }, this.$route.query)
-      console.log('SUBMITTING')
-      console.log(this.$router)
       this.$router.replace({ query })
     },
 
@@ -639,9 +635,7 @@ export default {
       this.searchData.skip = 0
 
       const query = { ...this.$route.query, q: '' }
-      this.$router.replace({ query }).then(() => {
-        this.fetchResults()
-      })
+      this.$router.replace({ query })
     },
 
     /**

--- a/pages/data/index.vue
+++ b/pages/data/index.vue
@@ -390,6 +390,7 @@ export default {
 
     '$route.query.q': {
       handler: function() {
+        console.log('QUERY CHANGED')
         this.searchQuery = this.$route.query.q
       },
       immediate: true
@@ -623,9 +624,14 @@ export default {
     submitSearch: function() {
       this.searchData.skip = 0
 
+      console.log(this.searchQuery, this.$route.query.q)
       const query = mergeLeft({ q: this.searchQuery }, this.$route.query)
+      console.log('SUBMITTING')
+      console.log(this.$router)
       this.$router.replace({ query }).then(() => {
+        console.log('FETCHING')
         this.fetchResults()
+        console.log('FETCHED')
       })
     },
 

--- a/pages/data/index.vue
+++ b/pages/data/index.vue
@@ -392,6 +392,7 @@ export default {
       handler: function() {
         console.log('QUERY CHANGED')
         this.searchQuery = this.$route.query.q
+        this.fetchResults()
       },
       immediate: true
     }
@@ -628,11 +629,7 @@ export default {
       const query = mergeLeft({ q: this.searchQuery }, this.$route.query)
       console.log('SUBMITTING')
       console.log(this.$router)
-      this.$router.replace({ query }).then(() => {
-        console.log('FETCHING')
-        this.fetchResults()
-        console.log('FETCHED')
-      })
+      this.$router.replace({ query })
     },
 
     /**


### PR DESCRIPTION
# Description

Added a search bar with a dropdown menu to select either "Datasets" or "Support Center". User will be brought to those respective routes with query params.

## Tickets
[Clickup](https://app.clickup.com/t/70e8ut)
[Wrike](https://www.wrike.com/open.htm?id=467366936)

## Type of change

- [x] New feature (non-breaking change which adds functionality)

# How Has This Been Tested?

**Datasets Search**
1. Navigate to the homepage.
2. On the top right, search bar dropdown should be default to "Datasets".
3. Type in "Heart".
4. Click the search button or hit enter.
5. You will be routed to the Find Data page where datasets will be filtered by "Heart".

**Support Center Search**
1. Navigate to the homepage.
2. On the top right, click the dropdown and select "Support Center".
3. Type in "Help".
4. Click the search button or hit enter.
5. You will be routed to the Help page where the information will be filtered by "Help".

**Note:** The search bar persists site-wide, so the same tests can be run on any of the pages.


# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
