### PR TITLE
Remove Get Dataset link from Simulations Page

### DIFF
--- a/pages/datasets/_datasetId.vue
+++ b/pages/datasets/_datasetId.vue
@@ -93,15 +93,6 @@
               Run Simulation
             </a>
           </button>
-          <a
-            :href="
-              `https://discover.blackfynn.com/datasets/${$route.params.datasetId}/index.html`
-            "
-            target="_blank"
-            class="dataset-link"
-          >
-            Get Dataset
-          </a>
         </div>
         <div v-else>
           <button class="dataset-button" @click="isDownloadModalVisible = true">


### PR DESCRIPTION
# Description

The purpose of this PR is to remove the `Get Dataset` link from the Simulations page. 

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

Navigate to a simulation page. The `Get Dataset` link should no longer be displayed next to the `Run Simulation` button on the page.

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
