### PR TITLE
feat(Dataset): Protocol links on separate lines

### DIFF
--- a/components/DatasetDetails/DatasetDescriptionInfo.vue
+++ b/components/DatasetDetails/DatasetDescriptionInfo.vue
@@ -11,15 +11,15 @@
         </strong>
       </p>
       <div v-if="datasetRecords.length !== 0">
-        <a
-          v-for="(record, index) in datasetRecords"
-          :key="`${record}-${index}`"
-          :href="record.properties.url"
-          target="_blank"
-          class="description-container__protocol-block--protocol-text"
-        >
-          {{ record.properties.url }}
-        </a>
+        <p v-for="record in datasetRecords" :key="record.properties.id">
+          <a
+            :href="record.properties.url"
+            target="_blank"
+            class="description-container__protocol-block--protocol-text"
+          >
+            {{ record.properties.url }}
+          </a>
+        </p>
       </div>
       <div
         v-else


### PR DESCRIPTION
# Description

The purpose of this PR is to make the protocol links appear on their own line.

## Before
![localhost_3000_datasets_32_type=dataset(Laptop with HiDPI screen) (1)](https://user-images.githubusercontent.com/1493195/101797103-a6750a80-3ad7-11eb-998b-4aa57e652972.png)

## After
![localhost_3000_datasets_32_type=dataset(Laptop with HiDPI screen)](https://user-images.githubusercontent.com/1493195/101797117-a96ffb00-3ad7-11eb-9cb6-64c55250854f.png)

## Type of change

- [x] New feature (non-breaking change which adds functionality)

# How Has This Been Tested?
[This dataset](http://localhost:3000/datasets/32?type=dataset) should have its protocol links on separate lines.

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas