### PR TITLE
fix(Homepage): Fix bug where site will crash if no news

### DIFF
--- a/pages/index.vue
+++ b/pages/index.vue
@@ -60,7 +60,19 @@ export default {
       client.getEntry(process.env.ctf_home_page_id)
     ])
       .then(([homepage]) => {
-        return { ...homepage.fields }
+        const fields = homepage.fields || {}
+
+        return {
+          heroHeading: fields.heroHeading || '',
+          heroCopy: fields.heroCopy || '',
+          heroButtonLabel: fields.heroButtonLabel || '',
+          heroImage: fields.heroImage || {},
+          heroButtonLink: fields.heroButtonLink || '',
+          featuredData: fields.featuredData || [],
+          newsAndEvents: fields.newsAndEvents || [],
+          testimonials: fields.testimonials || [],
+          title: fields.title || ''
+        }
       })
       .catch(console.error)
   },

--- a/pages/index.vue
+++ b/pages/index.vue
@@ -39,6 +39,7 @@ import HomepageTwitter from '@/components/HomepageTwitter/HomepageTwitter.vue'
 
 import createClient from '@/plugins/contentful.js'
 import marked from '@/mixins/marked/index'
+import getHomepageFields from '@/utils/homepageFields'
 
 const client = createClient()
 export default {
@@ -60,19 +61,7 @@ export default {
       client.getEntry(process.env.ctf_home_page_id)
     ])
       .then(([homepage]) => {
-        const fields = homepage.fields || {}
-
-        return {
-          heroHeading: fields.heroHeading || '',
-          heroCopy: fields.heroCopy || '',
-          heroButtonLabel: fields.heroButtonLabel || '',
-          heroImage: fields.heroImage || {},
-          heroButtonLink: fields.heroButtonLink || '',
-          featuredData: fields.featuredData || [],
-          newsAndEvents: fields.newsAndEvents || [],
-          testimonials: fields.testimonials || [],
-          title: fields.title || ''
-        }
+        return getHomepageFields(homepage.fields)
       })
       .catch(console.error)
   },

--- a/utils/homepageFields.js
+++ b/utils/homepageFields.js
@@ -1,0 +1,18 @@
+/**
+ * Get homepage fields, but default to empty values
+ * @param {Object} field
+ * @returns {Object}
+ */
+export default (fields = {}) => {
+  return {
+    heroHeading: fields.heroHeading || '',
+    heroCopy: fields.heroCopy || '',
+    heroButtonLabel: fields.heroButtonLabel || '',
+    heroImage: fields.heroImage || {},
+    heroButtonLink: fields.heroButtonLink || '',
+    featuredData: fields.featuredData || [],
+    newsAndEvents: fields.newsAndEvents || [],
+    testimonials: fields.testimonials || [],
+    title: fields.title || ''
+  }
+}

--- a/utils/homepageFields.spec.js
+++ b/utils/homepageFields.spec.js
@@ -1,0 +1,27 @@
+import getHomepageFields from './homepageFields'
+
+const defaultData = {
+  heroHeading: '',
+  heroCopy: '',
+  heroButtonLabel: '',
+  heroImage: {},
+  heroButtonLink: '',
+  featuredData: [],
+  newsAndEvents: [],
+  testimonials: [],
+  title: ''
+}
+
+describe('homepageFields', () => {
+  it('Should return default data if no fields provided', () => {
+    const fields = getHomepageFields({})
+    expect(fields).toMatchObject(defaultData)
+  })
+
+  it('Should return default data if some fields are missing', () => {
+    const fields = getHomepageFields({
+      heroHeading: 'foo'
+    })
+    expect(fields).toMatchObject({ ...defaultData, heroHeading: 'foo' })
+  })
+})


### PR DESCRIPTION
# Description

The purpose of this PR is to fix a bug where the site would should be error message for the homepage if there was no news. This bug was a result in Contentful not returning empty fields (which is a standard REST practice) and which would then result in the component being passed `undefined`. For the case with the news, you can't run `filter()` on `undefined`, which would then crash the page.

# Clickup Ticket
https://app.clickup.com/t/jjvfbf

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

- Unit test was written to test empty response as well as missing fields from the response.
- Homepage renders correctly

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have added unit tests that prove my fix is effective or that my feature works
