### PR TITLE
Change SPARC Portal menu item Resources to Tools & Resources

### DIFF
--- a/components/header/Header.vue
+++ b/components/header/Header.vue
@@ -173,7 +173,7 @@ const links = [
   },
   {
     title: 'resources',
-    displayTitle: 'Resources',
+    displayTitle: 'Tools & Resources',
     href: `/resources?type=${process.env.ctf_resource_id}`
   },
   {
@@ -611,7 +611,7 @@ export default {
       display: inline;
       padding-right: 5rem;
       @media screen and (min-width: 1023px) {
-        padding-right: 2rem;
+        padding-right: 0.5rem;
       }
 
       a {

--- a/pages/resources/index.vue
+++ b/pages/resources/index.vue
@@ -2,7 +2,7 @@
   <div class="resources">
     <breadcrumb :breadcrumb="breadcrumb" :title="title" />
     <page-hero>
-      <h1>Resources</h1>
+      <h1>Tools &amp; Resources</h1>
       <p>
         {{ fields.heroCopy }}
       </p>
@@ -137,7 +137,7 @@ export default Vue.extend<Data, Methods, Computed, never>({
 
   data() {
     return {
-      title: 'Resources',
+      title: 'Tools & Resources',
       breadcrumb: [
         {
           to: {


### PR DESCRIPTION
# Description

Change nav bar link "Resources" to "Tools & Resources". Also updates the spacing to maintain the style.

Looking at the style guidelines on abstract, I believe this change keeps it consistent. Let me know if it seems off compared to the designs.

## Tickets
[90h7e5](https://app.clickup.com/t/90h7e5)
[Wrike](https://www.wrike.com/open.htm?id=518220477)

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

1. Look at the nav bar.
2. "Tools & Resources" will be the third item.
3. Resize the browser to different sizes.
4. The nav bar will adjust appropriately.
5. Click on "Tools & Resources".
6. The page hero will say "Tools & Resources".
7. The breadcrumb will say "Tools & Resources".


# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
