### PR TITLE
feat(Datasets): Show references in about tab

### DIFF
--- a/components/DatasetDetails/DatasetAboutInfo.vue
+++ b/components/DatasetDetails/DatasetAboutInfo.vue
@@ -69,7 +69,8 @@
                 The dataset citation generator (<a
                   href="https://citation.crosscite.org/"
                   target="_blank"
-                >https://citation.crosscite.org/</a>) encountered an internal error and was unable to complete your
+                  >https://citation.crosscite.org/</a
+                >) encountered an internal error and was unable to complete your
                 request.<br />
                 Please come back later.
               </p>
@@ -92,6 +93,18 @@
       <div v-else>
         <p>N/A</p>
       </div>
+
+      <div v-if="externalPublications.length" class="row mt-24">
+        <div class="col-xs-12">
+          <h3>References</h3>
+          <external-publication-list-item
+            v-for="publication in externalPublications"
+            :key="publication.doi"
+            class="mb-16"
+            :publication="publication"
+          />
+        </div>
+      </div>
     </div>
   </div>
 </template>
@@ -99,6 +112,7 @@
 <script>
 import { compose, propOr, head } from 'ramda'
 
+import ExternalPublicationListItem from '@/components/ExternalPublicationListItem/ExternalPublicationListItem.vue'
 import TagList from '@/components/TagList/TagList.vue'
 
 import { successMessage, failMessage } from '@/utils/notification-messages'
@@ -106,6 +120,7 @@ export default {
   name: 'DatasetAboutInfo',
 
   components: {
+    ExternalPublicationListItem,
     TagList
   },
   props: {
@@ -137,6 +152,11 @@ export default {
     datasetOwnerEmail: {
       type: String,
       default: ''
+    },
+
+    externalPublications: {
+      type: Array,
+      default: () => []
     }
   },
 

--- a/components/ExternalPublicationListItem/ExternalPublicationListItem.vue
+++ b/components/ExternalPublicationListItem/ExternalPublicationListItem.vue
@@ -1,0 +1,55 @@
+<template>
+  <div class="external-publication-list-item">
+    <p v-if="citation" class="mb-0" v-html="$sanitize(citation, ['i', 'b'])" />
+  </div>
+</template>
+
+<script>
+export default {
+  name: 'ExternalPublicationListItem',
+
+  props: {
+    publication: {
+      type: Object,
+      default: () => {
+        return {
+          doi: ''
+        }
+      }
+    }
+  },
+
+  data() {
+    return {
+      citation: ''
+    }
+  },
+
+  mounted() {
+    this.getDoi()
+  },
+
+  methods: {
+    /**
+     * Get the DOI from doi.org
+     */
+    async getDoi() {
+      this.citation = await this.$axios.$get(
+        `https://doi.org/${this.publication.doi}`,
+        {
+          headers: {
+            Accept: 'text/x-bibliography; style=apa; locale=en-US'
+          }
+        }
+      )
+    }
+  }
+}
+</script>
+
+<style lang="scss" scoped>
+@import '../../assets/_variables.scss';
+.external-publication-list-item {
+  font-size: 0.875rem;
+}
+</style>

--- a/pages/datasets/_datasetId.vue
+++ b/pages/datasets/_datasetId.vue
@@ -135,6 +135,7 @@
           :dataset-tags="datasetTags"
           :dataset-owner-name="datasetOwnerName"
           :dataset-owner-email="datasetOwnerEmail"
+          :external-publications="externalPublications"
         />
         <dataset-files-info
           v-show="activeTab === 'files'"
@@ -299,21 +300,26 @@ const getImagesData = async (datasetId, datasetDetails, $axios) => {
       })
     }
 
-    // This data can be found via scicrunch. Currently is hardcoded while waiting for 
+    // This data can be found via scicrunch. Currently is hardcoded while waiting for
     // ImageGallery.vue to start making scicrunch calls
     let plotData = Plots[datasetId]
     if (plotData) {
       plotData = [plotData]
     }
 
-    // This data can be found via scicrunch. Currently is hardcoded while waiting for 
+    // This data can be found via scicrunch. Currently is hardcoded while waiting for
     // ImageGallery.vue to start making scicrunch calls
     let videoData = Videos[datasetId]
     if (videoData) {
       videoData = [videoData]
     }
 
-    if (imagesData.status === 'success' || scaffoldData.length || plotData || videoData) {
+    if (
+      imagesData.status === 'success' ||
+      scaffoldData.length ||
+      plotData ||
+      videoData
+    ) {
       tabsData.push({ label: 'Gallery', type: 'images' })
     }
 
@@ -600,6 +606,13 @@ export default {
      */
     datasetTags: function() {
       return propOr([], 'tags', this.datasetInfo)
+    },
+    /**
+     * Returns list of external publications for dataset
+     * @returns {Array}
+     */
+    externalPublications: function() {
+      return propOr([], 'externalPublications', this.datasetInfo)
     },
     /**
      * Returns the current location href from the window object


### PR DESCRIPTION
# Description

The purpose of this PR is to show the references in the about tab for a dataset, if available. This is using the same `ExternalPublicationListItem` component from Discover.

## Type of change

- [x] New feature (non-breaking change which adds functionality)

# How Has This Been Tested?

- Open [a dataset with references](http://localhost:3000/datasets/97?type=dataset) and go to the about tab
- References should be listed at the bottom of this tab
- Open [a dataset without references](http://localhost:3000/datasets/94?type=dataset) and go to the about tab
- The references section, including the heading, should not be shown

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
