### PR TITLE
Add Dataset Owner Contact Info

### DIFF
--- a/components/DatasetDetails/DatasetAboutInfo.vue
+++ b/components/DatasetDetails/DatasetAboutInfo.vue
@@ -3,6 +3,11 @@
     <div class="dataset-about-info__container">
       <h3>Last Updated</h3>
       <p>{{ updatedDate }}</p>
+      <h3>Contact Information</h3>
+      <p>
+        {{ datasetOwnerName }}<br />
+        {{ datasetOwnerEmail }}
+      </p>
       <h3>Dataset DOI</h3>
       <p>
         <a
@@ -120,6 +125,16 @@ export default {
     datasetTags: {
       type: Array,
       default: () => []
+    },
+
+    datasetOwnerName: {
+      type: String,
+      default: ''
+    },
+
+    datasetOwnerEmail: {
+      type: String,
+      default: ''
     }
   },
 

--- a/pages/datasets/_datasetId.vue
+++ b/pages/datasets/_datasetId.vue
@@ -139,6 +139,8 @@
           :doi="datasetDOI"
           :doi-value="datasetInfo.doi"
           :dataset-tags="datasetTags"
+          :dataset-owner-name="datasetOwnerName"
+          :dataset-owner-email="datasetOwnerEmail"
         />
         <dataset-files-info
           v-show="activeTab === 'files'"
@@ -242,6 +244,17 @@ export default {
     } else {
       datasetDetails = await $axios.$get(datasetUrl)
     }
+
+    const datasetOwnerId = datasetDetails.ownerId || ''
+    const datasetOwnerEmail = await $axios
+      .$get(`${process.env.portal_api}/get_owner_email/${datasetOwnerId}`)
+      .then(response => {
+        return response.email
+      })
+      .catch(() => {
+        return ''
+      })
+    datasetDetails.ownerEmail = datasetOwnerEmail
 
     const imagesData = await $axios
       .$get(
@@ -431,6 +444,20 @@ export default {
       return this.isContributorListVisible
         ? this.datasetContributors
         : [last(this.datasetContributors)]
+    },
+
+    /**
+     * Returns dataset owner full name
+     * @returns {String}
+     */
+    datasetOwnerName: function() {
+      const ownerFirstName = this.datasetInfo.ownerFirstName || ''
+      const ownerLastName = this.datasetInfo.ownerLastName || ''
+      return `${ownerFirstName} ${ownerLastName}`
+    },
+
+    datasetOwnerEmail: function() {
+      return this.datasetInfo.ownerEmail || ''
     },
 
     /**

--- a/pages/datasets/_datasetId.vue
+++ b/pages/datasets/_datasetId.vue
@@ -456,6 +456,10 @@ export default {
       return `${ownerFirstName} ${ownerLastName}`
     },
 
+    /**
+     * Returns dataset owner email
+     * @returns {String}
+     */
     datasetOwnerEmail: function() {
       return this.datasetInfo.ownerEmail || ''
     },

--- a/pages/datasets/_datasetId.vue
+++ b/pages/datasets/_datasetId.vue
@@ -249,7 +249,7 @@ export default {
     const datasetOwnerEmail = await $axios
       .$get(`${process.env.portal_api}/get_owner_email/${datasetOwnerId}`)
       .then(response => {
-        return response.email
+        return response.data.email
       })
       .catch(() => {
         return ''


### PR DESCRIPTION
# Description

Add the dataset owner name and email to the About tab.

## Tickets
[7pg85v](https://app.clickup.com/t/7pg85v)
[Wrike](https://www.wrike.com/open.htm?id=490179111)

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

This cannot be tested locally for now due to CORS issues with the sparc api. When this is merged, it can be tested in staging with the following steps:

1. Navigate to the Find Data page.
2. Select any dataset.
3. Go to the about tab.
4. Contact information of dataset owner will be displayed.


# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas