### PR TITLE
feat(global search): add resources and news to global search

### DIFF
--- a/components/header/Header.vue
+++ b/components/header/Header.vue
@@ -131,9 +131,9 @@
               <el-select slot="prepend" v-model="searchSelect">
                 <el-option
                   v-for="option in searchSelectOptions"
-                  :key="option"
-                  :label="option"
-                  :value="option"
+                  :key="option.key"
+                  :label="option.label"
+                  :value="option.value"
                 />
               </el-select>
             </el-input>
@@ -193,8 +193,24 @@ export default {
     menuOpen: false,
     searchOpen: false,
     searchQuery: '',
-    searchSelect: 'Datasets',
-    searchSelectOptions: ['Datasets', 'Support Center']
+    searchSelect: 'data',
+    searchSelectOptions: [{
+      key: 'data',
+      value: 'data',
+      label: 'Datasets'
+    }, {
+      key: 'resources',
+      value: 'resources',
+      label: 'Resources'
+    }, {
+      key: 'news-and-events',
+      value: 'news-and-events',
+      label: 'News and Events'
+    }, {
+      key: 'help',
+      value: 'help',
+      label: 'Support Center'
+    }]
   }),
 
   computed: {
@@ -286,22 +302,22 @@ export default {
      * option and query
      */
     executeSearch: function() {
-      if (this.searchSelect === 'Datasets') {
-        this.$router.push({
-          name: 'data',
-          query: {
-            type: 'dataset',
-            q: this.searchQuery
-          }
-        })
-      } else if (this.searchSelect === 'Support Center') {
-        this.$router.push({
-          name: 'help',
-          query: {
-            search: this.searchQuery
-          }
-        })
-      }
+      const option = this.searchSelectOptions.find(o => o.value === this.searchSelect)
+      const searchKey = option.value === 'data' ? 'q' : 'search'
+      const type = option.value === 'data'
+        ? 'dataset'
+        : option.value === 'resources'
+            ? 'sparcPartners'
+            : undefined
+
+      this.$router.push({
+        name: option.value,
+        query: {
+          type,
+          [searchKey]: this.searchQuery
+        }
+      })
+
       this.searchQuery = ''
       this.searchSelect = 'Datasets'
     }

--- a/pages/news-and-events/index.vue
+++ b/pages/news-and-events/index.vue
@@ -117,12 +117,15 @@ export default Vue.extend<Data, never, Computed, never>({
   },
 
   watch: {
-    '$route.query': async function(this: NewsAndEventsComponent) {
-      const { upcomingEvents, pastEvents, news, heroData } = await fetchData(client, this.$route.query.search as string)
-      this.upcomingEvents = upcomingEvents;
-      this.pastEvents = pastEvents;
-      this.news = news;
-      this.heroData = heroData;
+    '$route.query': {
+      handler: async function(this: NewsAndEventsComponent) {
+        const { upcomingEvents, pastEvents, news, heroData } = await fetchData(client, this.$route.query.search as string)
+        this.upcomingEvents = upcomingEvents;
+        this.pastEvents = pastEvents;
+        this.news = news;
+        this.heroData = heroData;
+      },
+      immediate: true
     }
   },
 


### PR DESCRIPTION
# Description

This PR adds Resources and News/Events to the global search bar.

NOTE: this PR is into #132 to make things easier to review.  Please review #132 first.

## Type of change

- [x] New feature (non-breaking change which adds functionality)

# How Has This Been Tested?

Select Resources from the global search bar and enter a search term.  You should be routed to the Resources page with the term in the search box and the results filtered accordingly.  The same should be true of News and Events.

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added unit tests that prove my fix is effective or that my feature works
