### PR TITLE
Add SPARC Glossary Link to Footer

### DIFF
--- a/components/footer/Footer.vue
+++ b/components/footer/Footer.vue
@@ -63,6 +63,11 @@
               SPARC Publications
             </a>
           </li>
+          <li>
+            <a href="https://sparc.science/help/3vcLloyvrvmnK3Nopddrka" target="_blank">
+              SPARC Glossary
+            </a>
+          </li>
         </ul>
         <h3>Help us Improve</h3>
         <ul>


### PR DESCRIPTION
# Description

The purpose of this PR is to add the SPARC Glossary link under the `Learn More` section in the footer.

## Type of change

- [x] New feature (non-breaking change which adds functionality)

# How Has This Been Tested?

Navigate to the homepage and scroll down to the footer. You should see the SPARC Glossary link under the `Learn More` header and it should navigate to the glossary page as expected.

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
