### PR TITLE
passing new query param to indicate downloadOrigin

### DIFF
--- a/components/DownloadDataset/DownloadDataset.vue
+++ b/components/DownloadDataset/DownloadDataset.vue
@@ -156,7 +156,7 @@ export default {
      * @returns {String}
      */
     downloadUrl: function() {
-      return `${process.env.bf_api_host}/discover/datasets/${this.datasetId}/versions/${this.versionId}/download`
+      return `${process.env.bf_api_host}/discover/datasets/${this.datasetId}/versions/${this.versionId}/download?downloadOrigin=SPARC`
     }
   },
 


### PR DESCRIPTION
# Description

This PR aims to pass 'SPARC' as the value for the optional query parameter `downloadOrigin` when downloading a dataset directly from the back-end of `discover`


## Type of change

- [X] New feature (non-breaking change which adds functionality)

# How Has This Been Tested?

Went to download a Dataset and verified in the database that the download is labeled 'SPARC'

# Checklist:

- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my own code
