### PR TITLE
Markdown support in page heros, and all markdown links should open in a new tab CU-90h6m7 CU-90h5zx CU-90h83a

### DIFF
--- a/components/PageHero/PageHero.vue
+++ b/components/PageHero/PageHero.vue
@@ -47,6 +47,10 @@ export default {
     @media (min-width: 64em) {
       max-width: 53rem;
     }
+    a {
+      color: #fff;
+      text-decoration: underline;
+    }
   }
   &__image {
     display: none;
@@ -82,9 +86,6 @@ export default {
     @-moz-document url-prefix() {
       background: rgba(33, 39, 90, 0.75);
     }
-  }
-  p:last-child {
-    margin: 0;
   }
 
   .row {

--- a/mixins/marked/index.js
+++ b/mixins/marked/index.js
@@ -1,7 +1,19 @@
 import marked from 'marked'
 
+/**
+ * Modify the link renderer to add `target="blank"`
+ * https://github.com/markedjs/marked/pull/1371#issuecomment-434320596
+ */
+const renderer = new marked.Renderer()
+
+renderer.link = function(href, title, text) {
+  const link = marked.Renderer.prototype.link.apply(this, arguments)
+  return link.replace('<a', "<a target='_blank'")
+}
+
 marked.setOptions({
-  sanitize: true
+  sanitize: true,
+  renderer
 })
 
 export default {

--- a/pages/about/index.vue
+++ b/pages/about/index.vue
@@ -3,19 +3,9 @@
     <breadcrumb :breadcrumb="breadcrumb" :title="pageTitle" />
     <page-hero v-if="heroCopy">
       <h1>{{ pageTitle }}</h1>
-      <p>
-        {{ heroCopy }}
-      </p>
-      <p>
-        Visit the
-        <a
-          class="about-page-link"
-          href="https://commonfund.nih.gov/sparc/"
-          target="_blank"
-        >
-          NIH SPARC program website</a>
-        to learn more.
-      </p>
+      <!-- eslint-disable vue/no-v-html -->
+      <!-- marked will sanitize the HTML injected -->
+      <div v-html="parseMarkdown(heroCopy)" />
     </page-hero>
     <div class="page-wrap container">
       <div class="subpage">

--- a/pages/data/index.vue
+++ b/pages/data/index.vue
@@ -3,6 +3,9 @@
     <breadcrumb :breadcrumb="breadcrumb" title="Find Data" />
 
     <page-hero>
+      <h1>
+        Find Data
+      </h1>
       <search-form
         v-model="searchQuery"
         :q="q"

--- a/pages/index.vue
+++ b/pages/index.vue
@@ -4,9 +4,9 @@
       <h1 v-if="heroHeading">
         {{ heroHeading }}
       </h1>
-      <p>
-        {{ heroCopy }}
-      </p>
+      <!-- eslint-disable vue/no-v-html -->
+      <!-- marked will sanitize the HTML injected -->
+      <div v-html="parseMarkdown(heroCopy)" />
       <a v-if="heroButtonLink" class="btn-link" :href="heroButtonLink">
         <el-button class="uppercase">
           {{ heroButtonLabel }}
@@ -41,6 +41,7 @@ import HomepageTestimonials from '@/components/HomepageTestimonials/HomepageTest
 import HomepageTwitter from '@/components/HomepageTwitter/HomepageTwitter.vue'
 
 import createClient from '@/plugins/contentful.js'
+import marked from '@/mixins/marked/index'
 
 const client = createClient()
 export default {
@@ -53,6 +54,8 @@ export default {
     HomepageTestimonials,
     HomepageTwitter
   },
+
+  mixins: [marked],
 
   asyncData() {
     return Promise.all([

--- a/pages/resources/index.vue
+++ b/pages/resources/index.vue
@@ -3,9 +3,9 @@
     <breadcrumb :breadcrumb="breadcrumb" :title="title" />
     <page-hero>
       <h1>Resources</h1>
-      <p>
-        {{ fields.heroCopy }}
-      </p>
+      <!-- eslint-disable vue/no-v-html -->
+      <!-- marked will sanitize the HTML injected -->
+      <div v-html="parseMarkdown(fields.heroCopy)" />
       <search-controls-contentful
         placeholder="Search resources"
         path="/resources"
@@ -86,6 +86,7 @@ import PaginationMenu from '@/components/Pagination/PaginationMenu.vue'
 import createClient from '@/plugins/contentful.js'
 import SearchControlsContentful from '@/components/SearchControlsContentful/SearchControlsContentful.vue';
 import { Computed, Data, Methods, Resource } from '~/pages/resources/model';
+import marked from '@/mixins/marked/index'
 
 const client = createClient()
 
@@ -115,6 +116,8 @@ const tabTypes = [
 
 export default Vue.extend<Data, Methods, Computed, never>({
   name: 'Resources',
+
+  mixins: [marked],
 
   components: {
     SearchControlsContentful,

--- a/test/MarkdownTest/MarkdownTest.spec.js
+++ b/test/MarkdownTest/MarkdownTest.spec.js
@@ -1,0 +1,15 @@
+import { mount } from '@vue/test-utils'
+import MarkdownTest from './MarkdownTest'
+
+describe('MarkdownTest', () => {
+  const wrapper = mount(MarkdownTest)
+
+  it('Renders the correct markup', () => {
+    expect(wrapper.find('a').exists()).toBe(true)
+    expect(wrapper.find('h1').exists()).toBe(true)
+  })
+
+  it('Adds target="blank" to links', () => {
+    expect(wrapper.find('a').element.getAttribute('target')).toBe('_blank')
+  })
+})

--- a/test/MarkdownTest/MarkdownTest.vue
+++ b/test/MarkdownTest/MarkdownTest.vue
@@ -1,0 +1,24 @@
+<template>
+  <!-- eslint-disable vue/no-v-html -->
+  <!-- marked will sanitize the HTML injected -->
+  <div v-html="parseMarkdown(markdown)" />
+</template>
+
+<script>
+import MarkedMixin from '@/mixins/marked'
+
+export default {
+  name: 'MarkdownTest',
+
+  mixins: [MarkedMixin],
+
+  data() {
+    return {
+      markdown: `[go to SPARC](https://sparc.science) \n # This is a heading
+      `
+    }
+  }
+}
+</script>
+
+<style lang="scss" scoped></style>


### PR DESCRIPTION
# Description

The purpose of this PR is to add markdown support for all page heros, and to have all markdown links open in a new tab.

## ClickUp Tickets
[CU-90h6m7](https://app.clickup.com/t/90h6m7)
[CU-90h5zx](https://app.clickup.com/t/90h5zx)
[CU-90h83a](https://app.clickup.com/t/90h83a)

## Wrike Tickets
https://www.wrike.com/open.htm?id=511079440
https://www.wrike.com/open.htm?id=519660261
https://www.wrike.com/open.htm?id=503776942

## Type of change

- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)

# How Has This Been Tested?

- All page's heros should be rendering the same as non-prod
- The [about page](http://localhost:3000/about) hero should have two paragraphs and a link. This link should open in a new tab. This content is all in Contentful, which proves that the markdown parsing renders links to open in tabs.

MarkdownTest should pass

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
