### PR TITLE
feat(Tables): Add support for markdown tables

### DIFF
--- a/assets/components/_el-table.scss
+++ b/assets/components/_el-table.scss
@@ -1,5 +1,64 @@
+@import '../_variables.scss';
+
 .el-table {
+  color: $dark-sky;
+  font-size: 1rem;
+  &__fixed-body-wrapper {
+    td:first-child .cell {
+      padding-right: 2.5rem;
+    }
+  }
+  td {
+    background: #fff;
+    padding: 1.5rem 0 2rem;
+    vertical-align: top;
+  }
   .cell {
+    padding-left: 1rem;
+    padding-right: 1rem;
     word-break: normal
   }
+}
+
+.table-wrap {
+  border: 1px solid rgb(219, 223, 230);
+  padding: 0 1.5rem;
+}
+
+// DEFAULT HTML TABLE
+
+/*
+ * Style all tables the same as .el-table, but
+ * make sure that `table` children inside of an
+ * .el-table don't also get these styles applied
+ */
+table:not([class^="el-table__"]) {
+  @extend .el-table;
+  border: 1px solid #dbdfe6;
+  border-spacing: 0;
+  padding: 0 1.5rem;
+  th,
+  td {
+    border-left: none;
+    border-right: none;
+    border-bottom: 1px solid #dbdfe6;
+    padding: 0.75rem 1rem;
+    transition: background-color 0.25s ease;
+  }
+  tr:last-child td {
+    border: none;
+  }
+  tr:hover td {
+    background-color: #f3e6f9;
+  }
+}
+
+thead {
+  th {
+    color: $dark-sky;
+    font-weight: 500;
+  }
+}
+td {
+  vertical-align: top;
 }

--- a/assets/components/_el-table.scss
+++ b/assets/components/_el-table.scss
@@ -62,3 +62,8 @@ thead {
 td {
   vertical-align: top;
 }
+
+.markdown-table-wrap {
+  overflow: scroll;
+  width: 100%;
+}

--- a/mixins/marked/index.js
+++ b/mixins/marked/index.js
@@ -6,6 +6,7 @@ import marked from 'marked'
  */
 const renderer = new marked.Renderer()
 const linkRenderer = renderer.link
+const tableRenderer = renderer.table
 
 const isAnchor = str => {
   return /(?:^|\s)(#[^ ]+)/i.test(str)
@@ -22,6 +23,12 @@ renderer.link = function(href, title, text) {
   return isInternal
     ? html
     : html.replace(/^<a /, '<a target="_blank" rel="nofollow" ')
+}
+
+renderer.table = function(header, body) {
+  const html = tableRenderer.call(renderer, header, body)
+
+  return `<div class="markdown-table-wrap">${html}</div>`
 }
 
 marked.setOptions({


### PR DESCRIPTION
# Description

The purpose of this PR is to add styles for markdown tables, which would be added in Contentful. This does not yet use the [SPARC Design System components](https://github.com/nih-sparc/sparc-design-system-components) directly, as that a much larger ticket, but it is the same styles from that library.

## Type of change

- [x] New feature (non-breaking change which adds functionality)
# How Has This Been Tested?

- Navigate to [this help article](http://localhost:3000/help/6QBSfoJRRLo1BmaKMuQUYO)
- The table should render properly on all viewports, scrolling horizontally if necessary.

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have added unit tests that prove my fix is effective or that my feature works
