### PR TITLE
proper way to create the downloaded file

### DIFF
--- a/mixins/request-download-file/index.js
+++ b/mixins/request-download-file/index.js
@@ -7,15 +7,18 @@ export default {
      * Request download file via axios.
      */
     requestDownloadFile: function(downloadInfo) {
-      const filePath = compose(
-        last,
-        defaultTo([]),
-        split('s3://blackfynn-discover-use1/'),
-        propOr('', 'uri'),
-      )(downloadInfo)
 
       const fileName = propOr('', 'name', downloadInfo)
+      const datasetVersionRegexp = /s3:\/\/blackfynn-discover-use1\/(?<datasetId>\d*)\/(?<version>\d*)\/(?<filePath>.*)/;
+      const matches = downloadInfo.uri.match(datasetVersionRegexp)
 
+      const payload = {
+        data: {
+          paths: [matches.groups.filePath],
+          datasetId: matches.groups.datasetId,
+          version: matches.groups.version
+        }
+      }
       this.$axios.$post(process.env.zipit_api_host, payload).then((response) => {
         FileDownload(response, fileName)
       })

--- a/mixins/request-download-file/index.js
+++ b/mixins/request-download-file/index.js
@@ -1,4 +1,5 @@
 import { compose, last, defaultTo, split, propOr } from 'ramda'
+import FileDownload from 'js-file-download'
 
 export default {
   methods: {
@@ -18,26 +19,9 @@ export default {
         }
       }
 
-      this.$axios.post(process.env.zipit_api_host, payload).then((response) => {
-        this._downloadFile(fileName, response)
+      this.$axios.$post(process.env.zipit_api_host, payload).then((response) => {
+        FileDownload(response, fileName)
       })
     },
-  /**
-   * Create an `a` tag to trigger downloading file
-   * @param {String} filename
-   * @param {String} url
-   */
-  _downloadFile: function(filename, url) {
-    const el = document.createElement('a')
-    el.setAttribute('href', url)
-    el.setAttribute('download', filename)
-
-    el.style.display = 'none'
-    document.body.appendChild(el)
-
-    el.click()
-
-    document.body.removeChild(el)
-  },
 }
 }

--- a/mixins/request-download-file/index.js
+++ b/mixins/request-download-file/index.js
@@ -6,17 +6,19 @@ export default {
      * Request download file via axios.
      */
     requestDownloadFile: function(downloadInfo) {
-      const filePath = compose(
-        last,
-        defaultTo([]),
-        split('s3://blackfynn-discover-use1/'),
-        propOr('', 'uri'),
-      )(downloadInfo)
-
       const fileName = propOr('', 'name', downloadInfo)
+      const datasetVersionRegexp = /s3:\/\/blackfynn-discover-use1\/(?<datasetId>\d*)\/(?<version>\d*)\/(?<filePath>.*)/;
+      const matches = downloadInfo.uri.match(datasetVersionRegexp)
 
-      const requestUrl = `${process.env.portal_api}/download?key=${filePath}`
-      this.$axios.$get(requestUrl).then((response) => {
+      const payload = {
+        data: {
+          paths: [matches.groups.filePath],
+          datasetId: matches.groups.datasetId,
+          version: matches.groups.version
+        }
+      }
+
+      this.$axios.post(process.env.zipit_api_host, payload).then((response) => {
         this._downloadFile(fileName, response)
       })
     },

--- a/package.json
+++ b/package.json
@@ -34,6 +34,7 @@
     "eslint-loader": "^3.0.3",
     "eslint-plugin-prettier": "^3.1.2",
     "eslint-plugin-vue": "^6.1.2",
+    "js-file-download": "^0.4.12",
     "marked": "^0.7.0",
     "nuxt": "^2.12.1",
     "prettier": "^1.19.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -9456,6 +9456,11 @@ js-beautify@^1.6.12:
     mkdirp "^1.0.4"
     nopt "^5.0.0"
 
+js-file-download@^0.4.12:
+  version "0.4.12"
+  resolved "https://registry.yarnpkg.com/js-file-download/-/js-file-download-0.4.12.tgz#10c70ef362559a5b23cdbdc3bd6f399c3d91d821"
+  integrity sha512-rML+NkoD08p5Dllpjo0ffy4jRHeY6Zsapvr/W86N7E0yuzAO6qa5X9+xog6zQNlH102J7IXljNY2FtS6Lj3ucg==
+
 js-sha3@0.8.0:
   version "0.8.0"
   resolved "https://registry.yarnpkg.com/js-sha3/-/js-sha3-0.8.0.tgz#b9b7a5da73afad7dedd0f8c463954cbde6818840"


### PR DESCRIPTION
# Description

This PR aims to change the way we download individual files. By using the ZipIt endoint, we allow the file download to be counted in the Download Metrics

## Type of change

- [X] New feature (non-breaking change which adds functionality)

# How was it tested
1/ run `export ZIPIT_API_HOST="https://cors-anywhere.herokuapp.com/https://api.blackfynn.io/zipit/discover"` to avoid CORS issue due to the sparc-app running as localhost (blocked by ZipIt)
2/ run the sparc-app server
3/ navigate to a file browser in a dataset
4/ click on the "..." at the end of the line and click download

Alternate ending:
4/ click on the file to go to the file details page
5/ click on "Download"

In both cases, the download works and is done via ZipIt.

# Checklist:

- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my own code
- [X] I have commented my code, particularly in hard-to-understand areas
