### PR TITLE
Consistency in Find Data naming

### DIFF
--- a/components/FeaturedData/FeaturedData.vue
+++ b/components/FeaturedData/FeaturedData.vue
@@ -1,6 +1,6 @@
 <template>
   <div class="featured-data container">
-    <h2>Browse Data by Category</h2>
+    <h2>Find Data by Category</h2>
     <div class="data-wrap">
       <nuxt-link
         v-for="item in featuredData"


### PR DESCRIPTION
# Description

Change the "Browse Data ..." heading to "Find Data ..."
The "Explore Data" button was changed in Contentful

## Tickets
[90h5th](https://app.clickup.com/t/90h5th)
[Wrike](https://www.wrike.com/open.htm?id=492740021)

## Type of change
- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

1. Navigate to the homepage.
2. Explore Data button will read Find Data.
3. Browse Data heading will read Find Data.


# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
