### PR TITLE
Hotfix: Use fetch instead of axios for citations

### DIFF
--- a/components/DatasetDetails/DatasetAboutInfo.vue
+++ b/components/DatasetDetails/DatasetAboutInfo.vue
@@ -270,10 +270,15 @@ export default {
       this.activeCitation = citationType
       // find all citation types at https://github.com/citation-style-language/style
       const url = `${this.crosscite_host}/format?doi=${this.doiValue}&style=${citationType.type}&lang=en-US`
-      this.$axios
-        .get(url)
+      fetch(url)
         .then(response => {
-          this.citationText = response.data
+          if (response.status !== 200) {
+            throw Error
+          }
+          return response.text()
+        })
+        .then(text => {
+          this.citationText = text
         })
         .catch(() => {
           this.hasCitationError = true


### PR DESCRIPTION
# Description

Firefox and Safari fail `Axios` GET request for citations endpoint. Switched to `Fetch`.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

On Chrome, Safari, and Firefox:

1. Navigate to Find Data page.
2. Select any dataset.
3. Go to About tab.
4. Select citation styles.
5. Citations will populate properly.


# Checklist:

- [x] My code follows the style guidelines of this project
