### PR TITLE
Update citation border style

### DIFF
--- a/components/DatasetDetails/DatasetAboutInfo.vue
+++ b/components/DatasetDetails/DatasetAboutInfo.vue
@@ -341,7 +341,7 @@ export default {
     }
 
     &--citation-links {
-      border-bottom: 1px solid black;
+      border-bottom: 1px solid #E4E7ED;
       display: flex;
       flex-wrap: wrap;
       list-style: none;


### PR DESCRIPTION
# Description

Quick style update for the citations area based on updated designs provided by Gazelle. Border is now light gray.
[Designs](https://share.goabstract.com/f93d41ce-bfd5-4b25-b8f6-18afd7f06036)

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

1. Navigate to Find Data page.
2. Select any dataset
3. Go to About tab.
4. Border under citation names will be light gray and not black as it was previously.


# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
