### PR TITLE
Fix date sorting on organs page for datasets - CU-guvtwh

### DIFF
--- a/components/SearchResults/DatasetSearchResults.vue
+++ b/components/SearchResults/DatasetSearchResults.vue
@@ -9,6 +9,7 @@
       sortable="custom"
       prop="name"
       label="Title"
+      :sort-orders="sortOrders"
       :width="titleColumnWidth"
     >
       <template slot-scope="scope">
@@ -55,6 +56,7 @@
       label="Last Published"
       width="200"
       sortable="custom"
+      :sort-orders="sortOrders"
     >
       <template slot-scope="scope">
         {{ formatDate(scope.row.createdAt) }}
@@ -66,6 +68,7 @@
       label="Size"
       width="150"
       sortable="custom"
+      :sort-orders="sortOrders"
     >
       <template slot-scope="scope">
         {{ formatMetric(scope.row.size) }}
@@ -93,6 +96,12 @@ export default {
     titleColumnWidth: {
       type: Number,
       default: () => 300
+    }
+  },
+
+  data() {
+    return {
+      sortOrders: ['ascending', 'descending']
     }
   },
 

--- a/pages/organs/_organId.vue
+++ b/pages/organs/_organId.vue
@@ -90,7 +90,7 @@ export default {
     const datasets = await $axios.$get(
       `${
         process.env.discover_api_host
-      }/search/datasets?query=${projectSection.toLowerCase()}&limit=100`
+      }/search/datasets?query=${projectSection.toLowerCase()}&limit=100&orderBy=date`
     )
 
     const tabsData = clone(tabs)

--- a/utils/toQueryParams.js
+++ b/utils/toQueryParams.js
@@ -1,0 +1,31 @@
+/**
+ * Turn a key value pair into a query param
+ * @param {String} key
+ * @param {String} value
+ * @returns {String}
+ */
+const toParam = (key, value) => {
+  return `${key}=${encodeURIComponent(value)}`
+}
+
+/**
+ * Take an object and transform it into URL query parameters
+ * @param {Object} params
+ * @returns {String}
+ */
+const toQueryParams = params =>
+  Object.keys(params)
+    .map(key => {
+      if (Array.isArray(params[key])) {
+        return params[key]
+          .map(param => {
+            return toParam(key, param)
+          })
+          .join('&')
+      }
+
+      return toParam(key, params[key])
+    })
+    .join('&')
+
+export default toQueryParams


### PR DESCRIPTION
# Description

The purpose of this PR is to fix the sorting for datasets on an organ's page, and allow the user to sort the datasets table.

## Type of change

- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)

# How Has This Been Tested?

- Go to the [Bladder/Lower Urinary Tract](http://localhost:3000/organs/54xPL40EaKrarCqBkAFExU) organ
- The datasets should be ordered by date
- Clicking on the Title or Date column headings should refetch the datasets and sort properly

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
