### PR TITLE
fix(footer): ToS link underline

### DIFF
--- a/components/footer/Footer.vue
+++ b/components/footer/Footer.vue
@@ -188,6 +188,7 @@ export default {
 
       a {
         color: $dark-gray;
+        display: inline-block;
       }
     }
   }
@@ -287,6 +288,7 @@ export default {
 
         a {
           color: $dark-gray;
+          display: inline-block;
         }
       }
     }


### PR DESCRIPTION
# Description

While working on [ayqvtz](https://app.clickup.com/t/ayqvtz), I noticed that the ToS link underline extended past the end of the word and included the space before the divider character. This PR is a quick fix for the styling.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

On all screen sizes and devices
1. Scroll to the bottom of any page.
2. ToS is styled properly.
This:
![Screen Shot 2020-08-31 at 10 31 03 AM](https://user-images.githubusercontent.com/55994045/91731796-518b3500-eb75-11ea-94a2-d7280fde279b.png)
Instead of:
![Screen Shot 2020-08-31 at 10 31 12 AM](https://user-images.githubusercontent.com/55994045/91731804-54862580-eb75-11ea-912b-8cc878ff7a9d.png)

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
