### PR TITLE
fix(Datasets): Use revised at date

### DIFF
--- a/components/DatasetDetails/DatasetAboutInfo.vue
+++ b/components/DatasetDetails/DatasetAboutInfo.vue
@@ -43,7 +43,8 @@
                   }"
                   @click="handleCitationChanged(citationType)"
                 >
-                  {{ citationType.label }}</a>
+                  {{ citationType.label }}
+                </a>
               </li>
               <li>
                 <a
@@ -65,9 +66,10 @@
               <p>
                 <strong>Internal Server Error</strong><br />
                 Sorry, something went wrong.<br />
-                The dataset citation generator
-                (<a href="https://citation.crosscite.org/" target="_blank">https://citation.crosscite.org/</a>)
-                encountered an internal error and was unable to complete your
+                The dataset citation generator (<a
+                  href="https://citation.crosscite.org/"
+                  target="_blank"
+                >https://citation.crosscite.org/</a>) encountered an internal error and was unable to complete your
                 request.<br />
                 Please come back later.
               </p>
@@ -361,7 +363,7 @@ export default {
     }
 
     &--citation-links {
-      border-bottom: 1px solid #E4E7ED;
+      border-bottom: 1px solid #e4e7ed;
       display: flex;
       flex-wrap: wrap;
       list-style: none;

--- a/pages/datasets/_datasetId.vue
+++ b/pages/datasets/_datasetId.vue
@@ -564,7 +564,8 @@ export default {
      * @return {String}
      */
     lastUpdatedDate: function() {
-      const date = propOr('', 'updatedAt', this.datasetInfo)
+      const date =
+        this.datasetInfo.revisedAt || this.datasetInfo.versionPublishedAt
       return this.formatDate(date)
     },
     /**
@@ -903,7 +904,7 @@ export default {
             name: this.datasetName,
             creator: creators,
             datePublished: this.datasetInfo.createdAt,
-            dateModified: this.datasetInfo.updatedAt,
+            dateModified: this.datasetInfo.revisedAt,
             description: this.datasetDescription,
             license: this.licenseLink,
             version: this.datasetInfo.version,


### PR DESCRIPTION
# Description

The purpose of this PR is to used the `revisedAt` date for datasets, and default to the `versionPublishedAt` date.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

Go to a dataset. The date should be the same in the following places
- About tab
  - Last updated
  - Cite this dataset
- Dataset details header

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
