### PR TITLE
Fix the owner email endpoint call

### DIFF
--- a/pages/datasets/_datasetId.vue
+++ b/pages/datasets/_datasetId.vue
@@ -248,8 +248,8 @@ export default {
     const datasetOwnerId = datasetDetails.ownerId || ''
     const datasetOwnerEmail = await $axios
       .$get(`${process.env.portal_api}/get_owner_email/${datasetOwnerId}`)
-      .then(response => {
-        return response.data.email
+      .then(resp => {
+        return resp.email
       })
       .catch(() => {
         return ''


### PR DESCRIPTION
# Description

Properly access the owner return object.

**Note:** If you want to test this locally, you will need to run the sparc-api locally and hook it up to the sparc-app as the sole portal api environment variable.


## Type of change

Delete those that don't apply.

- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

1. Navigate to the Find Data page.
2. Select any dataset.
3. Go to the about tab.
4. Contact information of dataset owner will be displayed.


# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
