### PR TITLE
Project detail and list truncation CU-7pg8up CU-7pg95y

### DIFF
--- a/components/DetailsHeader/DetailsHeader.vue
+++ b/components/DetailsHeader/DetailsHeader.vue
@@ -20,7 +20,11 @@
             {{ fullDescription ? description : formatDescription(description) }}
           </p>
           <p class="details-header__container--content-description-mobile">
-            {{ formatMobileDescription(description) }}
+            {{
+              fullDescription
+                ? description
+                : formatMobileDescription(description)
+            }}
           </p>
           <slot name="meta content" />
         </div>

--- a/components/SearchResults/ProjectSearchResults.vue
+++ b/components/SearchResults/ProjectSearchResults.vue
@@ -1,5 +1,9 @@
 <template>
-  <el-table :data="tableData" empty-text="No Results" @sort-change="onSortChange">
+  <el-table
+    :data="tableData"
+    empty-text="No Results"
+    @sort-change="onSortChange"
+  >
     <el-table-column
       :fixed="true"
       sortable="custom"
@@ -21,7 +25,7 @@
     </el-table-column>
     <el-table-column prop="fields.description" label="Description" width="648">
       <template slot-scope="scope">
-        {{ truncateField(scope.row.fields.description, 500) }}
+        {{ scope.row.fields.shortDescription || '' }}
       </template>
     </el-table-column>
     <el-table-column
@@ -29,7 +33,12 @@
       label="Institution"
       width="200"
     />
-    <el-table-column sortable="custom" prop="fields.awardId" label="NIH Award" width="150" />
+    <el-table-column
+      sortable="custom"
+      prop="fields.awardId"
+      label="NIH Award"
+      width="150"
+    />
 
     <el-table-column
       sortable="custom"

--- a/pages/projects/_projectId.vue
+++ b/pages/projects/_projectId.vue
@@ -4,6 +4,7 @@
       :subtitle="projectSection"
       :title="fields.title"
       :description="fields.description"
+      :full-description="true"
       :breadcrumb="breadcrumb"
     >
       <img


### PR DESCRIPTION
# Description

The purpose of this PR is to remove truncation of the description on a project's page, and add support for a short description field on the projects list (find data.)
 ## Project detail
![localhost_3000_data_type=sparcAward (1)](https://user-images.githubusercontent.com/1493195/85319587-bf3d2580-b48f-11ea-9235-36b47ff4735d.png)

## Project list
![localhost_3000_data_type=sparcAward](https://user-images.githubusercontent.com/1493195/85319592-bfd5bc00-b48f-11ea-80c8-9e17951abdc5.png)


## Type of change

- [x] New feature (non-breaking change which adds functionality)

# How Has This Been Tested?

- Go to the [Find Data projects page](http://localhost:3000/data?type=sparcAward)
- The first project "Mapping the linkage between auricular vagus nerve receptors and visceral organ modulation" should be showing its short description. _This is the only project that has been updated at the moment to support the new short description field_
- Open this [project](http://localhost:3000/projects/6O6hZNUoEapRCpgztIkKEQ)
- The full description should be displayed on all viewports.

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
