### PR TITLE
Remove unused command in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,9 +15,6 @@ $ yarn dev
 # build for production and launch server
 $ yarn build
 $ yarn start
-
-# generate static project
-$ yarn generate
 ```
 
 For detailed explanation on how things work, check out [Nuxt.js docs](https://nuxtjs.org).


### PR DESCRIPTION
# Description

The purpose of this PR is to remove the unused `yarn generate` command from the readme. We are using a server side rendered app, so this command to generate a static site isn't being used.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

N/A

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code