### PR TITLE
remove hero video from about page, update help banner color

### DIFF
--- a/pages/about/index.vue
+++ b/pages/about/index.vue
@@ -16,12 +16,6 @@
           NIH SPARC program website</a>
         to learn more.
       </p>
-      <img
-        v-if="heroImage"
-        slot="image"
-        class="page-hero-img"
-        :src="heroImage.fields.file.url"
-      />
     </page-hero>
     <div class="page-wrap container">
       <div class="subpage">

--- a/pages/help/index.vue
+++ b/pages/help/index.vue
@@ -118,7 +118,7 @@ export default Vue.extend<Data, Methods, never, never>({
 <style lang="scss" scoped>
 @import '@/assets/_variables.scss';
 .page-hero {
-  background-color: #383671;
+  background-color: #292b66;
   background-image: none;
   h2 {
     font-size: 2rem;


### PR DESCRIPTION
# Description

- Remove hero video from about page
- Update the banner color in the help page.


## Type of change
- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

1. Navigate to the About page.
2. Hero video will not display.

1. Navigate to the help page.
2. Banner color will be `#292b66`.

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
