### PR TITLE
Add owner contact info to tools and resources

### DIFF
--- a/components/Resources/ResourcesSearchResults.vue
+++ b/components/Resources/ResourcesSearchResults.vue
@@ -15,6 +15,24 @@
         <p class="resources-search-results__items--content-date">
           {{ formatDate(data.sys.updatedAt) }}
         </p>
+
+        <template v-if="data.fields.owner">
+          <h3 class="metadata-title">
+            Owner
+          </h3>
+          <p>
+            <a
+              v-if="data.fields.contactEmail"
+              :href="`mailto:${data.fields.contactEmail}`"
+            >
+              {{ data.fields.owner }}
+            </a>
+            <template v-else>
+              {{ data.fields.owner }}
+            </template>
+          </p>
+        </template>
+
         <p class="resources-search-results__items--content-description">
           {{ data.fields.description }}
         </p>
@@ -54,17 +72,12 @@ export default {
 @import '@/assets/_variables.scss';
 .resources-search-results {
   &__items {
-    height: 9.375rem;
     display: flex;
     flex-direction: row;
     border-bottom: solid 1px $light-grey;
     padding: 1.25em 0;
     @media screen and (max-width: 768px) {
-      height: 100%;
       display: block;
-    }
-    @media screen and (max-width: 1024px) {
-      height: 100%;
     }
     h2 {
       font-size: 1em;
@@ -106,5 +119,13 @@ export default {
       color: $dark-sky;
     }
   }
+}
+.metadata-title {
+  color: $dark-sky;
+  font-size: 1em;
+  font-weight: 500;
+  line-height: 1.2;
+  margin-bottom: 0.375rem;
+  text-transform: uppercase;
 }
 </style>


### PR DESCRIPTION
# Description

The purpose of this PR is to add the owner and contact info to tools and resources. In addition, I fixed a bug where each resource may be too small for the content. This was due to the height specified when it shouldn't have been.

![localhost_3000_resources_type=sparcPartners(Laptop with HiDPI screen) (2)](https://user-images.githubusercontent.com/1493195/100901139-84eda080-3491-11eb-86e2-8ffe71d404ec.png)

## Type of change

- [x] New feature (non-breaking change which adds functionality)

# How Has This Been Tested?

- Go to the tools and resources page
- The owner should be listed, if available, and it should link to the email, if available. If there is no email, it should be plain text.

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
