### PR TITLE
Set description tab to be the default on Simulations page - CU-cuj6u5

### DIFF
--- a/pages/datasets/_datasetId.vue
+++ b/pages/datasets/_datasetId.vue
@@ -302,7 +302,7 @@ export default {
       errorLoading: false,
       loadingMarkdown: false,
       markdown: {},
-      activeTab: 'about',
+      activeTab: 'description',
       datasetRecords: [],
       discover_host: process.env.discover_api_host,
       isContributorListVisible: true,

--- a/pages/datasets/_datasetId.vue
+++ b/pages/datasets/_datasetId.vue
@@ -632,12 +632,6 @@ export default {
     }
   },
 
-  mounted() {
-    if (this.datasetType !== 'simulation') {
-      this.activeTab = 'description'
-    }
-  },
-
   methods: {
     /**
      * Sets active tab


### PR DESCRIPTION
# Description
The purpose of this PR is to set the description tab as the default tab on the simulations page.

[Wrike Ticket](https://www.wrike.com/workspace.htm?acc=3203588&wr=14#path=folder&t=502019661&a=3203588&id=441356195&st=space-441356195)
[Clickup Ticket](https://app.clickup.com/t/cuj6u5)

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

Navigate to a simulations page. The `description` tab should be the selected by default.

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
