### PR TITLE
Apply style to DOI and protocol links

### DIFF
--- a/components/DatasetDetails/DatasetAboutInfo.vue
+++ b/components/DatasetDetails/DatasetAboutInfo.vue
@@ -405,8 +405,9 @@ export default {
     }
 
     &--doi-link {
-      color: black;
+      color: $median;
       text-decoration: none;
+      font-weight: 500;
     }
   }
 }

--- a/components/DatasetDetails/DatasetDescriptionInfo.vue
+++ b/components/DatasetDetails/DatasetDescriptionInfo.vue
@@ -62,6 +62,7 @@ export default {
 </script>
 
 <style lang="scss" scoped>
+@import '@/assets/_variables.scss';
 .dataset-description-info {
   // Markdown styles
   .description-container {
@@ -161,9 +162,9 @@ export default {
       }
 
       &--protocol-text {
-        color: black;
+        color: $median;
         text-decoration: none;
-        font-size: 0.875em;
+        font-weight: 500;
       }
 
       &--protocol-text-na {


### PR DESCRIPTION
# Description

Style DOI and protocol links according to the [designs](https://app.abstract.com/projects/e709ca90-5ba9-11e9-9eaa-59df656d954a/branches/master/commits/latest/files/CD711200-A81D-447E-A416-7EC0284A48C1/layers/32510A4E-0CE5-4EF7-BCBA-69840C184F90?collectionId=d5e9f917-15c3-4c21-8e2e-f0260cd92536&collectionLayerId=ec13cb81-7eda-4fff-8bc1-d635ee2cf8a2&mode=build&selected=root-703EBC5D-4A2D-4B45-BDC8-A3A7DCFE7C66). The designs use a `font-size` of `16px` but the About tab is all `14px`, so I left the DOI link at `14px` because it would look too big compared to the rest of the text.

## Tickets
[90h5hh](https://app.clickup.com/t/90h5hh)
[Wrike](https://www.wrike.com/open.htm?id=491181541)

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

1. Navigate to a dataset with protocol links (http://localhost:3000/datasets/62?type=dataset).
2. The Description tab with have protocol links styled per the designs.
3. Go to the About tab, the DOI link will be style per the designs.


# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
