### PR TITLE
feat(Resources): Update tabs to match design system

### DIFF
--- a/pages/resources/index.vue
+++ b/pages/resources/index.vue
@@ -10,23 +10,6 @@
         placeholder="Search resources"
         path="/resources"
       />
-      <ul class="resources__tabs">
-        <li v-for="type in tabTypes" :key="type.label">
-          <nuxt-link
-            class="resources__tabs--button"
-            :class="{ active: type.type === $route.query.type }"
-            :to="{
-              name: 'resources',
-              query: {
-                ...$route.query,
-                type: type.type
-              }
-            }"
-          >
-            {{ type.label }}
-          </nuxt-link>
-        </li>
-      </ul>
       <img
         v-if="fields.heroImage"
         slot="image"
@@ -34,44 +17,51 @@
         :src="fields.heroImage.fields.file.url"
       />
     </page-hero>
-    <div class="page-wrap container">
-      <div class="page-wrap__results">
-        <div class="resources-heading">
-          <p>
-            {{ currentResourceCount }} {{ resourceHeading }} | Showing
-            <pagination-menu
-              :page-size="resourceData.limit"
-              @update-page-size="updateDataSearchLimit"
-            />
-            <el-pagination
-              v-if="resourceData.limit < resourceData.total"
-              :page-size="resourceData.limit"
-              :pager-count="5"
-              :current-page="curSearchPage"
-              layout="prev, pager, next"
-              :total="resourceData.total"
-              @current-change="onPaginationPageChange"
-            />
-          </p>
+    <div class="page-wrap">
+      <div class="container">
+        <tab-nav
+          :tabs="tabTypes"
+          :active-tab="activeTab"
+          @set-active-tab="setActiveTab"
+        />
+        <div class="page-wrap__results">
+          <div class="resources-heading">
+            <p>
+              {{ currentResourceCount }} {{ resourceHeading }} | Showing
+              <pagination-menu
+                :page-size="resourceData.limit"
+                @update-page-size="updateDataSearchLimit"
+              />
+              <el-pagination
+                v-if="resourceData.limit < resourceData.total"
+                :page-size="resourceData.limit"
+                :pager-count="5"
+                :current-page="curSearchPage"
+                layout="prev, pager, next"
+                :total="resourceData.total"
+                @current-change="onPaginationPageChange"
+              />
+            </p>
+          </div>
         </div>
-      </div>
-      <div v-loading="isLoadingSearch" class="table-wrap">
-        <resources-search-results :table-data="tableData" />
-      </div>
-      <div class="resources-heading">
-        {{ currentResourceCount }} {{ resourceHeading }} | Showing
-        <pagination-menu
-          :page-size="resourceData.limit"
-          @update-page-size="updateDataSearchLimit"
-        />
-        <el-pagination
-          :page-size="resourceData.limit"
-          :pager-count="5"
-          :current-page="curSearchPage"
-          layout="prev, pager, next"
-          :total="resourceData.total"
-          @current-change="onPaginationPageChange"
-        />
+        <div v-loading="isLoadingSearch" class="table-wrap">
+          <resources-search-results :table-data="tableData" />
+        </div>
+        <div class="resources-heading">
+          {{ currentResourceCount }} {{ resourceHeading }} | Showing
+          <pagination-menu
+            :page-size="resourceData.limit"
+            @update-page-size="updateDataSearchLimit"
+          />
+          <el-pagination
+            :page-size="resourceData.limit"
+            :pager-count="5"
+            :current-page="curSearchPage"
+            layout="prev, pager, next"
+            :total="resourceData.total"
+            @current-change="onPaginationPageChange"
+          />
+        </div>
       </div>
     </div>
   </div>
@@ -83,6 +73,7 @@ import Breadcrumb from '@/components/Breadcrumb/Breadcrumb.vue'
 import ResourcesSearchResults from '@/components/Resources/ResourcesSearchResults.vue'
 import PageHero from '@/components/PageHero/PageHero.vue'
 import PaginationMenu from '@/components/Pagination/PaginationMenu.vue'
+import TabNav from '@/components/TabNav/TabNav.vue'
 import createClient from '@/plugins/contentful.js'
 import SearchControlsContentful from '@/components/SearchControlsContentful/SearchControlsContentful.vue';
 import { Computed, Data, Methods, Resource } from '~/pages/resources/model';
@@ -124,7 +115,8 @@ export default Vue.extend<Data, Methods, Computed, never>({
     Breadcrumb,
     ResourcesSearchResults,
     PageHero,
-    PaginationMenu
+    PaginationMenu,
+    TabNav
   },
 
   asyncData() {
@@ -152,7 +144,8 @@ export default Vue.extend<Data, Methods, Computed, never>({
       resourceData,
       tabTypes,
       isLoadingSearch: false,
-      resourceHeading: ''
+      resourceHeading: '',
+      activeTab: 'sparcPartners'
     }
   },
 
@@ -261,6 +254,20 @@ export default Vue.extend<Data, Methods, Computed, never>({
       this.resourceData.skip = offset
 
       this.fetchResults()
+    },
+
+    /**
+     * Set active tab
+     */
+    setActiveTab: function(tab) {
+      this.activeTab = tab
+      this.$router.push({
+        name: 'resources',
+        query: {
+          ...this.$route.query,
+          type: tab
+        }
+      })
     }
   }
 })
@@ -301,9 +308,6 @@ export default Vue.extend<Data, Methods, Computed, never>({
       p {
         margin-top: 1.5rem;
       }
-    }
-    @media (min-width: 48em) {
-      padding-top: 0;
     }
   }
 

--- a/pages/resources/model.ts
+++ b/pages/resources/model.ts
@@ -1,5 +1,6 @@
 import { Entry, EntryCollection } from 'contentful';
 import { Route } from 'vue-router';
+import VueRouter from 'vue-router';
 
 export interface Resource {
   description: string;
@@ -17,6 +18,7 @@ export interface Data {
   tabTypes: TabType[];
   isLoadingSearch: boolean;
   resourceHeading: string;
+  activeTab: string
 }
 
 export interface Computed {
@@ -29,9 +31,10 @@ export interface Methods {
   updateDataSearchLimit: (this: ResourcesComponent, limit: number | string) => void;
   fetchResults: (this: ResourcesComponent) => void;
   onPaginationPageChange: (this: ResourcesComponent, page: number) => void;
+  setActiveTab: (this: ResourcesComponent, tab: string) => void;
 }
 
-export type ResourcesComponent = Data & Computed & Methods & { $route: Route }
+export type ResourcesComponent = Data & Computed & Methods & { $route: Route, $router: VueRouter }
 
 type ResourceType = 'Platform' | 'Tool' | 'sparcPartners'
 


### PR DESCRIPTION
# Description

The purpose of this PR is to update the tabs on the Tools and Resources page to match the design system, and the tabs on the News and Events page.

![localhost_3000_(Laptop with HiDPI screen) (9)](https://user-images.githubusercontent.com/1493195/97743107-8fe09a00-1abb-11eb-9796-61fbec6371d2.png)

## Type of change

- [x] New feature (non-breaking change which adds functionality)

# How Has This Been Tested?

- Go to the [Tools & Resources](http://localhost:3000/resources?type=sparcPartners) page
- Utilizing the tabs should show the proper tab and results
- Utilizing the search bar in the page's hero should show results for the search term
- Utilizing the search bar in the site's hero, and selecting "Resources" from the dropdown should show results for the search term (especially from another page.)

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
