### PR TITLE
feat(Homepage news): Allow image to be same height as content

### DIFF
--- a/components/SparcCard/SparcCard.vue
+++ b/components/SparcCard/SparcCard.vue
@@ -3,8 +3,8 @@
     class="sparc-card"
     :class="{ 'sparc-card--image-right': imageAlign === 'right' }"
   >
-    <div class="sparc-card__image">
-      <img :src="image" :alt="imageAlt" />
+    <div class="sparc-card__image" :style="`background-image: url(${image})`">
+      <img class="visuallyhidden" :src="image" :alt="imageAlt" />
     </div>
 
     <div class="sparc-card__content-wrap">
@@ -37,10 +37,8 @@ export default {
 </script>
 
 <style lang="scss" scoped>
-$image-fixed-small: 250px;
-$image-fixed-large: 350px;
-$tablet-small: 768px;
-$tablet-large: 1024px;
+$tablet-small: 48em;
+$tablet-large: 64em;
 .sparc-card {
   @media (min-width: $tablet-small) {
     display: flex;
@@ -53,18 +51,11 @@ $tablet-large: 1024px;
     }
   }
   &__image {
+    background-size: cover;
+    background-position: center;
+    height: 300px;
     @media (min-width: $tablet-small) {
-      flex: 0 0 $image-fixed-small;
-      max-height: $image-fixed-small;
-    }
-    @media (min-width: $tablet-large) {
-      flex: 0 0 $image-fixed-large;
-      max-height: $image-fixed-large;
-    }
-    img {
-      display: block;
-      width: 100%;
-      height: 100%;
+      height: auto;
     }
   }
   &__content-wrap {
@@ -73,14 +64,7 @@ $tablet-large: 1024px;
   }
   &__image,
   &__content-wrap {
-    @media (min-width: $tablet-small) {
-      min-height: $image-fixed-small;
-      display: flex;
-    }
-    @media (min-width: $tablet-large) {
-      min-height: $image-fixed-large;
-      display: flex;
-    }
+    flex: 1 0 0em; // Unit required for IE11
     &__content {
       color: #fff;
       font-size: 0.75em;


### PR DESCRIPTION
# Description

The purpose of this PR is to change the homepage news and events images to be full height of the content. 

https://www.wrike.com/open.htm?id=510367560
https://app.clickup.com/t/cuhzqx

## Type of change
- [x] New feature (non-breaking change which adds functionality)

# How Has This Been Tested?

- Inspect `SparcHomepage` component, and add a `summary`  key to the first object of the `newsAndEvents` list with long  content: `newsAndEvents[0].fields.summary = 'lorem ipsum lorem ipsum lorem ipsum lorem ipsum lorem ipsum lorem ipsum lorem ipsum lorem ipsum lorem ipsum lorem ipsum lorem ipsum lorem ipsum lorem ipsum lorem ipsum lorem ipsum lorem ipsum lorem ipsum lorem ipsum lorem ipsum lorem ipsum lorem ipsum lorem ipsum lorem ipsum lorem ipsum`
- Look at the news item on all viewports.

![localhost_3000_(iPad) (1)](https://user-images.githubusercontent.com/1493195/97221870-e2f8db00-17a3-11eb-8de2-2b2f2778a1ce.png)
![localhost_3000_(iPhone X) (2)](https://user-images.githubusercontent.com/1493195/97221871-e3917180-17a3-11eb-84b8-0fcdae122c16.png)
![localhost_3000_(Laptop with HiDPI screen) (8)](https://user-images.githubusercontent.com/1493195/97221873-e3917180-17a3-11eb-8505-edd58d1ab859.png)


# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
