### PR TITLE
fix(search): Fix enter not working after first search on global search bar

### DIFF
--- a/components/header/Header.vue
+++ b/components/header/Header.vue
@@ -319,7 +319,7 @@ export default {
       })
 
       this.searchQuery = ''
-      this.searchSelect = 'Datasets'
+      this.searchSelect = 'data'
     }
   }
 }


### PR DESCRIPTION
# Description

Fixed enter not working after first search by properly resetting the dropdown to Datasets.

## Tickets
[Wrike](https://www.wrike.com/workspace.htm?acc=3203588#path=folder&id=473707106&p=441356195&a=3203588&c=list&t=467366936&so=2&bso=10&sd=0&f=&st=space-441356195)
[Clickup](https://app.clickup.com/t/78f0fw)

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

1. Search something in the global search bar using Enter.
2. After results display, global search bar will clear.
3. Search something again in the global search bar using Enter.
4. Results will display.


# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
