### PR TITLE
fix(Markdown): Only make external links open in new tab

### DIFF
--- a/mixins/marked/index.js
+++ b/mixins/marked/index.js
@@ -5,10 +5,23 @@ import marked from 'marked'
  * https://github.com/markedjs/marked/pull/1371#issuecomment-434320596
  */
 const renderer = new marked.Renderer()
+const linkRenderer = renderer.link
+
+const isAnchor = str => {
+  return /(?:^|\s)(#[^ ]+)/i.test(str)
+}
+
+const isInternalLink = str => {
+  return isAnchor(str) ? true : str.includes(document.location.origin)
+}
 
 renderer.link = function(href, title, text) {
-  const link = marked.Renderer.prototype.link.apply(this, arguments)
-  return link.replace('<a', "<a target='_blank'")
+  const html = linkRenderer.call(renderer, href, title, text)
+  const isInternal = isInternalLink(href)
+
+  return isInternal
+    ? html
+    : html.replace(/^<a /, '<a target="_blank" rel="nofollow" ')
 }
 
 marked.setOptions({

--- a/mixins/marked/index.js
+++ b/mixins/marked/index.js
@@ -12,7 +12,7 @@ const isAnchor = str => {
 }
 
 const isInternalLink = str => {
-  return isAnchor(str) ? true : str.includes(document.location.origin)
+  return isAnchor(str) ? true : str.includes(process.env.ROOT_URL)
 }
 
 renderer.link = function(href, title, text) {

--- a/nuxt.config.js
+++ b/nuxt.config.js
@@ -62,7 +62,8 @@ export default {
     CTF_CDA_ACCESS_TOKEN: process.env.CTF_CDA_ACCESS_TOKEN,
     CTF_API_HOST: process.env.CTF_API_HOST,
     BL_SERVER_URL: 'https://sparc.biolucida.net/api/v1/',
-    BL_SHARE_LINK_PREFIX: 'https://sparc.biolucida.net/image?c='
+    BL_SHARE_LINK_PREFIX: 'https://sparc.biolucida.net/image?c=',
+    ROOT_URL: process.env.ROOT_URL || 'http://localhost:3000'
   },
 
   serverMiddleware: [
@@ -84,9 +85,9 @@ export default {
       // Redirects
       routes.push({
         path: '/submit_data.html',
-        redirect: '/help/7k8nEPuw3FjOq2HuS8OVsd',
+        redirect: '/help/7k8nEPuw3FjOq2HuS8OVsd'
       })
-    },
+    }
   },
   /*
    ** Global CSS
@@ -138,6 +139,6 @@ export default {
     /*
      ** You can extend webpack config here
      */
-    extend(config, ctx) {},
+    extend(config, ctx) {}
   }
 }

--- a/test/MarkdownTest/MarkdownTest.spec.js
+++ b/test/MarkdownTest/MarkdownTest.spec.js
@@ -5,11 +5,19 @@ describe('MarkdownTest', () => {
   const wrapper = mount(MarkdownTest)
 
   it('Renders the correct markup', () => {
-    expect(wrapper.find('a').exists()).toBe(true)
-    expect(wrapper.find('h1').exists()).toBe(true)
+    expect(wrapper.find('#externalWrap a').exists()).toBe(true)
+    expect(wrapper.find('#externalWrap h1').exists()).toBe(true)
   })
 
   it('Adds target="blank" to links', () => {
-    expect(wrapper.find('a').element.getAttribute('target')).toBe('_blank')
+    expect(wrapper.find('#externalWrap a').element.getAttribute('target')).toBe(
+      '_blank'
+    )
+  })
+
+  it('Renders an anchor tag properly', () => {
+    expect(wrapper.find('#anchorWrap a').element.getAttribute('target')).toBe(
+      null
+    )
   })
 })

--- a/test/MarkdownTest/MarkdownTest.vue
+++ b/test/MarkdownTest/MarkdownTest.vue
@@ -1,7 +1,10 @@
 <template>
-  <!-- eslint-disable vue/no-v-html -->
-  <!-- marked will sanitize the HTML injected -->
-  <div v-html="parseMarkdown(markdown)" />
+  <div>
+    <!-- eslint-disable vue/no-v-html -->
+    <!-- marked will sanitize the HTML injected -->
+    <div id="externalWrap" v-html="parseMarkdown(markdown)" />
+    <div id="anchorWrap" v-html="parseMarkdown(markdownAnchor)" />
+  </div>
 </template>
 
 <script>
@@ -14,8 +17,8 @@ export default {
 
   data() {
     return {
-      markdown: `[go to SPARC](https://sparc.science) \n # This is a heading
-      `
+      markdown: `[go to SPARC](https://sparc.science) \n # This is a heading`,
+      markdownAnchor: `[Link to section](#foo) \n # Foo`
     }
   }
 }


### PR DESCRIPTION
# Description
The purpose of this PR is to change the logic for rendering links with markdown to only open external links in new tabs. This will fix a bug with anchor tags not linking to items on the same page.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

- Go to the [SPARC Glossary](http://localhost:3000/help/3vcLloyvrvmnK3Nopddrka)
- External links should open in a new tab
- Scroll to the DAT-Core section and click the `SIM-Core` link at the end of the paragraph.
- You should be taken down to that anchor tag

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have added unit tests that prove my fix is effective or that my feature works
