### PR TITLE
feat(Dataset): Download multiple files - CU-cuj5j9

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -2,7 +2,8 @@ module.exports = {
   root: true,
   env: {
     browser: true,
-    node: true
+    node: true,
+    jest: true
   },
   parserOptions: {
     parser: 'babel-eslint'

--- a/components/BfDownloadFile/BfDownloadFile.spec.js
+++ b/components/BfDownloadFile/BfDownloadFile.spec.js
@@ -1,0 +1,134 @@
+import { shallowMount, mount } from '@vue/test-utils'
+import BfDownloadFile from './BfDownloadFile.vue'
+
+import Config from '@/nuxt.config'
+
+const smallFile = {
+  name: '1G.random',
+  path: 'files/1G.random',
+  size: 100000,
+  icon: 'Generic',
+  uri: 's3://dev-discover-publish-use1/676/17/files/1G.random',
+  fileType: 'GenericData',
+  packageType: 'Unknown',
+  sourcePackageId: 'N:package:503af663-118e-4c9f-9046-4359871d2e95',
+  createdAt: null,
+  type: 'File'
+}
+
+const selectedMock = [
+  smallFile,
+  {
+    name: '1G.random (1)',
+    path: 'files/1G.random (1)',
+    size: 1073741824,
+    icon: 'Generic',
+    uri: 's3://dev-discover-publish-use1/676/17/files/1G.random (1)',
+    fileType: 'GenericData',
+    packageType: 'Unknown',
+    sourcePackageId: 'N:package:84a65d32-ed67-4685-852f-e2ee33893b02',
+    createdAt: null,
+    type: 'File'
+  },
+  {
+    name: '20G.random',
+    path: 'files/20G.random',
+    size: 21474836480,
+    icon: 'Generic',
+    uri: 's3://dev-discover-publish-use1/676/17/files/20G.random',
+    fileType: 'GenericData',
+    packageType: 'Unknown',
+    sourcePackageId: 'N:package:2cbbec8e-0bd8-43aa-b8e4-afe0f0eec7ad',
+    createdAt: null,
+    type: 'File'
+  }
+]
+const dataset = {
+  id: 676,
+  sourceDatasetId: 1338,
+  name: '1 terabyte data',
+  description: 'Test for publishing large datasets',
+  ownerId: 11,
+  ownerFirstName: 'Bo',
+  ownerLastName: 'Marchman',
+  ownerOrcid: '0000-0003-4794-225X',
+  organizationName: 'Blackfynn Test',
+  organizationId: 19,
+  license: 'Community Data License Agreement – Sharing',
+  tags: ['data'],
+  version: 17,
+  revision: null,
+  size: 572307256170,
+  modelCount: [],
+  fileCount: 1141,
+  recordCount: 0,
+  uri: 's3://dev-discover-publish-use1/676/17/',
+  arn: 'arn:aws:s3:::dev-discover-publish-use1/676/17/',
+  status: 'PUBLISH_SUCCEEDED',
+  doi: '10.21397/gonm-7vsy',
+  banner:
+    'https://assets.discover.blackfynn.net/dataset-assets/676/17/banner.jpg',
+  readme:
+    'https://assets.discover.blackfynn.net/dataset-assets/676/17/readme.md',
+  contributors: [
+    {
+      firstName: 'Bo',
+      middleInitial: null,
+      lastName: 'Marchman',
+      degree: null,
+      orcid: '0000-0003-4794-225X'
+    }
+  ],
+  collections: [],
+  externalPublications: [],
+  sponsorship: null,
+  blackfynnSchemaVersion: '4.0',
+  createdAt: '2020-09-17T17:09:33.04728Z',
+  updatedAt: '2020-10-27T20:12:17.446566Z',
+  firstPublishedAt: '2020-09-15T11:26:25.589161Z',
+  versionPublishedAt: '2020-09-17T17:09:33.04728Z',
+  revisedAt: null,
+  embargo: false,
+  embargoReleaseDate: null,
+  ownerEmail: ''
+}
+
+beforeAll(() => {
+  process.env = Config.env
+})
+
+describe('BfDownloadFile.vue', () => {
+  test('Does not allow downloads over the app threshold', () => {
+    const wrapper = shallowMount(BfDownloadFile, {
+      propsData: {
+        dataset,
+        selected: selectedMock
+      },
+      stubs: {
+        SvgIcon: true,
+        ElButton: true,
+        ElDialog: true,
+        ElInput: true
+      }
+    })
+
+    expect(wrapper.vm.downloadDisabled).toBe(true)
+  })
+
+  test('Allows downloads under the app threshold', () => {
+    const wrapper = shallowMount(BfDownloadFile, {
+      propsData: {
+        dataset,
+        selected: [smallFile]
+      },
+      stubs: {
+        SvgIcon: true,
+        ElButton: true,
+        ElDialog: true,
+        ElInput: true
+      }
+    })
+
+    expect(wrapper.vm.downloadDisabled).toBe(false)
+  })
+})

--- a/components/BfDownloadFile/BfDownloadFile.vue
+++ b/components/BfDownloadFile/BfDownloadFile.vue
@@ -3,7 +3,7 @@
     <el-button @click="onDownloadClick">
       Download
     </el-button>
-    <form id="zipForm" method="POST" :action="zipitUrl">
+    <form id="zipForm" ref="zipForm" method="POST" :action="zipitUrl">
       <input v-model="zipData" type="hidden" name="data" />
     </form>
     <el-dialog
@@ -86,10 +86,6 @@ export default {
       default: () => {
         return {}
       }
-    },
-    filePath: {
-      type: String,
-      default: ''
     }
   },
 
@@ -175,8 +171,6 @@ export default {
         version: this.dataset.version
       }
 
-      // const [, ...path] = this.filePath
-      // const rootPathPayload = path ? { rootPath: path.join('/') } : {}
       const archiveNamePayload =
         this.archiveName && this.selected.length > 1
           ? { archiveName: this.archiveName }
@@ -184,12 +178,12 @@ export default {
 
       const payload = {
         ...mainPayload,
-        // ...rootPathPayload,
         ...archiveNamePayload
       }
+
       this.zipData = JSON.stringify(payload, undefined)
       this.$nextTick(() => {
-        zipForm.submit() // eslint-disable-line no-undef
+        this.$refs.zipForm.submit() // eslint-disable-line no-undef
       })
       this.closeConfirmDownload()
     },

--- a/components/BfDownloadFile/BfDownloadFile.vue
+++ b/components/BfDownloadFile/BfDownloadFile.vue
@@ -1,0 +1,253 @@
+<template>
+  <div>
+    <el-button @click="onDownloadClick">
+      Download
+    </el-button>
+    <form id="zipForm" method="POST" :action="zipitUrl">
+      <input v-model="zipData" type="hidden" name="data" />
+    </form>
+    <el-dialog
+      :visible.sync="confirmDownloadVisible"
+      :show-close="false"
+      @close="closeConfirmDownload"
+    >
+      <div slot="title" class="bf-dialog-header">
+        <span class="bf-dialog-header-title">Confirm Download</span>
+        <button class="icon-close btn" @click="closeConfirmDownload">
+          <svg-icon icon="icon-remove" height="12" width="12" />
+        </button>
+      </div>
+
+      <div class="bf-dialog-body">
+        <div v-if="showReduceSize" class="mb-24">
+          <p>
+            The file(s) you are trying to download exceed the limit of
+            {{ maxDownloadSize }}. Please reduce the number of files selected
+            and try again.
+          </p>
+          <el-table :show-header="false" :border="false" :data="selected">
+            <el-table-column prop="name" />
+            <el-table-column align="right">
+              <template slot-scope="scope">
+                {{ formatMetric(scope.row.size) }}
+                <button class="btn btn-remove">
+                  <svg-icon
+                    color="#bdbdbd #404554"
+                    icon="icon-remove"
+                    height="12"
+                    width="12"
+                    @click="$emit('remove-selection', scope.row)"
+                  />
+                </button>
+              </template>
+            </el-table-column>
+          </el-table>
+        </div>
+        <div v-if="selected.length > 1" class="download-name">
+          <label for="downloadName">
+            File Name
+          </label>
+          <el-input id="downloadName" v-model="archiveName" />
+          <span>.zip</span>
+        </div>
+      </div>
+
+      <div slot="footer" class="dialog-footer">
+        <el-button class="secondary" @click="closeConfirmDownload">
+          Cancel
+        </el-button>
+        <el-button :disabled="downloadDisabled" @click="confirmDownload">
+          Download
+        </el-button>
+      </div>
+    </el-dialog>
+  </div>
+</template>
+
+<script>
+import StorageMetrics from '@/mixins/bf-storage-metrics'
+
+const DEFAULT_ARCHIVE_NAME = 'sparc-portal-data'
+
+export default {
+  name: 'BfDownloadFile',
+
+  mixins: [StorageMetrics],
+
+  props: {
+    selected: {
+      type: Array,
+      default: () => {
+        return []
+      }
+    },
+    dataset: {
+      type: Object,
+      default: () => {
+        return {}
+      }
+    },
+    filePath: {
+      type: String,
+      default: ''
+    }
+  },
+
+  data() {
+    return {
+      zipData: '',
+      confirmDownloadVisible: false,
+      archiveName: DEFAULT_ARCHIVE_NAME,
+      showReduceSize: false,
+      downloadConfirmed: false
+    }
+  },
+
+  computed: {
+    /**
+     * Compute URL for zipit service
+     * @returns {String}
+     */
+    zipitUrl: function() {
+      return process.env.zipit_api_host
+    },
+
+    /**
+     * download is disabled if the total size is greater than the threshold, or no rows are selected
+     * @returns {Boolean}
+     */
+    downloadDisabled() {
+      if (this.selected.length === 0) return true
+      const totalSize = this.selected.reduce(
+        (total, node) => total + node.size || 0,
+        0
+      )
+
+      return totalSize > process.env.max_download_size
+    },
+
+    /**
+     * determines whether the confirm download dialog should open
+     * @returns {Boolean}
+     */
+    shouldConfirmDownload() {
+      return (
+        this.downloadDisabled ||
+        (this.selected.length > 1 && !this.downloadConfirmed)
+      )
+    },
+
+    /**
+     * Compute max size for download
+     * @returns {Number}
+     */
+    maxDownloadSize() {
+      return this.formatMetric(process.env.max_download_size)
+    }
+  },
+
+  methods: {
+    /**
+     * Show the confirm dialog if downloading multiple files
+     * Otherwise, just download the file
+     */
+    onDownloadClick() {
+      if (this.shouldConfirmDownload) {
+        this.showReduceSize = this.downloadDisabled
+        this.confirmDownloadVisible = true
+      } else {
+        this.executeDownload()
+      }
+    },
+
+    /**
+     * Confirm to start the download, or show the
+     */
+    confirmDownload() {
+      this.downloadConfirmed = true
+      this.onDownloadClick()
+    },
+
+    executeDownload() {
+      const mainPayload = {
+        paths: this.selected.map(f => f.path),
+        datasetId: this.dataset.id,
+        version: this.dataset.version
+      }
+
+      // const [, ...path] = this.filePath
+      // const rootPathPayload = path ? { rootPath: path.join('/') } : {}
+      const archiveNamePayload =
+        this.archiveName && this.selected.length > 1
+          ? { archiveName: this.archiveName }
+          : {}
+
+      const payload = {
+        ...mainPayload,
+        // ...rootPathPayload,
+        ...archiveNamePayload
+      }
+      this.zipData = JSON.stringify(payload, undefined)
+      this.$nextTick(() => {
+        zipForm.submit() // eslint-disable-line no-undef
+      })
+      this.closeConfirmDownload()
+    },
+
+    closeConfirmDownload() {
+      this.archiveName = DEFAULT_ARCHIVE_NAME
+      this.downloadConfirmed = false
+      this.showReduceSize = false
+      this.confirmDownloadVisible = false
+    }
+  }
+}
+</script>
+
+<style lang="scss" scoped>
+.btn {
+  background: none;
+  border: none;
+  color: #000;
+  cursor: pointer;
+  &:active {
+    outline: none;
+  }
+}
+.btn-remove {
+  box-sizing: border-box;
+  height: 1rem;
+  width: 1rem;
+}
+.bf-dialog-header {
+  align-items: center;
+  display: flex;
+  position: relative;
+}
+.bf-dialog-header-title {
+  flex: 1;
+  font-size: 18px;
+  font-weight: 400;
+  line-height: 1;
+  margin-right: 8px;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  color: #000;
+}
+
+.bf-dialog-body {
+  word-break: normal;
+}
+
+.download-name {
+  display: flex;
+  align-items: center;
+  label {
+    min-width: 64px;
+  }
+  ::v-deep .el-input {
+    margin: 0 8px;
+  }
+}
+</style>

--- a/components/DownloadDataset/DownloadDataset.vue
+++ b/components/DownloadDataset/DownloadDataset.vue
@@ -155,7 +155,7 @@ export default {
      * @returns {String}
      */
     downloadUrl: function() {
-      return `https://api.blackfynn.net/discover/datasets/${this.datasetId}/versions/${this.versionId}/download`
+      return `${process.env.bf_api_host}/discover/datasets/${this.datasetId}/versions/${this.versionId}/download`
     }
   },
 

--- a/components/DownloadDataset/DownloadDataset.vue
+++ b/components/DownloadDataset/DownloadDataset.vue
@@ -155,7 +155,7 @@ export default {
      * @returns {String}
      */
     downloadUrl: function() {
-      return `https://api.blackfynn.io/discover/datasets/${this.datasetId}/versions/${this.versionId}/download`
+      return `https://api.blackfynn.net/discover/datasets/${this.datasetId}/versions/${this.versionId}/download`
     }
   },
 

--- a/components/FilesTable/FilesTable.vue
+++ b/components/FilesTable/FilesTable.vue
@@ -1,22 +1,32 @@
 <template>
   <div class="files-table">
-    <div class="breadcrumb-list">
-      <div v-for="(item, idx) in breadcrumbs" :key="idx" class="breadcrumb">
-        <a
-          class="breadcrumb-link"
-          href="#"
-          @click.prevent="breadcrumbNavigation(idx)"
-        >
-          {{ item }}
-        </a>
+    <div class="files-table-header">
+      <div class="breadcrumb-list">
+        <div v-for="(item, idx) in breadcrumbs" :key="idx" class="breadcrumb">
+          <a
+            class="breadcrumb-link"
+            href="#"
+            @click.prevent="breadcrumbNavigation(idx)"
+          >
+            {{ item }}
+          </a>
 
-        <span
-          v-if="breadcrumbs.length > 1 && idx !== breadcrumbs.length - 1"
-          class="breadcrumb-separator"
-        >
-          /
-        </span>
+          <span
+            v-if="breadcrumbs.length > 1 && idx !== breadcrumbs.length - 1"
+            class="breadcrumb-separator"
+          >
+            /
+          </span>
+        </div>
       </div>
+
+      <bf-download-file
+        class="mb-8"
+        :selected="selected"
+        :dataset="datasetDetails"
+        :file-path="path"
+        @remove-selection="removeSelection"
+      />
     </div>
 
     <div class="files-table-table">
@@ -26,7 +36,14 @@
           Try again
         </el-button>
       </div>
-      <el-table v-else v-loading="isLoading" :data="data">
+      <el-table
+        v-else
+        ref="table"
+        v-loading="isLoading"
+        :data="data"
+        @selection-change="handleSelectionChange"
+      >
+        <el-table-column type="selection" fixed width="55" />
         <el-table-column fixed prop="name" label="Name" width="340" sortable>
           <template slot-scope="scope">
             <div class="file-name-wrap">
@@ -138,11 +155,17 @@ import {
   pathOr
 } from 'ramda'
 
+import BfDownloadFile from '@/components/BfDownloadFile/BfDownloadFile'
+
 import FormatStorage from '@/mixins/bf-storage-metrics/index'
 import RequestDownloadFile from '@/mixins/request-download-file'
 
 export default {
   name: 'FilesTable',
+
+  components: {
+    BfDownloadFile
+  },
 
   mixins: [FormatStorage, RequestDownloadFile],
 
@@ -161,7 +184,8 @@ export default {
       data: [],
       isLoading: false,
       hasError: false,
-      limit: 500
+      limit: 500,
+      selected: []
     }
   },
 
@@ -177,7 +201,7 @@ export default {
     getFilesurl: function() {
       const id = pathOr('', ['params', 'datasetId'], this.$route)
       const version = propOr(1, 'version', this.datasetDetails)
-      const url = `https://api.blackfynn.io/discover/datasets/${id}/versions/${version}/files/browse`
+      const url = `https://api.blackfynn.net/discover/datasets/${id}/versions/${version}/files/browse`
 
       return this.path
         ? `${url}?path=${this.path}&limit=${this.limit}`
@@ -191,7 +215,7 @@ export default {
     getFilesIdUrl: function() {
       const id = pathOr('', ['params', 'datasetId'], this.$route)
       const version = propOr(1, 'version', this.datasetDetails)
-      return `https://api.blackfynn.io/discover/datasets/${id}/versions/${version}`
+      return `https://api.blackfynn.net/discover/datasets/${id}/versions/${version}`
     }
   },
 
@@ -216,6 +240,10 @@ export default {
   mounted: function() {},
 
   methods: {
+    handleSelectionChange(val) {
+      this.selected = val
+    },
+
     /**
      * Converts a semver version string to an integer
      * @param {String} semverVersion
@@ -365,6 +393,19 @@ export default {
     isImage: function(fileType) {
       const images = ['JPG', 'PNG', 'JPEG', 'TIFF', 'GIF']
       return images.indexOf(fileType) >= 0
+    },
+
+    /**
+     * Remove selection
+     * @param {Object} row
+     */
+    removeSelection(row) {
+      this.selected = this.selected.filter(f => f.path !== row.path)
+
+      const selectedPaths = this.selected.map(s => s.path)
+      this.data.forEach(r => {
+        this.$refs.table.toggleRowSelection(r, selectedPaths.includes(r.path))
+      })
     }
   }
 }
@@ -373,14 +414,20 @@ export default {
 <style lang="scss" scoped>
 @import '@/assets/_variables.scss';
 .breadcrumb {
+  background: none;
+  height: auto;
+  margin-bottom: 8px;
+}
+.files-table-header {
+  align-items: center;
   display: flex;
   margin-bottom: 8px;
-  background: none;
 }
 .breadcrumb-list {
+  align-items: center;
   display: flex;
+  flex: 1;
   flex-wrap: wrap;
-  margin-bottom: 8px;
 }
 .breadcrumb-link {
   word-break: break-word;
@@ -419,6 +466,9 @@ export default {
       font-size: 14px;
       font-weight: 500;
       line-height: 16px;
+    }
+    &.el-table-column--selection .cell {
+      padding: 0 14px;
     }
   }
 }

--- a/components/FilesTable/FilesTable.vue
+++ b/components/FilesTable/FilesTable.vue
@@ -201,7 +201,7 @@ export default {
     getFilesurl: function() {
       const id = pathOr('', ['params', 'datasetId'], this.$route)
       const version = propOr(1, 'version', this.datasetDetails)
-      const url = `https://api.blackfynn.net/discover/datasets/${id}/versions/${version}/files/browse`
+      const url = `${process.env.bf_api_host}/discover/datasets/${id}/versions/${version}/files/browse`
 
       return this.path
         ? `${url}?path=${this.path}&limit=${this.limit}`
@@ -215,7 +215,7 @@ export default {
     getFilesIdUrl: function() {
       const id = pathOr('', ['params', 'datasetId'], this.$route)
       const version = propOr(1, 'version', this.datasetDetails)
-      return `https://api.blackfynn.net/discover/datasets/${id}/versions/${version}`
+      return `${process.env.bf_api_host}/discover/datasets/${id}/versions/${version}`
     }
   },
 

--- a/components/MetadataTable/MetadataTable.vue
+++ b/components/MetadataTable/MetadataTable.vue
@@ -86,7 +86,7 @@ export default {
         this.value = this.defaultModel
       }
       const datasetId = propOr('', 'id', this.datasetDetails)
-      return `https://api.blackfynn.io/discover/search/records?datasetId=${datasetId}&model=${this.defaultModel}`
+      return `${process.env.bf_api_host}/discover/search/records?datasetId=${datasetId}&model=${this.defaultModel}`
     }
   },
 

--- a/nuxt.config.js
+++ b/nuxt.config.js
@@ -34,6 +34,8 @@ export default {
     discover_api_host:
       process.env.BLACKFYNN_DISCOVER_API_HOST ||
       'https://api.blackfynn.io/discover',
+    zipit_api_host:
+      process.env.ZIPIT_API_HOST || 'https://api.blackfynn.io/zipit/discover',
     ctf_event_id: 'event',
     ctf_news_id: 'news',
     ctf_resource_id: 'sparcPartners',
@@ -63,7 +65,8 @@ export default {
     CTF_API_HOST: process.env.CTF_API_HOST,
     BL_SERVER_URL: 'https://sparc.biolucida.net/api/v1/',
     BL_SHARE_LINK_PREFIX: 'https://sparc.biolucida.net/image?c=',
-    ROOT_URL: process.env.ROOT_URL || 'http://localhost:3000'
+    ROOT_URL: process.env.ROOT_URL || 'http://localhost:3000',
+    max_download_size: parseInt(process.env.MAX_DOWNLOAD_SIZE || '5000000000')
   },
 
   serverMiddleware: [

--- a/nuxt.config.js
+++ b/nuxt.config.js
@@ -34,6 +34,7 @@ export default {
     discover_api_host:
       process.env.BLACKFYNN_DISCOVER_API_HOST ||
       'https://api.blackfynn.io/discover',
+    bf_api_host: process.env.BF_API_HOST || 'https://api.blackfynn.io',
     zipit_api_host:
       process.env.ZIPIT_API_HOST || 'https://api.blackfynn.io/zipit/discover',
     ctf_event_id: 'event',

--- a/package.json
+++ b/package.json
@@ -13,7 +13,8 @@
     "lint": "eslint --ext .js,.vue --ignore-path .gitignore .",
     "lintfix": "eslint --fix --ext .js,.vue --ignore-path .gitignore .",
     "generate-icons": "vsvg -s ./static/icons-svg -t ./static/icons-js",
-    "test": "jest"
+    "test": "jest",
+    "test:debug": "node --inspect node_modules/.bin/jest --runInBand"
   },
   "dependencies": {
     "@abi-software/mapintegratedvuer": "^0.1.26",


### PR DESCRIPTION
# Description

The purpose of this PR is the add the feature to download multiple files on a dataset. This work was largely bringing over the `BfDownloadFile` component that does this same functionality on Discover.

## Type of change

- [x] New feature (non-breaking change which adds functionality)

# How Has This Been Tested?

- Open a data
- Go to the Files tab
- Select multiple files over 5GB
- Click on download button above the table
- A dialog should appear notifying you the download size is too big
- In the dialog, remove some packages to go under the download size
- Change the file's name
- Click the download button to download
- Download should begin, with the file's name you input
- Select one file that is under 5GB
- Click on download button above the table
- Download should begin

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x]  I have commented my code, particularly in hard-to-understand areas
- [x] I have added unit tests that prove my fix is effective or that my feature works
