### PR TITLE
Add support for Future Plans section in about page

### DIFF
--- a/pages/about/index.vue
+++ b/pages/about/index.vue
@@ -42,6 +42,14 @@
           </div>
         </div>
       </div>
+
+      <div class="subpage">
+        <div class="row">
+          <div class="subpage-col">
+            <div class="about-page-text" v-html="parseMarkdown(futurePlans)" />
+          </div>
+        </div>
+      </div>
     </div>
   </div>
 </template>


### PR DESCRIPTION
# Description

Adds support for "Future Plans" section in the About page, which will be filled with relevant information once it's added in Contentful.


## Type of change

- [x] New feature (non-breaking change which adds functionality)

# How Has This Been Tested?

1. Navigate to the About page.
2. At the bottom is a clearly defined area for the Future Plans information.
3. For now, it just renders "Lorem Ipsum".


# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
