### PR TITLE
fix(about): Updated about page link style

### DIFF
--- a/pages/about/index.vue
+++ b/pages/about/index.vue
@@ -8,9 +8,12 @@
       </p>
       <p>
         Visit the
-        <a href="https://commonfund.nih.gov/sparc/" target="_blank">
-          NIH SPARC program website
-        </a>
+        <a
+          class="about-page-link"
+          href="https://commonfund.nih.gov/sparc/"
+          target="_blank"
+        >
+          NIH SPARC program website</a>
         to learn more.
       </p>
       <img
@@ -150,6 +153,14 @@ export default {
     @media screen and (max-width: 767px) {
       flex-direction: column;
     }
+  }
+}
+
+.about-page-link {
+  color: white;
+  text-decoration: underline;
+  &:hover {
+    color: #909399;
   }
 }
 


### PR DESCRIPTION
# Description

Updated about page link style per the designs.

## Tickets
[Wrike](https://www.wrike.com/workspace.htm?acc=3203588#path=folder&id=473707106&p=441356195&a=3203588&c=list&t=473576238&so=2&bso=10&sd=0&f=&st=space-441356195)
[Clickup](https://app.clickup.com/t/78e8qp)


## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

1. Navigate to the about page.
2. About page link in banner will be white and underlined.
3. Hover over the link.
4. The link will become gray (#909399)

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
