### PR TITLE
fix(Datasets): Display proper date in results

### DIFF
--- a/components/SearchResults/DatasetSearchResults.vue
+++ b/components/SearchResults/DatasetSearchResults.vue
@@ -1,5 +1,9 @@
 <template>
-  <el-table :data="tableData" empty-text="No Results" @sort-change="onSortChange">
+  <el-table
+    :data="tableData"
+    empty-text="No Results"
+    @sort-change="onSortChange"
+  >
     <el-table-column
       :fixed="true"
       sortable="custom"
@@ -41,13 +45,28 @@
         </nuxt-link>
       </template>
     </el-table-column>
-    <el-table-column prop="description" label="Description" :width="areSimulationResults ? 550 : 400" />
-    <el-table-column prop="createdAt" label="Last Published" width="200" sortable="custom">
+    <el-table-column
+      prop="description"
+      label="Description"
+      :width="areSimulationResults ? 550 : 400"
+    />
+    <el-table-column
+      prop="createdAt"
+      label="Last Published"
+      width="200"
+      sortable="custom"
+    >
       <template slot-scope="scope">
-        {{ formatDate(scope.row.updatedAt) }}
+        {{ formatDate(scope.row.createdAt) }}
       </template>
     </el-table-column>
-    <el-table-column v-if="!areSimulationResults" prop="size" label="Size" width="150" sortable="custom">
+    <el-table-column
+      v-if="!areSimulationResults"
+      prop="size"
+      label="Size"
+      width="150"
+      sortable="custom"
+    >
       <template slot-scope="scope">
         {{ formatMetric(scope.row.size) }}
       </template>


### PR DESCRIPTION
# Description

The purpose of this PR is to fix an issue with ordering on the datasets search results. It was being ordered by date properly, but we were not display the correct date in the search results. This also includes some formatting issues.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

- Go to the find data/datasets page
- Datasets should be ordered newest to oldest
- Click on the "Last Published" column header to sort by date
- The datasets should be ordered oldest to newest

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
