### PR TITLE
fix(organs): Pagination dropdown fix

### DIFF
--- a/pages/data/index.vue
+++ b/pages/data/index.vue
@@ -496,7 +496,10 @@ export default {
         })
         .then(async response => {
           this.searchData = { ...response, order: this.searchData.order }
-          if (this.$route.query.type === 'organ') {
+          if (
+            this.$route.query.type === 'organ' &&
+            origSearchDataLimit !== 999
+          ) {
             this.searchData.items = await this.removeOrganNoDatasets()
             // Reset search data values for pagination
             this.searchData.limit = origSearchDataLimit


### PR DESCRIPTION
# Description

Fixes the following:
- When user goes to an organs detail page from the Organs tab in Find Data and goes back, the pagination dropdown goes to 999.


## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

1. Navigate to the Find Data page.
2. Click on any organ.
3. Go back to the Find Data page (using the back button in your browser).
4. The pagination dropdown will be reset to 10, not 999.


# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
