### PR TITLE
fix(hero): Update background of hero video

### DIFF
--- a/components/PageHero/PageHero.vue
+++ b/components/PageHero/PageHero.vue
@@ -72,7 +72,7 @@ export default {
   }
   h1,
   p {
-    background-color: #383671;
+    background-color: rgba(56, 54, 113, 0.75);
   }
   p:last-child {
     margin: 0;

--- a/components/PageHero/PageHero.vue
+++ b/components/PageHero/PageHero.vue
@@ -27,7 +27,7 @@ export default {
 
 <style lang="scss">
 .page-hero {
-  background: #24245b;
+  background: #383671;
   color: #f0f2f5;
   font-size: 1em;
   line-height: 1.5rem;
@@ -72,7 +72,7 @@ export default {
   }
   h1,
   p {
-    background-color: rgba(36, 36, 91, 0.75);
+    background-color: #383671;
   }
   p:last-child {
     margin: 0;

--- a/pages/help/index.vue
+++ b/pages/help/index.vue
@@ -118,7 +118,7 @@ export default Vue.extend<Data, Methods, never, never>({
 <style lang="scss" scoped>
 @import '@/assets/_variables.scss';
 .page-hero {
-  background-color: $navy;
+  background-color: #383671;
   background-image: none;
   h2 {
     font-size: 2rem;

--- a/pages/index.vue
+++ b/pages/index.vue
@@ -17,7 +17,6 @@
         slot="image"
         class="page-hero-video"
         autoplay
-        loop
         muted
       >
         <source :src="heroImage.fields.file.url" type="video/mp4" />


### PR DESCRIPTION
# Description

Updated the background color of the page hero to reflect that of the hero video. Removed loop property so that the video only plays once.

**Note:** The clickup ticket recommends to use `#313062`, I found that `#383671` was a better color fit with the hero video.

## Tickets
[Clickup](https://app.clickup.com/t/6ygpw3)
[Wrike](https://www.wrike.com/open.htm?id=487378873)

## Type of change

Delete those that don't apply.

- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

1. Navigate to the homepage.
2. Background of page hero is the same as the hero video.
3. Hero video plays once.

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
