### PR TITLE
Make Materials Sharing Policy Visible for SPARC Users CU-ayqv82

### DIFF
--- a/components/footer/Footer.vue
+++ b/components/footer/Footer.vue
@@ -44,6 +44,11 @@
             </nuxt-link>
           </li>
           <li>
+            <a href="#" target="_blank">
+              Material Sharing Policy
+            </a>
+          </li>
+          <li>
             <a href="https://commonfund.nih.gov/sparc/awards" target="_blank">
               Funding Opportunities
             </a>

--- a/components/footer/Footer.vue
+++ b/components/footer/Footer.vue
@@ -44,7 +44,7 @@
             </nuxt-link>
           </li>
           <li>
-            <a href="#" target="_blank">
+            <a href="https://commonfund.nih.gov/sites/default/files/SPARC_material%20sharing%20policy%2026jan17_508.pdf" target="_blank">
               Material Sharing Policy
             </a>
           </li>


### PR DESCRIPTION
# Description

The purpose of this PR is to make the Materials Sharing Policy more visible for users on the SPARC Portal. The following has been done to achieve this:

- Add Materials Sharing Policy to link in footer
- Add paragraph about Materials Sharing Policy on About Page
- Add link to policy in the help section

## Type of change

- [x] New feature (non-breaking change which adds functionality)

# How Has This Been Tested?

1. Navigate to the portal and scroll to the footer. You should see `Material Sharing Policy` link underneath the `Learn More` section on the footer.
2. Navigate to the `About` page. You should see a paragraph on the Materials Sharing Policy underneath the goal section.
3. Navigate to the help section. An article to the policy with a PDF link should be found underneath the `SPARC For Investigators Only` section. Clicking on the link should open the policy in a PDF as expected.

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
