### PR TITLE
fix(Cookie banner): Prevent close button overlap

### DIFF
--- a/components/CookieNotice/CookieNotice.vue
+++ b/components/CookieNotice/CookieNotice.vue
@@ -61,7 +61,7 @@ export default {
   color: $navy;
   left: 0;
   right: 0;
-  padding: 1.625em 0;
+  padding: 2rem 0;
   position: fixed;
   z-index: 9;
 }
@@ -100,7 +100,7 @@ p {
   cursor: pointer;
   padding: 0.25em;
   position: absolute;
-  right: 1em;
-  top: 1em;
+  right: 0.25rem;
+  top: 0.25rem;
 }
 </style>


### PR DESCRIPTION
# Description

The purpose of this PR is to fix an issue with the close button overlapping the Accept button.

https://app.clickup.com/t/cuj1qt
https://www.wrike.com/workspace.htm?acc=3203588&wr=14#path=folder&t=516884661&a=3203588&id=441356195&st=space-441356195

![localhost_3000_(iPad) (2)](https://user-images.githubusercontent.com/1493195/97228571-80a4d800-17ad-11eb-8480-4818fdcbdb27.png)
![localhost_3000_(iPhone X) (3)](https://user-images.githubusercontent.com/1493195/97228574-813d6e80-17ad-11eb-8586-7e3e0b3dc0b9.png)
![localhost_3000_(Laptop with MDPI screen) (2)](https://user-images.githubusercontent.com/1493195/97228578-813d6e80-17ad-11eb-8284-27df3ab62694.png)


## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)isting functionality to not work as expected)

# How Has This Been Tested?

See screens above for all viewports

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
