### PR TITLE
Remove Find Data heading

### DIFF
--- a/pages/data/index.vue
+++ b/pages/data/index.vue
@@ -3,9 +3,6 @@
     <breadcrumb :breadcrumb="breadcrumb" title="Find Data" />
 
     <page-hero>
-      <h1>
-        Find Data
-      </h1>
       <search-form
         v-model="searchQuery"
         :q="q"


### PR DESCRIPTION
# Description

The purpose of this PR is to remove the Find Data heading. This needs to go out on normal release, and not mid-sprint.

## Type of change

- [x] New feature (non-breaking change which adds functionality)

# How Has This Been Tested?

The Find Data page should have no heading in the hero.

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
