### PR TITLE
feat(Homepage Hero): Image and proper brand color

### DIFF
--- a/components/PageHero/PageHero.vue
+++ b/components/PageHero/PageHero.vue
@@ -26,8 +26,10 @@ export default {
 </script>
 
 <style lang="scss">
+@import '../../assets/_variables.scss';
+
 .page-hero {
-  background: #292b66;
+  background: $navy;
   color: #f0f2f5;
   font-size: 1em;
   line-height: 1.5rem;
@@ -36,10 +38,6 @@ export default {
     font-size: 1.25em;
     line-height: 2rem;
     padding: 2.5rem 0;
-  }
-  // Firefox hack to fix color discrepancy
-  @-moz-document url-prefix() {
-    background: #21275a;
   }
   &__copy {
     position: relative;
@@ -56,8 +54,9 @@ export default {
     display: none;
 
     @media (min-width: 48em) {
-      display: block;
+      display: flex;
       height: calc(100% + 5rem);
+      justify-content: flex-end;
       right: 0;
       position: absolute;
       top: -2.5rem;
@@ -80,12 +79,7 @@ export default {
   }
   h1,
   p {
-    background-color: rgba(41, 43, 102, 0.75);
-
-    // Firefox hack to fix color discrepancy
-    @-moz-document url-prefix() {
-      background: rgba(33, 39, 90, 0.75);
-    }
+    background-color: rgba(36, 36, 91, 0.75);
   }
 
   .row {

--- a/pages/index.vue
+++ b/pages/index.vue
@@ -12,15 +12,12 @@
           {{ heroButtonLabel }}
         </el-button>
       </a>
-      <video
+      <img
         v-if="heroImage"
         slot="image"
-        class="page-hero-video"
-        autoplay
-        muted
-      >
-        <source :src="heroImage.fields.file.url" type="video/mp4" />
-      </video>
+        class="page-hero-img"
+        :src="heroImage.fields.file.url"
+      />
     </page-hero>
 
     <featured-data :featured-data="featuredData" />


### PR DESCRIPTION
# Description

The purpose of this PR is to replace the video on the homepage hero with an image. I also made this image transparent so we don't have a color issue like the video had. 

![localhost_3000_(Laptop with HiDPI screen) (7)](https://user-images.githubusercontent.com/1493195/92624467-8bef8300-f295-11ea-9e96-3c4d7286f092.png)


## Type of change

- [x] New feature (non-breaking change which adds functionality)

# How Has This Been Tested?

This has been tested on all supported browsers and OS.

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have added unit tests that prove my fix is effective or that my feature works
