### PR TITLE
Only show the future plans section if there is content

### DIFF
--- a/pages/about/index.vue
+++ b/pages/about/index.vue
@@ -43,7 +43,7 @@
         </div>
       </div>
 
-      <div v-if="hasFuturePlans" class="subpage">
+      <div v-if="futurePlans" class="subpage">
         <div class="row">
           <div class="subpage-col">
             <div class="about-page-text" v-html="parseMarkdown(futurePlans)" />
@@ -97,16 +97,8 @@ export default {
         }
       ],
       projectId: process.env.ctf_project_id,
-      heroImage: {}
-    }
-  },
-
-  computed: {
-    /**
-     * Compute if the future plans field is available
-     */
-    hasFuturePlans: function() {
-      return Boolean(this.futurePlans)
+      heroImage: {},
+      futurePlans: ''
     }
   }
 }

--- a/pages/about/index.vue
+++ b/pages/about/index.vue
@@ -43,7 +43,7 @@
         </div>
       </div>
 
-      <div class="subpage">
+      <div v-if="hasFuturePlans" class="subpage">
         <div class="row">
           <div class="subpage-col">
             <div class="about-page-text" v-html="parseMarkdown(futurePlans)" />
@@ -98,6 +98,15 @@ export default {
       ],
       projectId: process.env.ctf_project_id,
       heroImage: {}
+    }
+  },
+
+  computed: {
+    /**
+     * Compute if the future plans field is available
+     */
+    hasFuturePlans: function() {
+      return Boolean(this.futurePlans)
     }
   }
 }


### PR DESCRIPTION
# Description

The purpose of this PR is to only show the future plans section if there is content.

## Type of change

- [x] New feature (non-breaking change which adds functionality)

# How Has This Been Tested?

- I removed content for the future plans section in Contentful, and the section no longer appears.
- Using vue devtools, find the `AboutPage` component
- Change `futurePlans` to `# foo` and the section should render an `h1` with `foo` as its text.

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have added unit tests that prove my fix is effective or that my feature works
