### PR TITLE
feat(overview): Citation button in dataset details and increase contributor threshold

### DIFF
--- a/components/DatasetDetails/DatasetAboutInfo.vue
+++ b/components/DatasetDetails/DatasetAboutInfo.vue
@@ -28,7 +28,7 @@
           Blackfynn Discover
         </a>
       </p>
-      <div class="dataset-about-info__container--citation">
+      <div id="citationsArea" class="dataset-about-info__container--citation">
         <el-row type="flex" justify="center">
           <el-col :span="24">
             <ul class="dataset-about-info__container--citation-links">

--- a/pages/datasets/_datasetId.vue
+++ b/pages/datasets/_datasetId.vue
@@ -107,6 +107,9 @@
           <button class="dataset-button" @click="isDownloadModalVisible = true">
             Get Dataset
           </button>
+          <el-button class="citation-button" @click="scrollToCitations">
+            Cite Dataset
+          </el-button>
           <nuxt-link
             :to="{
               name: 'help-helpId',
@@ -616,7 +619,7 @@ export default {
 
     datasetContributors: {
       handler: function(val) {
-        if (val.length > 5) {
+        if (val.length > 15) {
           this.isContributorListVisible = false
         }
       },
@@ -702,6 +705,32 @@ export default {
           .catch(error => {
             throw error
           })
+      }
+    },
+
+    /**
+     * Get the citations area in the
+     * About tab by id
+     * @returns {Object}
+     */
+    getCitationsArea: function() {
+      return document.getElementById('citationsArea')
+    },
+
+    /**
+     * Scroll to the citations area
+     * in the About tab
+     */
+    scrollToCitations: function() {
+      const aboutTabType = tabs[1].type
+      if (this.activeTab != aboutTabType) {
+        this.setActiveTab(aboutTabType)
+        this.$nextTick(() =>
+          // Wait until Vue renders the About tab
+          this.getCitationsArea().scrollIntoView()
+        )
+      } else {
+        this.getCitationsArea().scrollIntoView()
       }
     }
   },
@@ -888,7 +917,22 @@ export default {
         font-weight: 500;
         text-transform: uppercase;
       }
-
+      .citation-button {
+        margin-left: 0.5rem;
+        padding-top: 0.688rem;
+        width: 8rem;
+        background: #f9f2fc;
+        border: 1px solid $median;
+        color: $median;
+        text-transform: uppercase;
+        &:hover {
+          color: #1a1489;
+        }
+        @media (max-width: 24em) {
+          margin-top: 10px;
+          margin-left: 0;
+        }
+      }
       .dataset-link {
         text-decoration: none;
       }


### PR DESCRIPTION
# Description

Acceptance Criteria:
- Add "Cite Dataset" button next to "Get Dataset" and link to bottom of About Page
- Display the whole the contributor list (remove ellipsis)

**Draft**
The threshold for the number of contributors to display before applying the ellipsis is still being decided on, but most probably will be 15 (refer to wrike comment thread). However, the code for this story is complete so in the meantime it can be reviewed and once the threshold number is confirmed, changed if needed and opened.

## Tickets
[ayqvwm](https://app.clickup.com/t/ayqvwm)
[wrike](https://www.wrike.com/open.htm?id=495964822)

## Type of change

- [x] New feature (non-breaking change which adds functionality)

# How Has This Been Tested?

1. Navigate to any dataset.
2. The list of contributors will not be shortened if there are 15 or less contributors.
3. Click the Cite Dataset button next to the Get Dataset button.
4. The tab will be changed to About.
5. The citation area will be scrolled into view.
6. Scroll back up to the dataset details header and click the Cite Dataset button again (staying on the About tab).
7. The citation area will be scrolled into view.


# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
