### PR TITLE
Fix event date logic

### DIFF
--- a/components/EventCard/EventCard.vue
+++ b/components/EventCard/EventCard.vue
@@ -59,11 +59,9 @@ export default {
     eventDate: function(event) {
       const startDate = this.formatDate(event.fields.startDate || '')
       const endDate = this.formatDate(event.fields.endDate || '')
-      return startDate === endDate
+      return startDate === endDate || !endDate
         ? startDate
-        : endDate
-        ? `${startDate} - ${endDate}`
-        : startDate
+        : `${startDate} - ${endDate}`
     }
   }
 }

--- a/components/EventCard/EventCard.vue
+++ b/components/EventCard/EventCard.vue
@@ -53,13 +53,17 @@ export default {
       return pathOr('', ['fields', 'image', 'fields', 'title'], event)
     },
     /**
-     * Get event date range
+     * Get event date range, if there is no end date, default to start date
      * @returns {String}
      */
     eventDate: function(event) {
-      const startDate = this.formatDate(event.fields.startDate)
-      const endDate = this.formatDate(event.fields.endDate)
-      return startDate === endDate ? startDate : `${startDate} - ${endDate}`
+      const startDate = this.formatDate(event.fields.startDate || '')
+      const endDate = this.formatDate(event.fields.endDate || '')
+      return startDate === endDate
+        ? startDate
+        : endDate
+        ? `${startDate} - ${endDate}`
+        : startDate
     }
   }
 }

--- a/components/HomepageNews/HomepageNews.vue
+++ b/components/HomepageNews/HomepageNews.vue
@@ -105,11 +105,9 @@ export default {
     eventDate: function(event) {
       const startDate = this.formatDate(event.fields.startDate || '')
       const endDate = this.formatDate(event.fields.endDate || '')
-      return startDate === endDate
+      return startDate === endDate || !endDate
         ? startDate
-        : endDate
-        ? `${startDate} - ${endDate}`
-        : startDate
+        : `${startDate} - ${endDate}`
     },
     /**
      * Check if an event is upcoming, if there is no end date, default to start date

--- a/components/HomepageNews/HomepageNews.vue
+++ b/components/HomepageNews/HomepageNews.vue
@@ -99,23 +99,27 @@ export default {
       )
     },
     /**
-     * Get event date range
+     * Get event date range, if there is no end date, default to start date
      * @returns {String}
      */
     eventDate: function(event) {
-      const startDate = this.formatDate(event.fields.startDate)
-      const endDate = this.formatDate(event.fields.endDate)
-      return startDate === endDate ? startDate : `${startDate} - ${endDate}`
+      const startDate = this.formatDate(event.fields.startDate || '')
+      const endDate = this.formatDate(event.fields.endDate || '')
+      return startDate === endDate
+        ? startDate
+        : endDate
+        ? `${startDate} - ${endDate}`
+        : startDate
     },
     /**
-     * Check if an event is upcoming
+     * Check if an event is upcoming, if there is no end date, default to start date
      * @param {Object} item
      * @returns {Boolean}
      */
     isUpcoming: function(item) {
       const today = new Date()
-      const eventEndDate = pathOr('', ['fields', 'endDate'], item)
-      return Date.parse(eventEndDate) > Date.parse(today) ? true : false
+      const checkDate = item.fields.endDate || item.fields.startDate || ''
+      return Date.parse(checkDate) > Date.parse(today)
     }
   }
 }


### PR DESCRIPTION
# Description

When checking if an event is upcoming, default to start date if there is no end date. End date is not a required field in Contentful so this needs to be accounted for. Additionally, only display the start date if there is no end date. 

## Tickets
[Wrike](https://www.wrike.com/workspace.htm?acc=3203588#path=folder&t=530654681&a=3203588&id=441356195&st=space-441356195)

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

1. Navigate to the homepage.
2. Open chrome dev tools.
3. Find SparcHomepage/HomepageNews.
4. The `news` prop will be an array of all the events.
5. There will be a computed property named `upcomingNews` that is properly filtered based on end date or start date.

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
