### PR TITLE
Hotfix: Datasets Not Rendering

### DIFF
--- a/pages/data/index.vue
+++ b/pages/data/index.vue
@@ -32,7 +32,7 @@
       <el-row :gutter="32" type="flex">
         <el-col :span="24">
           <div class="search-heading">
-            <p v-if="!isLoadingSearch && searchData.items.length">
+            <p v-show="!isLoadingSearch && searchData.items.length">
               {{ searchHeading }} | Showing
               <pagination-menu
                 :page-size="searchData.limit"


### PR DESCRIPTION
# Description

This PR is to handle an issue where, on refresh, the datasets do not load on the Find Data page. 

**Note:** This issue only happens on refresh, not initial load.

Working on this, I discovered some strange behavior that is definitely tied to Nuxt's SSR. When running locally, if you navigate to the Find Data page and refresh, the table is rendered with duplicated content:
![Screen Shot 2020-06-01 at 2 28 30 PM](https://user-images.githubusercontent.com/55994045/83441482-9982aa80-a414-11ea-8553-05c70ca99710.png)

When refreshing in dev or prod, the content doesn't render:
![Screen Shot 2020-06-01 at 10 52 59 AM](https://user-images.githubusercontent.com/55994045/83441535-ac957a80-a414-11ea-8480-f2125373977c.png)

I believe these are the same issue and it stems from an error in which the server-rendered and client-rendered content do not match. The specific content is the `searchData.total` on the top left of the table. Nuxt renders it as:
- "undefined Datasets | Showing"

While the client renders:
- "{some number} Datasets | Showing"

Console printout:
<img width="1280" alt="Screen Shot 2020-06-01 at 2 22 37 PM" src="https://user-images.githubusercontent.com/55994045/83441972-65f45000-a415-11ea-8432-f63f201fef34.png">


The only solution I found was to change the directive of the pagination menu area from `v-if` to a `v-show`, such that the content is mounted regardless of the mismatch. However, I think this is only a sort-term fix and may cause issues with the inherit SSR nature of Nuxt. 

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

Navigate to the Find Data page.
Refresh multiple times.
The datasets display properly.


# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
