### PR TITLE
Address background color on Firefox

### DIFF
--- a/components/PageHero/PageHero.vue
+++ b/components/PageHero/PageHero.vue
@@ -37,6 +37,10 @@ export default {
     line-height: 2rem;
     padding: 2.5rem 0;
   }
+  // Firefox hack to fix color discrepancy
+  @-moz-document url-prefix() {
+    background: #21275a;
+  }
   &__copy {
     position: relative;
     z-index: 1;
@@ -73,6 +77,11 @@ export default {
   h1,
   p {
     background-color: rgba(41, 43, 102, 0.75);
+
+    // Firefox hack to fix color discrepancy
+    @-moz-document url-prefix() {
+      background: rgba(33, 39, 90, 0.75);
+    }
   }
   p:last-child {
     margin: 0;


### PR DESCRIPTION
# Description

The purpose of this PR is to add a hack to fix a color discrepancy in Firefox.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

Tested the homepage hero background color to match the video background color in various browsers.

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have added unit tests that prove my fix is effective or that my feature works