### PR TITLE
feat(Support Center): Highlight search terms in results CU-7pg719

### DIFF
--- a/components/HelpCard/HelpCard.vue
+++ b/components/HelpCard/HelpCard.vue
@@ -7,7 +7,7 @@
         {{ helpItem.fields.title || '' }}
       </nuxt-link>
     </h3>
-    <p>{{ helpItem.fields.summary || '' }}</p>
+    <p v-html="highlightText(searchTerms, helpItem.fields.summary || '')" />
   </div>
 </template>
 
@@ -15,8 +15,15 @@
 import Vue from 'vue';
 import {HelpDocument} from "~/pages/help/model";
 
-export default Vue.extend<never, never, never, { helpItem: HelpDocument }>({
+import HighlightText from '@/mixins/highlight-text'
+
+export default Vue.extend<never, never, never, { helpItem: HelpDocument, searchTerms: string }>({
   name: 'HelpCard',
+
+  mixins: [
+    HighlightText
+  ],
+
   props: {
     helpItem: {
       type: Object,
@@ -26,6 +33,10 @@ export default Vue.extend<never, never, never, { helpItem: HelpDocument }>({
           fields: {}
         } as HelpDocument
       }
+    },
+    searchTerms: {
+      type: String,
+      default: ''
     }
   }
 })

--- a/components/HelpSection/HelpSection.vue
+++ b/components/HelpSection/HelpSection.vue
@@ -18,6 +18,7 @@
                 v-for="(item, index) in section.fields.helpDocuments"
                 :key="`${item}-${index}`"
                 :help-item="item"
+                :search-terms="searchTerms"
               />
             </div>
           </div>

--- a/mixins/highlight-text/index.js
+++ b/mixins/highlight-text/index.js
@@ -1,0 +1,22 @@
+import { defaultTo, head } from 'ramda'
+
+export default {
+  methods: {
+    /**
+     * Replaces matched search text with bolded version
+     * @param {String} needle
+     * @param {String} stack
+     */
+    highlightText: function(needle, stack) {
+      if (!needle) {
+        return stack || ''
+      }
+      const regex = new RegExp(needle, 'gi')
+      const matched = stack.match(regex)
+      if (matched && matched.length >= 1) {
+        return stack.replace(regex, `<strong>${matched[0]}</strong>`)
+      }
+      return this.$sanitize(stack, ['strong'])
+    }
+  }
+}


### PR DESCRIPTION
# Description

The purpose of this PR is to highlight search terms in results on the support center.

## Tickets
[ClickUp](https://app.clickup.com/t/7pg719)
[Wrike](https://www.wrike.com/workspace.htm?acc=3203588#path=folder&t=488219710&a=3203588&id=441356195&st=space-441356195)

## Type of change

- [x] New feature (non-breaking change which adds functionality)

# How Has This Been Tested?

- Click on the "Need Help?" link in the header
- Enter a search term like "SPARC"
- All instances matching your search term should be bold.

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
