### PR TITLE
fix(footer): Update status link text in footer

### DIFF
--- a/components/footer/Footer.vue
+++ b/components/footer/Footer.vue
@@ -50,7 +50,9 @@
             </a>
           </li>
           <li>
-            <a href="http://status.sparc.science/" target="_blank">SPARC.science Site Status</a>
+            <a href="http://status.sparc.science/" target="_blank">
+              SPARC Systems Status
+            </a>
           </li>
         </ul>
         <h3>Help us Improve</h3>


### PR DESCRIPTION
# Description

Update site status link in footer from "SPARC.science Site Status" to "SPARC Systems Status".

## Tickets
[Wrike](https://www.wrike.com/workspace.htm?acc=3203588#path=folder&id=473707106&p=441356195&a=3203588&c=list&t=484953340&so=2&bso=10&sd=0&f=&st=space-441356195)
[Clikup](https://app.clickup.com/t/78eb82)

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

1. Scroll down to the footer.
2. SPARC Systems Status will be the last option in the "Learn More" section.
3. Click on it.
4. You will be brought to http://status.sparc.science/
5. The first label will be https://sparc.science

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
