### PR TITLE
Resource Page Modifications

### DIFF
--- a/components/Resources/ResourcesSearchResults.vue
+++ b/components/Resources/ResourcesSearchResults.vue
@@ -13,6 +13,9 @@
           <h2>{{ data.fields.name }}</h2>
         </a>
 
+        <template v-if="data.fields.developedBySparc">
+          <p class="resource-category">SPARC</p>
+        </template>
         <template v-if="data.fields.owner">
           <h3 class="metadata-title">
             Owner
@@ -29,6 +32,7 @@
             </template>
           </p>
         </template>
+
 
         <p class="resources-search-results__items--content-description">
           {{ data.fields.description }}
@@ -124,5 +128,17 @@ export default {
   line-height: 1.2;
   margin-bottom: 0.375rem;
   text-transform: uppercase;
+}
+
+.resource-category {
+  background: $median;
+  border-radius: 15px;
+  color: #fff;
+  font-size: .875rem;
+  top: 10px;
+  padding: 0 .65rem;
+  right: 14px;
+  width: fit-content;
+  margin-bottom: 10px;
 }
 </style>

--- a/components/Resources/ResourcesSearchResults.vue
+++ b/components/Resources/ResourcesSearchResults.vue
@@ -13,9 +13,7 @@
           <h2>{{ data.fields.name }}</h2>
         </a>
 
-        <template v-if="data.fields.developedBySparc">
-          <p class="resource-category">SPARC</p>
-        </template>
+        <p v-if="data.fields.developedBySparc" class="resource-category">SPARC</p>
         <template v-if="data.fields.owner">
           <h3 class="metadata-title">
             Owner

--- a/components/Resources/ResourcesSearchResults.vue
+++ b/components/Resources/ResourcesSearchResults.vue
@@ -12,9 +12,6 @@
         <a :href="data.fields.url" target="blank">
           <h2>{{ data.fields.name }}</h2>
         </a>
-        <p class="resources-search-results__items--content-date">
-          {{ formatDate(data.sys.updatedAt) }}
-        </p>
 
         <template v-if="data.fields.owner">
           <h3 class="metadata-title">


### PR DESCRIPTION
# Description

The purpose of this PR is to remove the `updatedDate` field and replace with a `developedBySparc` category for tools and resources.

[Clickup Ticket](https://app.clickup.com/t/guungw)
[Clickup Ticket](https://app.clickup.com/t/guvutf)

## Type of change

- [x] New feature (non-breaking change which adds functionality)

# How Has This Been Tested?

Navigate to the Tools and Resources page. You should no longer see a date underneath the title and now should see a purple SPARC pill if the resource was developed by SPARC.

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
