### PR TITLE
Fix Style and Link Label

### DIFF
--- a/components/DatasetDetails/DatasetFilesInfo.vue
+++ b/components/DatasetDetails/DatasetFilesInfo.vue
@@ -45,9 +45,9 @@ export default {
 @import '@/assets/_variables.scss';
 .dataset-files-info {
   .dataset-link {
-    font-size: 12px;
+    font-size: 0.75rem;
     font-weight: bold;
-    margin-bottom: 10px;
+    margin-bottom: 0.625rem;
     text-decoration: none;
   }
 }

--- a/components/DatasetDetails/DatasetFilesInfo.vue
+++ b/components/DatasetDetails/DatasetFilesInfo.vue
@@ -1,5 +1,18 @@
 <template>
   <div class="dataset-files-info">
+    <div class="dataset-link">
+      <nuxt-link
+        :to="{
+          name: 'help-helpId',
+          params: {
+            helpId: ctfDatasetNavigationInfoPageId
+          }
+        }"
+        class="dataset-link"
+      >
+        Learn more about navigating a SPARC dataset
+      </nuxt-link>
+    </div>
     <files-table :dataset-details="datasetDetails" />
   </div>
 </template>
@@ -17,9 +30,25 @@ export default {
     datasetDetails: {
       type: Object,
       default: () => {}
-    },
+    }
   },
+
+  data() {
+    return {
+      ctfDatasetNavigationInfoPageId: process.env.ctf_dataset_navigation_info_page_id
+    }
+  }
 }
 </script>
 
-<style lang="scss" scoped></style>
+<style lang="scss" scoped>
+@import '@/assets/_variables.scss';
+.dataset-files-info {
+  .dataset-link {
+    font-size: 12px;
+    font-weight: bold;
+    margin-bottom: 10px;
+    text-decoration: none;
+  }
+}
+</style>

--- a/nuxt.config.js
+++ b/nuxt.config.js
@@ -46,7 +46,7 @@ export default {
     ctf_support_page_id: '59F0dM5goobqjw3TsqINRw',
     ctf_home_page_id: '4qJ9WUWXg09FAUvCnbGxBY',
     ctf_news_and_events_page_id: '4IoMamTLRlN3OpxT1zgnU',
-    ctf_dataset_format_info_page_id: '3FXikFXC8shPRd8xZqhjVT',
+    ctf_dataset_navigation_info_page_id: 'qvEcnv56c76V0JC0KvtSd',
     ctf_project_id: 'sparcAward',
     ctf_organ_id: 'organ',
     ctf_filter_id: '6bya4tyw8399',

--- a/pages/datasets/_datasetId.vue
+++ b/pages/datasets/_datasetId.vue
@@ -107,17 +107,6 @@
           <button class="dataset-button" @click="isDownloadModalVisible = true">
             Get Dataset
           </button>
-          <nuxt-link
-            :to="{
-              name: 'help-helpId',
-              params: {
-                helpId: ctfDatasetFormatInfoPageId
-              }
-            }"
-            class="dataset-link"
-          >
-            SPARC Data Structure
-          </nuxt-link>
         </div>
       </div>
     </details-header>
@@ -309,8 +298,7 @@ export default {
           label: 'Find Data'
         }
       ],
-      subtitles: [],
-      ctfDatasetFormatInfoPageId: process.env.ctf_dataset_format_info_page_id
+      subtitles: []
     }
   },
 


### PR DESCRIPTION
# Description

- Moved SPARC Dataset Structure link to files table.
- Changed link to direct to Navigating a SPARC Dataset help page.
- Changed link label to represent link target

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

1. Navigate to the Find Data page.
2. Select any dataset.
3. SPARC Dataset Structure will not be next to the Get Dataset button.
4. Go to the Files tab.
5. Link labeled as "Learn more about navigating a SPARC dataset" will be above the files breadcrumb.
6. Click on the link.
7. You will be navigated to the Navigating a SPARC Dataset help page.


# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added unit tests that prove my fix is effective or that my feature works
