### PR TITLE
Search style updates #72fvb1

### DIFF
--- a/components/SearchControlsContentful/SearchControlsContentful.vue
+++ b/components/SearchControlsContentful/SearchControlsContentful.vue
@@ -1,11 +1,22 @@
 <template>
   <div class="search-form" @keyup.enter="submit">
-    <input
-      v-model="terms"
-      :placeholder="placeholder"
-      suffix-icon="el-icon-search"
-      @keyup.enter="submit"
-    />
+    <div class="input-wrap">
+      <input
+        v-model="terms"
+        :placeholder="placeholder"
+        suffix-icon="el-icon-search"
+        @keyup.enter="submit"
+      />
+      <button v-if="terms" class="btn-clear-search" @click="clear">
+        <svg-icon
+          name="icon-clear"
+          stroke="red"
+          color="#909399 #fff"
+          height="22"
+          width="22"
+        />
+      </button>
+    </div>
     <button title="Search" @click="submit">
       <span class="visuallyhidden">Search</span>
       <svg-icon name="icon-magnifying-glass" height="20" width="20" />
@@ -42,6 +53,9 @@ export default {
   methods: {
     submit() {
       this.$router.push({ path: this.path, query: { ...this.$route.query, search: this.terms } })
+    },
+    clear() {
+      this.$router.push({ path: this.path, query: { ...this.$route.query, search: '' } })
     }
   }
 }
@@ -54,18 +68,45 @@ export default {
   min-width: 275px;
   margin: 0 0 1rem;
 }
+.input-wrap {
+  display: flex;
+  margin-right: 0.5rem;
+  position: relative;
+  @media (min-width: 768px) {
+    width: 28.0625rem;
+  }
+}
 input {
+  background: #fff;
   border: 1px solid #909399;
   border-radius: 4px;
   box-sizing: border-box;
   color: #909399;
+  flex: 1;
   font-size: 0.875rem;
-  margin-right: 0.5rem;
   outline: none;
-  padding: 0.5rem 0.8125rem;
-  width: 100%;
+  margin: 0;
+  padding: 0.5rem 2.25rem 0.5rem 0.8125rem;
   &:focus {
     border-color: $median;
+  }
+  &::-ms-clear {
+    display: none;
+  }
+}
+.btn-clear-search {
+  background: none;
+  border: none;
+  cursor: pointer;
+  height: 100%;
+  outline: none;
+  margin: 0;
+  position: absolute;
+  right: 0;
+  top: 0;
+  &:hover,
+  &:active {
+    opacity: 0.75;
   }
 }
 button {

--- a/components/header/Header.vue
+++ b/components/header/Header.vue
@@ -56,7 +56,7 @@
             </div>
           </div>
 
-          <div :class="[menuOpen ? 'overlay' : '']">
+          <div class="mobile-navigation-wrapper" :class="[menuOpen ? 'overlay' : '']">
             <div class="mobile-navigation" :class="[menuOpen ? 'open' : '']">
               <ul>
                 <li
@@ -510,9 +510,7 @@ export default {
 
 .nav-main-container__search {
   display: flex;
-  flex-direction: row;
-  justify-content: flex-end;
-  width: 54%;
+  margin-left: auto;
   margin-right: 1rem;
   @media (min-width: 320px) and (max-width: 1023px) {
     width: 0;
@@ -520,7 +518,7 @@ export default {
 }
 
 .nav-main-container__search-input {
-  width: 26vw;
+  width: 30vw;
   height: 34px;
   border-radius: 4px;
   border: solid 1px $dark-gray;
@@ -528,7 +526,7 @@ export default {
     display: none;
   }
   .el-select {
-    width: 100px;
+    width: 150px;
   }
 }
 
@@ -586,6 +584,10 @@ export default {
       display: block;
     }
   }
+}
+
+.mobile-navigation-wrapper {
+  display: flex;
 }
 
 .mobile-navigation {

--- a/components/header/Header.vue
+++ b/components/header/Header.vue
@@ -56,7 +56,7 @@
             </div>
           </div>
 
-          <div class="mobile-navigation-wrapper" :class="[menuOpen ? 'overlay' : '']">
+          <div :class="[menuOpen ? 'overlay' : '']">
             <div class="mobile-navigation" :class="[menuOpen ? 'open' : '']">
               <ul>
                 <li
@@ -510,7 +510,9 @@ export default {
 
 .nav-main-container__search {
   display: flex;
-  margin-left: auto;
+  flex-direction: row;
+  justify-content: flex-end;
+  width: 54%;
   margin-right: 1rem;
   @media (min-width: 320px) and (max-width: 1023px) {
     width: 0;
@@ -584,10 +586,6 @@ export default {
       display: block;
     }
   }
-}
-
-.mobile-navigation-wrapper {
-  display: flex;
 }
 
 .mobile-navigation {


### PR DESCRIPTION
# Description

- Adjust the width of the global search control to accomodate for the longer text items e.g. "News and Events".

- Add a clear button to the `SearchControlsContentful.vue`

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)

# How Has This Been Tested?

- Using devtools, set your responsive width to 1024px (minimum width before mobile).  Make sure everything in the header fits.  On wider viewports, the search bar should be wider.  There should always be enough room for the longest dropdown value for global search (News and Events).

- The Help Center, Resources, and Find Data pages should all have working clear buttons for their search.

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added unit tests that prove my fix is effective or that my feature works
