### PR TITLE
Moved protocol links to Description tab

### DIFF
--- a/components/DatasetDetails/DatasetAboutInfo.vue
+++ b/components/DatasetDetails/DatasetAboutInfo.vue
@@ -13,27 +13,6 @@
           {{ doi }}
         </a>
       </p>
-      <el-row type="flex" justify="center" class="protocol-block">
-        <el-col :span="24">
-          <h3>
-            Protocol Links
-          </h3>
-          <div v-if="datasetRecords.length !== 0">
-            <a
-              v-for="(record, index) in datasetRecords"
-              :key="`${record}-${index}`"
-              :href="record.properties.url"
-              target="_blank"
-              class="dataset-about-info__container--protocol-text"
-            >
-              {{ record.properties.url }}
-            </a>
-          </div>
-          <div v-else class="dataset-about-info__container--protocol-text-na">
-            <p>N/A</p>
-          </div>
-        </el-col>
-      </el-row>
       <h3>NIH Award</h3>
       <p>{{ getSparcAwardNumber }}</p>
       <h3>Cite This Dataset</h3>
@@ -120,11 +99,6 @@ export default {
     doiValue: {
       type: String,
       default: ''
-    },
-
-    datasetRecords: {
-      type: Array,
-      default: () => []
     },
 
     datasetTags: {

--- a/components/DatasetDetails/DatasetDescriptionInfo.vue
+++ b/components/DatasetDetails/DatasetDescriptionInfo.vue
@@ -1,9 +1,37 @@
 <template>
-  <div class="dataset-description-info">
+  <div v-loading="loadingMarkdown" class="dataset-description-info">
     <div
-      v-loading="loadingMarkdown"
       class="col-xs-12 description-container"
-      v-html="parseMarkdown(markdown)"
+      v-html="parseMarkdown(markdown.markdownTop)"
+    />
+    <div class="description-container__protocol-block">
+      <p>
+        <strong>
+          Protocol Links:
+        </strong>
+      </p>
+      <div v-if="datasetRecords.length !== 0">
+        <a
+          v-for="(record, index) in datasetRecords"
+          :key="`${record}-${index}`"
+          :href="record.properties.url"
+          target="_blank"
+          class="description-container__protocol-block--protocol-text"
+        >
+          {{ record.properties.url }}
+        </a>
+      </div>
+      <div
+        v-else
+        class="description-container__protocol-block--protocol-text-na"
+      >
+        <p>N/A</p>
+      </div>
+    </div>
+    <div
+      v-if="markdown.markdownBottom"
+      class="col-xs-12 description-container"
+      v-html="parseMarkdown(markdown.markdownBottom)"
     />
   </div>
 </template>
@@ -22,8 +50,12 @@ export default {
       default: false
     },
     markdown: {
-      type: String,
-      default: ''
+      type: Object,
+      default: () => {}
+    },
+    datasetRecords: {
+      type: Array,
+      default: () => []
     }
   }
 }
@@ -36,7 +68,6 @@ export default {
     color: #000;
     font-size: 16px;
     line-height: 24px;
-    padding-bottom: 92px;
 
     h1,
     p,
@@ -119,6 +150,24 @@ export default {
       code {
         font-weight: normal;
         font-size: 14px;
+      }
+    }
+
+    &__protocol-block {
+      margin-bottom: 16px;
+
+      p {
+        margin-bottom: 4px;
+      }
+
+      &--protocol-text {
+        color: black;
+        text-decoration: none;
+        font-size: 0.875em;
+      }
+
+      &--protocol-text-na {
+        font-size: 0.875em;
       }
     }
   }

--- a/pages/datasets/_datasetId.vue
+++ b/pages/datasets/_datasetId.vue
@@ -130,6 +130,7 @@
         <dataset-description-info
           v-show="activeTab === 'description'"
           :markdown="markdown"
+          :dataset-records="datasetRecords"
           :loading-markdown="loadingMarkdown"
         />
         <dataset-about-info
@@ -137,7 +138,6 @@
           :updated-date="lastUpdatedDate"
           :doi="datasetDOI"
           :doi-value="datasetInfo.doi"
-          :dataset-records="datasetRecords"
           :dataset-tags="datasetTags"
         />
         <dataset-files-info
@@ -285,7 +285,7 @@ export default {
       isLoadingDataset: false,
       errorLoading: false,
       loadingMarkdown: false,
-      markdown: '',
+      markdown: {},
       activeTab: 'about',
       datasetRecords: [],
       discover_host: process.env.discover_api_host,
@@ -634,7 +634,14 @@ export default {
           .then(response => response.text())
           .then(response => {
             this.loadingMarkdown = false
-            this.markdown = response
+            const splitDelim = '\n\n---'
+            const splitResponse = response.split(splitDelim)
+            this.markdown = {
+              markdownTop: splitResponse[0],
+              markdownBottom: splitResponse[1]
+                ? splitDelim + splitResponse[1]
+                : ''
+            }
           })
           .catch(error => {
             throw error


### PR DESCRIPTION
# Description

Moved protocol links from the About tab to the Description tab.

**NOTE:** This was a little funky. Since we are fetching the entire markdown string for the description, I had to split the string where the protocol links are supposed to go. I'm not a huge fan of how I had to do this because there could be some issues when the markdown is not correctly formatted, although it works for now. I couldn't think of a better way. Let me know if there's a better/more optimized way to do this.


## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

1. Navigate to Find Data page.
2. Click on any dataset.
3. Protocol links will be in description tab below primary conclusion.
4. Got to About tab.
5. Protocol links will not be displayed.


# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code