### PR TITLE
using ZipIt for downloading files

### DIFF
--- a/mixins/request-download-file/index.js
+++ b/mixins/request-download-file/index.js
@@ -6,17 +6,19 @@ export default {
      * Request download file via axios.
      */
     requestDownloadFile: function(downloadInfo) {
-      const filePath = compose(
-        last,
-        defaultTo([]),
-        split('s3://blackfynn-discover-use1/'),
-        propOr('', 'uri'),
-      )(downloadInfo)
-
       const fileName = propOr('', 'name', downloadInfo)
+      const datasetVersionRegexp = /s3:\/\/blackfynn-discover-use1\/(?<datasetId>\d*)\/(?<version>\d*)\/(?<filePath>.*)/;
+      const matches = downloadInfo.uri.match(datasetVersionRegexp)
 
-      const requestUrl = `${process.env.portal_api}/download?key=${filePath}`
-      this.$axios.$get(requestUrl).then((response) => {
+      const payload = {
+        data: {
+          paths: [matches.groups.filePath],
+          datasetId: matches.groups.datasetId,
+          version: matches.groups.version
+        }
+      }
+
+      this.$axios.post(process.env.zipit_api_host, payload).then((response) => {
         this._downloadFile(fileName, response)
       })
     },


### PR DESCRIPTION
# Description

This PR aims to change the way we download individual files. By using the ZipIt endoint, we allow the file download to be counted in the Download Metrics

## Type of change

- [X] New feature (non-breaking change which adds functionality)

# How was it tested
1/ Run a local instance of ZipIt `npm run start:prod`
2/ set the environment variable ZIPIT_API_HOST="localhost:8080"
3/ run the sparc-app server
4/ navigate to a file browser in a dataset
5/ click on the "..." at the end of the line and click download

Alternate ending:
5/ click on the file to go to the file details page
6/ click on "Download"

In both cases, the download works and is done via ZipIt.

# Checklist:

- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my own code
- [X] I have commented my code, particularly in hard-to-understand areas
