### PR TITLE
fix(events): Properly display date and location on event cards

### DIFF
--- a/components/EventCard/EventCard.vue
+++ b/components/EventCard/EventCard.vue
@@ -13,7 +13,7 @@
       <svg-icon name="icon-calendar" height="16" width="16" />
       <p>{{ eventDate(event) }}</p>
     </div>
-    <div class="upcoming-event__detail">
+    <div v-if="event.fields.location" class="upcoming-event__detail">
       <svg-icon name="icon-map" height="16" width="16" />
       <p>{{ event.fields.location }}</p>
     </div>
@@ -59,7 +59,7 @@ export default {
     eventDate: function(event) {
       const startDate = this.formatDate(event.fields.startDate)
       const endDate = this.formatDate(event.fields.endDate)
-      return `${startDate} - ${endDate}`
+      return startDate === endDate ? startDate : `${startDate} - ${endDate}`
     }
   }
 }

--- a/components/HomepageNews/HomepageNews.vue
+++ b/components/HomepageNews/HomepageNews.vue
@@ -18,13 +18,15 @@
           <div class="sparc-card__detail">
             <svg-icon name="icon-calendar" height="16" width="16" />
             <p>{{ eventDate(item) }}</p>
-            <svg-icon
-              class="sparc-card__detail--location"
-              name="icon-map"
-              height="16"
-              width="16"
-            />
-            <p>{{ item.fields.location }}</p>
+            <div v-if="item.fields.location">
+              <svg-icon
+                class="sparc-card__detail--location"
+                name="icon-map"
+                height="16"
+                width="16"
+              />
+              <p>{{ item.fields.location }}</p>
+            </div>
           </div>
           <!-- eslint-disable vue/no-v-html -->
           <!-- marked will sanitize the HTML injected -->
@@ -103,7 +105,7 @@ export default {
     eventDate: function(event) {
       const startDate = this.formatDate(event.fields.startDate)
       const endDate = this.formatDate(event.fields.endDate)
-      return `${startDate} - ${endDate}`
+      return startDate === endDate ? startDate : `${startDate} - ${endDate}`
     },
     /**
      * Check if an event is upcoming

--- a/components/HomepageNews/HomepageNews.vue
+++ b/components/HomepageNews/HomepageNews.vue
@@ -18,7 +18,7 @@
           <div class="sparc-card__detail">
             <svg-icon name="icon-calendar" height="16" width="16" />
             <p>{{ eventDate(item) }}</p>
-            <div v-if="item.fields.location">
+            <template v-if="item.fields.location">
               <svg-icon
                 class="sparc-card__detail--location"
                 name="icon-map"
@@ -26,7 +26,7 @@
                 width="16"
               />
               <p>{{ item.fields.location }}</p>
-            </div>
+            </template>
           </div>
           <!-- eslint-disable vue/no-v-html -->
           <!-- marked will sanitize the HTML injected -->


### PR DESCRIPTION
# Description

- Display only the start date if the event start and end dates are the same.
- Do not display location icon if the event has no location data.

## Ticket
[Wrike](https://www.wrike.com/workspace.htm?acc=3203588#path=folder&id=473707106&p=441356195&a=3203588&c=list&t=467368706&so=2&bso=10&sd=0&f=&st=space-441356195)

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

Test on homepage and News & Events page (test event: New SPARC Funding Opportunity):
1. Events with same start & end date will only display start date.
2. Events with no location data will not display location icon.


# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
