### PR TITLE
Adjust page hero background color to match video

### DIFF
--- a/components/PageHero/PageHero.vue
+++ b/components/PageHero/PageHero.vue
@@ -27,7 +27,7 @@ export default {
 
 <style lang="scss">
 .page-hero {
-  background: #383671;
+  background: #292b66;
   color: #f0f2f5;
   font-size: 1em;
   line-height: 1.5rem;
@@ -72,7 +72,7 @@ export default {
   }
   h1,
   p {
-    background-color: rgba(56, 54, 113, 0.75);
+    background-color: rgba(41, 43, 102, 0.75);
   }
   p:last-child {
     margin: 0;


### PR DESCRIPTION
# Description
The purpose of this PR is to adjust the page hero background color to match the new video.

## Type of change

- [x] New feature (non-breaking change which adds functionality)

# How Has This Been Tested?

- Go to the homepage
- The background color of the hero should be the same as the video's background color.

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have added unit tests that prove my fix is effective or that my feature works
