### PR TITLE
bugfix(Find Data): Fix some organs not returning results

### DIFF
--- a/pages/data/index.vue
+++ b/pages/data/index.vue
@@ -521,12 +521,16 @@ export default {
      * @returns {Object}
      */
     getOrganDetails: function(organ) {
-      const organType = pathOr('', ['fields', 'name'], organ)
+      const projectSection = pathOr(
+        '',
+        ['fields', 'projectSection', 'fields', 'title'],
+        organ
+      )
       return this.$axios
         .get(
           `${
             process.env.discover_api_host
-          }/search/datasets?query=${organType.toLowerCase()}&limit=1`
+          }/search/datasets?query=${projectSection.toLowerCase()}&limit=1`
         )
         .then(response => {
           return response.data

--- a/pages/organs/_organId.vue
+++ b/pages/organs/_organId.vue
@@ -80,11 +80,15 @@ export default {
     }
 
     // Get related datasets
-    const organType = pathOr('', ['fields', 'name'], pageData)
+    const projectSection = pathOr(
+      '',
+      ['fields', 'projectSection', 'fields', 'title'],
+      pageData
+    )
     const datasets = await $axios.$get(
       `${
         process.env.discover_api_host
-      }/search/datasets?query=${organType.toLowerCase()}&limit=100`
+      }/search/datasets?query=${projectSection.toLowerCase()}&limit=100`
     )
 
     const tabsData = clone(tabs)


### PR DESCRIPTION
# Description

The purpose of this PR is to fix a bug where some organs weren't being display in the Find Data page, even though they did have datasets associated with them. This was because the Colon organ is actually "Colon and Large Intestine" and therefore the endpoint returns 0 results. To categorize these organs, there is a "Project Section" field where we assign organs to a generic category. In this example, "Colon and Large Intestine" is part of the "Colon" category. Using this field fixes the bug for the following organs:

- Colon
- Bladder/Lower Urinary Tract 
- Male Reproductive System

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

- Navigate to the [Find Data/Organs](http://localhost:3000/data?type=organ) page
- You should see all organs that have datasets associated with them, including the three from the list at the top.

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have added unit tests that prove my fix is effective or that my feature works
