### PR TITLE
Crosscite error message cu 5ygtye

### DIFF
--- a/components/DatasetDetails/DatasetAboutInfo.vue
+++ b/components/DatasetDetails/DatasetAboutInfo.vue
@@ -258,10 +258,7 @@ export default {
       this.$axios
         .get(url)
         .then(response => {
-          return response.data
-        })
-        .then(data => {
-          this.citationText = data
+          this.citationText = response.data
         })
         .catch(() => {
           this.hasCitationError = true


### PR DESCRIPTION
# Description

Display a formatted error message when crosscite fails.

## Tickets
[Clickup](https://app.clickup.com/t/5ygtye)
[Wrike](https://www.wrike.com/open.htm?id=491145983)

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

1. In `DatasetAboutInfo.vue` on line 257, change the crosscite endpoint url to `[...]/dontformat[...]` to simulate an error.
2. Navigate to Find Data page.
3. Select any dataset.
4. Click on the About tab.
5. Citation area will display a formatted error message.
6. Copy citation button will be disabled.

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
