### PR TITLE
fix(Files): Fix URL to allow linking to some file types - CU-cuj73d

### DIFF
--- a/components/FilesTable/FilesTable.vue
+++ b/components/FilesTable/FilesTable.vue
@@ -55,12 +55,14 @@
                 <div v-else>
                   <nuxt-link
                     :to="{
-                      name: 'file-datasetId-datasetVersion-path',
+                      name: 'file-datasetId-datasetVersion',
                       params: {
                         datasetId: datasetDetails.id,
-                        datasetVersion: datasetDetails.version,
-                        path: scope.row.path,
+                        datasetVersion: datasetDetails.version
                       },
+                      query: {
+                        path: scope.row.path
+                      }
                     }"
                   >
                     {{ scope.row.name }}
@@ -99,7 +101,7 @@
                 <el-dropdown-item
                   :command="{
                     type: 'getDownloadFile',
-                    scope,
+                    scope
                   }"
                 >
                   Download
@@ -108,7 +110,7 @@
                   v-if="isMicrosoftFileType(scope)"
                   :command="{
                     type: 'openFile',
-                    scope,
+                    scope
                   }"
                 >
                   Open
@@ -133,7 +135,7 @@ import {
   propOr,
   last,
   defaultTo,
-  pathOr,
+  pathOr
 } from 'ramda'
 
 import FormatStorage from '@/mixins/bf-storage-metrics/index'
@@ -149,8 +151,8 @@ export default {
       type: Object,
       default: function() {
         return {}
-      },
-    },
+      }
+    }
   },
 
   data: function() {
@@ -159,7 +161,7 @@ export default {
       data: [],
       isLoading: false,
       hasError: false,
-      limit: 500,
+      limit: 500
     }
   },
 
@@ -190,7 +192,7 @@ export default {
       const id = pathOr('', ['params', 'datasetId'], this.$route)
       const version = propOr(1, 'version', this.datasetDetails)
       return `https://api.blackfynn.io/discover/datasets/${id}/versions/${version}`
-    },
+    }
   },
 
   watch: {
@@ -198,7 +200,7 @@ export default {
       handler: function() {
         this.getDatasetVersionNumber()
       },
-      immediate: true,
+      immediate: true
     },
 
     path: {
@@ -207,8 +209,8 @@ export default {
           this.getFiles()
         }
       },
-      immediate: true,
-    },
+      immediate: true
+    }
   },
 
   mounted: function() {},
@@ -223,7 +225,7 @@ export default {
       let parts = semverVersion.split('.')
       // make sure no part is larger than 1023 or else it won't fit
       // into 32-bit integer
-      parts.forEach((part) => {
+      parts.forEach(part => {
         if (part >= 1024) {
           throw new Error(`Version string invalid, ${part} is too large`)
         }
@@ -245,9 +247,9 @@ export default {
 
       this.$axios
         .$get(this.getFilesIdUrl)
-        .then((response) => {
+        .then(response => {
           const schemaVersion = this.convertSchemaVersionToInteger(
-            response.blackfynnSchemaVersion,
+            response.blackfynnSchemaVersion
           )
           if (schemaVersion < 4.0) {
             this.path = 'packages'
@@ -279,7 +281,7 @@ export default {
 
       this.$axios
         .$get(this.getFilesurl)
-        .then((response) => {
+        .then(response => {
           this.data = response.files
         })
         .catch(() => {
@@ -343,12 +345,12 @@ export default {
         last,
         defaultTo([]),
         split('s3://blackfynn-discover-use1/'),
-        pathOr('', ['row', 'uri']),
+        pathOr('', ['row', 'uri'])
       )(scope)
 
       const requestUrl = `${process.env.portal_api}/download?key=${filePath}`
 
-      this.$axios.$get(requestUrl).then((response) => {
+      this.$axios.$get(requestUrl).then(response => {
         const url = response
         const encodedUrl = encodeURIComponent(url)
         const finalURL = `https://view.officeapps.live.com/op/view.aspx?src=${encodedUrl}`
@@ -363,8 +365,8 @@ export default {
     isImage: function(fileType) {
       const images = ['JPG', 'PNG', 'JPEG', 'TIFF', 'GIF']
       return images.indexOf(fileType) >= 0
-    },
-  },
+    }
+  }
 }
 </script>
 

--- a/pages/file/_datasetId/_datasetVersion/index.vue
+++ b/pages/file/_datasetId/_datasetVersion/index.vue
@@ -69,19 +69,19 @@ export default {
   components: {
     BiolucidaViewer,
     DetailTabs,
-    BfButton,
+    BfButton
   },
 
   mixins: [BfStorageMetrics, FormatDate, RequestDownloadFile],
 
   async asyncData({ route, $axios }) {
-    const fileUrl = `${process.env.discover_api_host}/datasets/${route.params.datasetId}/versions/${route.params.datasetVersion}/files?path=${route.params.path}`
+    const fileUrl = `${process.env.discover_api_host}/datasets/${route.params.datasetId}/versions/${route.params.datasetVersion}/files?path=${route.query.path}`
 
     const file = await $axios.$get(fileUrl)
 
     const sourcePackageId = file.sourcePackageId
     const biolucidaData = await $axios.$get(
-      `${process.env.BL_SERVER_URL}/imagemap/sharelink/${sourcePackageId}`,
+      `${process.env.BL_SERVER_URL}/imagemap/sharelink/${sourcePackageId}`
     )
 
     const hasViewer = biolucidaData.status !== 'error'
@@ -89,7 +89,7 @@ export default {
     return {
       biolucidaData,
       file,
-      hasViewer,
+      hasViewer
     }
   },
 
@@ -98,16 +98,16 @@ export default {
       biolucidaData: {
         biolucida_image_id: '',
         share_link: '',
-        status: '',
+        status: ''
       },
       tabs: [
         {
           label: 'Viewer',
-          type: 'viewer',
-        },
+          type: 'viewer'
+        }
       ],
       activeTab: 'viewer',
-      file: {},
+      file: {}
     }
   },
 
@@ -118,8 +118,8 @@ export default {
      */
     location: function() {
       return this.file.path.replace(`/${this.file.name}`, '')
-    },
-  },
+    }
+  }
 }
 </script>
 


### PR DESCRIPTION
# Description

The purpose of this PR is to fix an issue with some files when direct linking to them. Native file types were 

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

- Navigate to [a dataset with an image](http://localhost:3000/datasets/64)
- In the Files tab, navigate to the image and click on its name to open it. If using the above dataset, the path is: `files/derivative/sub-9/sam-3/sub-9sam-3P9-3Slide2p3MT10x.jp2`
- Refresh the page. File details page should load.

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have added unit tests that prove my fix is effective or that my feature works
