### PR TITLE
Add nuxt generate command

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,6 +8,7 @@
     "dev": "nuxt",
     "build": "nuxt build",
     "start": "nuxt start",
+    "generate": "nuxt generate",
     "heroku-postbuild": "npm run build",
     "lint": "eslint --ext .js,.vue --ignore-path .gitignore .",
     "lintfix": "eslint --fix --ext .js,.vue --ignore-path .gitignore .",


### PR DESCRIPTION
# Description

The purpose of this PR is to add the `generate` script, which is a shortcut for `yarn nuxt generate`. This will make the readme's commands match what is supported in the app.

## Type of change
- [x] Documentation

# How Has This Been Tested?

N/A

# Checklist:

- [x] My code follows the style guidelines of this project
- [x]I have performed a self-review of my own code