### PR TITLE
Fix resources tabs

### DIFF
--- a/pages/resources/index.vue
+++ b/pages/resources/index.vue
@@ -19,6 +19,11 @@
     </page-hero>
     <div class="page-wrap">
       <div class="container">
+        <tab-nav
+          :tabs="tabTypes"
+          :active-tab="activeTab"
+          @set-active-tab="setActiveTab"
+        />
         <div class="page-wrap__results">
           <div class="resources-heading">
             <p>
@@ -43,28 +48,6 @@
           <resources-search-results :table-data="tableData" />
         </div>
         <div class="resources-heading">
-          <tab-nav
-          :tabs="tabTypes"
-          :active-tab="activeTab"
-          @set-active-tab="setActiveTab"
-        />
-          <p>
-            {{ currentResourceCount }} {{ resourceHeading }} | Showing
-            <pagination-menu
-              :page-size="resourceData.limit"
-              @update-page-size="updateDataSearchLimit"
-            />
-            <el-pagination
-              v-if="resourceData.limit < resourceData.total"
-              :page-size="resourceData.limit"
-              :pager-count="5"
-              :current-page="curSearchPage"
-              layout="prev, pager, next"
-              :total="resourceData.total"
-              @current-change="onPaginationPageChange"
-            />
-          </p>
-
           {{ currentResourceCount }} {{ resourceHeading }} | Showing
           <pagination-menu
             :page-size="resourceData.limit"


### PR DESCRIPTION
# Description
The purpose of this PR is to fix the tabs on the resources page.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
# How Has This Been Tested?

- Go to the Tools and Resources page
- The tabs should be above the results, but below the hero

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
