### PR TITLE
fix(project): Hyperlink project award id to its nih report link

### DIFF
--- a/components/SearchResults/ProjectSearchResults.vue
+++ b/components/SearchResults/ProjectSearchResults.vue
@@ -38,7 +38,13 @@
       prop="fields.awardId"
       label="NIH Award"
       width="150"
-    />
+    >
+      <template slot-scope="scope">
+        <a :href="getNihReporterUrl(scope)" target="_blank">
+          {{ scope.row.fields.awardId }}
+        </a>
+      </template>
+    </el-table-column>
 
     <el-table-column
       sortable="custom"
@@ -89,6 +95,15 @@ export default {
       return scope.row.fields.institution.fields.logo
         ? scope.row.fields.institution.fields.logo.fields.file.description
         : ''
+    },
+
+    /**
+     * Get NIH RePORT Url
+     * @param {Object} scope
+     * @returns {String}
+     */
+    getNihReporterUrl: function(scope) {
+      return scope.row.fields.nihReporterUrl || '#'
     },
 
     onSortChange: function(payload) {


### PR DESCRIPTION
# Description

Link the project award id to its NIH RePORT url.

## Tickets
[ayqv4w](https://app.clickup.com/t/ayqv4w)
[wrike](https://www.wrike.com/open.htm?id=494581806)

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

Navigate to the project listing page.
Scroll over to the NIH award column.
All of the award ids will be a link to the project's respective NIH RePORT url.


# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
