### PR TITLE
fix(projects): Fix font resizing in projects table on mobile

### DIFF
--- a/components/SearchResults/ProjectSearchResults.vue
+++ b/components/SearchResults/ProjectSearchResults.vue
@@ -136,6 +136,7 @@ export default {
   @media screen and (max-width: 48em) {
     margin-bottom: 0;
     font-size: 0.875em;
+    -webkit-text-size-adjust: 100%;
   }
 }
 </style>


### PR DESCRIPTION
# Description

This PR fixes a font resizing issue on mobile (specifically iOS). Ref: #186 

Thanks Cameron for debugging this one!

## Tickets
[ayquj5](https://app.clickup.com/t/ayquj5)

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

1. Use Browserstack or something similar to simulate a mobile environment.
2. Navigate to the Find Data page.
3. Click on the Projects tab.
4. The description font-size will be correct.

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
