### PR TITLE
Feat news and events pages cu jjvd87

### DIFF
--- a/components/EventCard/EventCard.vue
+++ b/components/EventCard/EventCard.vue
@@ -5,14 +5,14 @@
       <span>{{ event.fields.eventType }}</span>
     </div>
     <h3>
-      <router-link
+      <nuxt-link
         :to="{
           name: 'news-and-events-events-id',
           params: { id: event.sys.id }
         }"
       >
         {{ event.fields.title }}
-      </router-link>
+      </nuxt-link>
     </h3>
     <div class="upcoming-event__detail">
       <svg-icon name="icon-calendar" height="16" width="16" />

--- a/components/EventCard/EventCard.vue
+++ b/components/EventCard/EventCard.vue
@@ -5,9 +5,14 @@
       <span>{{ event.fields.eventType }}</span>
     </div>
     <h3>
-      <a :href="event.fields.url" target="_blank">
+      <router-link
+        :to="{
+          name: 'news-and-events-events-id',
+          params: { id: event.sys.id }
+        }"
+      >
         {{ event.fields.title }}
-      </a>
+      </router-link>
     </h3>
     <div class="upcoming-event__detail">
       <svg-icon name="icon-calendar" height="16" width="16" />

--- a/components/HomepageNews/HomepageNews.vue
+++ b/components/HomepageNews/HomepageNews.vue
@@ -15,14 +15,14 @@
       >
         <div>
           <h3>
-            <router-link
+            <nuxt-link
               :to="{
                 name: 'news-and-events-news-id',
                 params: { id: item.sys.id }
               }"
             >
               {{ item.fields.title }}
-            </router-link>
+            </nuxt-link>
           </h3>
           <div class="sparc-card__detail">
             <svg-icon name="icon-calendar" height="16" width="16" />
@@ -41,7 +41,7 @@
           <!-- marked will sanitize the HTML injected -->
           <div v-html="parseMarkdown(item.fields.summary)" />
         </div>
-        <router-link
+        <nuxt-link
           :to="{
             name: 'news-and-events-news-id',
             params: { id: item.sys.id }
@@ -50,7 +50,7 @@
           <el-button size="medium">
             Learn More
           </el-button>
-        </router-link>
+        </nuxt-link>
       </sparc-card>
     </div>
   </div>

--- a/components/HomepageNews/HomepageNews.vue
+++ b/components/HomepageNews/HomepageNews.vue
@@ -15,9 +15,14 @@
       >
         <div>
           <h3>
-            <a :href="item.fields.url" target="_blank">
+            <router-link
+              :to="{
+                name: 'news-and-events-news-id',
+                params: { id: item.sys.id }
+              }"
+            >
               {{ item.fields.title }}
-            </a>
+            </router-link>
           </h3>
           <div class="sparc-card__detail">
             <svg-icon name="icon-calendar" height="16" width="16" />
@@ -36,11 +41,16 @@
           <!-- marked will sanitize the HTML injected -->
           <div v-html="parseMarkdown(item.fields.summary)" />
         </div>
-        <a :href="item.fields.url" target="_blank">
+        <router-link
+          :to="{
+            name: 'news-and-events-news-id',
+            params: { id: item.sys.id }
+          }"
+        >
           <el-button size="medium">
             Learn More
           </el-button>
-        </a>
+        </router-link>
       </sparc-card>
     </div>
   </div>

--- a/components/NewsEventsPage/NewsEventsPage.vue
+++ b/components/NewsEventsPage/NewsEventsPage.vue
@@ -82,6 +82,10 @@ export default {
       default: () => {
         return {}
       }
+    },
+    content: {
+      type: String,
+      default: ''
     }
   },
 
@@ -110,7 +114,7 @@ export default {
      * @returns {String}
      */
     htmlContent() {
-      return this.page.fields.copy || ''
+      return this.content || ''
     },
 
     /**

--- a/components/NewsEventsPage/NewsEventsPage.vue
+++ b/components/NewsEventsPage/NewsEventsPage.vue
@@ -17,9 +17,8 @@
 
             <h3>Share</h3>
             <share-network
-              class="btn-share"
               network="facebook"
-              tag="button"
+              tag="el-button"
               :url="pageUrl"
               :title="page.fields.title"
               :description="page.fields.summary"
@@ -27,18 +26,16 @@
               Share on Facebook
             </share-network>
             <share-network
-              class="btn-share"
               network="twitter"
-              tag="button"
+              tag="el-button"
               :url="pageUrl"
               :title="page.fields.title"
             >
               Share on Twitter
             </share-network>
             <share-network
-              class="btn-share"
               network="linkedin"
-              tag="button"
+              tag="el-button"
               :url="pageUrl"
               :title="page.fields.title"
             >
@@ -158,11 +155,5 @@ export default {
     height: auto;
     max-width: 100%;
   }
-}
-.btn-share {
-  background: none;
-  border: none;
-  cursor: pointer;
-  padding: 0;
 }
 </style>

--- a/components/NewsEventsPage/NewsEventsPage.vue
+++ b/components/NewsEventsPage/NewsEventsPage.vue
@@ -1,0 +1,169 @@
+<template>
+  <div>
+    <breadcrumb :breadcrumb="breadcrumb" :title="page.fields.title" />
+    <page-hero>
+      <h1>{{ page.fields.title }}</h1>
+      <p>
+        {{ page.fields.summary }}
+      </p>
+    </page-hero>
+    <div class="page-wrap container">
+      <div class="subpage">
+        <!-- eslint-disable vue/no-v-html -->
+        <!-- marked will sanitize the HTML injected -->
+        <el-row :gutter="32">
+          <el-col :xs="24" :sm="{ span: 12, push: 12 }" class="details">
+            <slot />
+
+            <h3>Share</h3>
+            <share-network
+              class="btn-share"
+              network="facebook"
+              tag="button"
+              :url="pageUrl"
+              :title="page.fields.title"
+              :description="page.fields.summary"
+            >
+              Share on Facebook
+            </share-network>
+            <share-network
+              class="btn-share"
+              network="twitter"
+              tag="button"
+              :url="pageUrl"
+              :title="page.fields.title"
+            >
+              Share on Twitter
+            </share-network>
+            <share-network
+              class="btn-share"
+              network="linkedin"
+              tag="button"
+              :url="pageUrl"
+              :title="page.fields.title"
+            >
+              Share on LinkedIn
+            </share-network>
+          </el-col>
+          <el-col :xs="24" :sm="{ span: 12, pull: 12 }">
+            <div class="content" v-html="parseMarkdown(htmlContent)" />
+          </el-col>
+        </el-row>
+      </div>
+    </div>
+  </div>
+</template>
+
+<script>
+import { pathOr } from 'ramda'
+
+import MarkedMixin from '@/mixins/marked'
+import FormatDate from '@/mixins/format-date'
+import Breadcrumb from '@/components/Breadcrumb/Breadcrumb'
+import PageHero from '@/components/PageHero/PageHero'
+
+import createClient from '@/plugins/contentful.js'
+
+const client = createClient()
+
+export default {
+  name: 'NewsEventsPage',
+
+  components: {
+    Breadcrumb,
+    PageHero
+  },
+
+  mixins: [FormatDate, MarkedMixin],
+
+  props: {
+    page: {
+      type: Object,
+      default: () => {
+        return {}
+      }
+    }
+  },
+
+  data() {
+    return {
+      breadcrumb: [
+        {
+          label: 'Home',
+          to: {
+            name: 'index'
+          }
+        },
+        {
+          label: 'News & Events',
+          to: {
+            name: 'news-and-events'
+          }
+        }
+      ]
+    }
+  },
+
+  computed: {
+    /**
+     * Compute HTML Content for the page
+     * @returns {String}
+     */
+    htmlContent() {
+      return this.page.fields.copy || ''
+    },
+
+    /**
+     * Compute the full URL of the page
+     * @returns {String}
+     */
+    pageUrl: function() {
+      return `${process.env.ROOT_URL}${this.$route.fullPath}`
+    }
+  }
+}
+</script>
+
+<style lang="scss" scoped>
+@import '@/assets/_variables.scss';
+
+.content {
+  & ::v-deep {
+    color: $vestibular;
+  }
+  & ::v-deep p {
+    margin-bottom: 1em;
+  }
+  & ::v-deep img {
+    height: auto;
+    margin: 0.5em 0;
+    max-width: 100%;
+  }
+}
+
+.header {
+  margin-bottom: 3em;
+  .updated {
+    color: #aaa;
+  }
+}
+.details ::v-deep {
+  font-size: 0.875rem;
+  h3 {
+    font-size: 0.875rem;
+    font-weight: 500;
+    line-height: 1.5rem;
+    text-transform: uppercase;
+  }
+  img {
+    height: auto;
+    max-width: 100%;
+  }
+}
+.btn-share {
+  background: none;
+  border: none;
+  cursor: pointer;
+  padding: 0;
+}
+</style>

--- a/components/NewsEventsPage/NewsEventsPage.vue
+++ b/components/NewsEventsPage/NewsEventsPage.vue
@@ -55,16 +55,10 @@
 </template>
 
 <script>
-import { pathOr } from 'ramda'
-
 import MarkedMixin from '@/mixins/marked'
 import FormatDate from '@/mixins/format-date'
 import Breadcrumb from '@/components/Breadcrumb/Breadcrumb'
 import PageHero from '@/components/PageHero/PageHero'
-
-import createClient from '@/plugins/contentful.js'
-
-const client = createClient()
 
 export default {
   name: 'NewsEventsPage',
@@ -138,7 +132,8 @@ export default {
   & ::v-deep p {
     margin-bottom: 1em;
   }
-  & ::v-deep img {
+  & ::v-deep img,
+  & ::v-deep video {
     height: auto;
     margin: 0.5em 0;
     max-width: 100%;

--- a/components/NewsListItem/NewsListItem.vue
+++ b/components/NewsListItem/NewsListItem.vue
@@ -1,7 +1,14 @@
 <template>
   <div class="news-list-item">
     <h3>
-      <a :href="item.fields.url" target="_blank">{{ item.fields.title }}</a>
+      <router-link
+        :to="{
+          name: 'news-and-events-news-id',
+          params: { id: item.sys.id }
+        }"
+      >
+        {{ item.fields.title }}
+      </router-link>
     </h3>
     <p>{{ item.fields.summary }}</p>
     <p class="news-list-item__date">
@@ -31,7 +38,7 @@ export default {
      * @returns {String}
      */
     publishedDate: function() {
-      return this.formatDate(this.item.fields.publishedDate)
+      return this.formatDate(this.item.fields.publishedDate || '')
     }
   }
 }

--- a/components/NewsListItem/NewsListItem.vue
+++ b/components/NewsListItem/NewsListItem.vue
@@ -1,14 +1,14 @@
 <template>
   <div class="news-list-item">
     <h3>
-      <router-link
+      <nuxt-link
         :to="{
           name: 'news-and-events-news-id',
           params: { id: item.sys.id }
         }"
       >
         {{ item.fields.title }}
-      </router-link>
+      </nuxt-link>
     </h3>
     <p>{{ item.fields.summary }}</p>
     <p class="news-list-item__date">

--- a/mixins/marked/index.js
+++ b/mixins/marked/index.js
@@ -31,6 +31,18 @@ renderer.table = function(header, body) {
   return `<div class="markdown-table-wrap">${html}</div>`
 }
 
+renderer.oldImage = renderer.image
+
+renderer.image = function(href, title, text) {
+  const videos = ['webm', 'mp4', 'mov']
+  const filetype = href.split('.').pop()
+  if (videos.indexOf(filetype) > -1) {
+    return `<video alt="${text}" controls><source src="${href}" type="video/${filetype}"></video>`
+  } else {
+    return renderer.oldImage(href, title, text)
+  }
+}
+
 marked.setOptions({
   sanitize: true,
   renderer

--- a/nuxt.config.js
+++ b/nuxt.config.js
@@ -120,7 +120,8 @@ export default {
     '@nuxtjs/axios',
     '@nuxtjs/robots',
     'cookie-universal-nuxt',
-    '@miyaoka/nuxt-twitter-widgets-module'
+    '@miyaoka/nuxt-twitter-widgets-module',
+    'vue-social-sharing/nuxt'
   ],
   /*
    ** robots.txt

--- a/package.json
+++ b/package.json
@@ -47,6 +47,7 @@
     "vue-clipboard2": "^0.3.1",
     "vue-infinite-loading": "^2.4.4",
     "vue-meta": "^2.3.2",
+    "vue-social-sharing": "^3.0.4",
     "vue-svgicon": "^3.2.6"
   },
   "devDependencies": {

--- a/pages/news-and-events/events/_id.vue
+++ b/pages/news-and-events/events/_id.vue
@@ -1,16 +1,16 @@
 <template>
-  <news-events-page :page="page" :content="page.fields.copy">
+  <news-events-page :page="page" :content="page.fields.description">
     <img :src="newsImage" :alt="newsImageAlt" />
     <hr />
-    <h3>Published Date</h3>
-    <p>{{ publishedDate }}</p>
 
-    <h3>External Link</h3>
-    <p>
-      <a :href="page.fields.url" target="_blank">
-        {{ page.fields.title }}
-      </a>
-    </p>
+    <h3>Type</h3>
+    <p>{{ page.fields.eventType }}</p>
+
+    <h3>Date</h3>
+    <p>{{ eventDate }}</p>
+
+    <h3>Location</h3>
+    <p>{{ page.fields.location }}</p>
   </news-events-page>
 </template>
 
@@ -65,11 +65,15 @@ export default {
     },
 
     /**
-     * Compute and formate start date
+     * Get event date range, if there is no end date, default to start date
      * @returns {String}
      */
-    publishedDate: function() {
-      return this.formatDate(this.page.fields.publishedDate)
+    eventDate: function() {
+      const startDate = this.formatDate(this.page.fields.startDate || '')
+      const endDate = this.formatDate(this.page.fields.endDate || '')
+      return startDate === endDate || !endDate
+        ? startDate
+        : `${startDate} - ${endDate}`
     }
   }
 }

--- a/pages/news-and-events/news/_id.vue
+++ b/pages/news-and-events/news/_id.vue
@@ -1,7 +1,10 @@
 <template>
   <news-events-page :page="page" :content="page.fields.copy">
-    <img :src="newsImage" :alt="newsImageAlt" />
-    <hr />
+    <template v-if="newsImage">
+      <img :src="newsImage" :alt="newsImageAlt" />
+      <hr />
+    </template>
+
     <h3>Published Date</h3>
     <p>{{ publishedDate }}</p>
 

--- a/pages/news-and-events/news/_id.vue
+++ b/pages/news-and-events/news/_id.vue
@@ -26,6 +26,34 @@
             </p>
 
             <h3>Share</h3>
+            <share-network
+              class="btn-share"
+              network="facebook"
+              tag="button"
+              :url="pageUrl"
+              :title="page.fields.title"
+              :description="page.fields.summary"
+            >
+              Share on Facebook
+            </share-network>
+            <share-network
+              class="btn-share"
+              network="twitter"
+              tag="button"
+              :url="pageUrl"
+              :title="page.fields.title"
+            >
+              Share on Twitter
+            </share-network>
+            <share-network
+              class="btn-share"
+              network="linkedin"
+              tag="button"
+              :url="pageUrl"
+              :title="page.fields.title"
+            >
+              Share on LinkedIn
+            </share-network>
           </el-col>
           <el-col :xs="24" :sm="{ span: 12, pull: 12 }">
             <div class="content" v-html="parseMarkdown(htmlContent)" />
@@ -121,6 +149,14 @@ export default {
      */
     publishedDate: function() {
       return this.formatDate(this.page.fields.publishedDate)
+    },
+
+    /**
+     * Compute the full URL of the page
+     * @returns {String}
+     */
+    pageUrl: function() {
+      return `${process.env.ROOT_URL}${this.$route.fullPath}`
     }
   }
 }
@@ -161,5 +197,11 @@ export default {
     height: auto;
     max-width: 100%;
   }
+}
+.btn-share {
+  background: none;
+  border: none;
+  cursor: pointer;
+  padding: 0;
 }
 </style>

--- a/pages/news-and-events/news/_id.vue
+++ b/pages/news-and-events/news/_id.vue
@@ -1,76 +1,25 @@
 <template>
-  <div>
-    <breadcrumb :breadcrumb="breadcrumb" :title="page.fields.title" />
-    <page-hero>
-      <h1>{{ page.fields.title }}</h1>
-      <p>
-        {{ page.fields.summary }}
-      </p>
-    </page-hero>
-    <div class="page-wrap container">
-      <div class="subpage">
-        <!-- eslint-disable vue/no-v-html -->
-        <!-- marked will sanitize the HTML injected -->
-        <el-row :gutter="32">
-          <el-col :xs="24" :sm="{ span: 12, push: 12 }" class="details">
-            <img :src="newsImage" :alt="newsImageAlt" />
-            <hr />
-            <h3>Published Date</h3>
-            <p>{{ publishedDate }}</p>
+  <news-events-page :page="page">
+    <img :src="newsImage" :alt="newsImageAlt" />
+    <hr />
+    <h3>Published Date</h3>
+    <p>{{ publishedDate }}</p>
 
-            <h3>External Link</h3>
-            <p>
-              <a :href="page.fields.url" target="_blank">
-                {{ page.fields.title }}
-              </a>
-            </p>
-
-            <h3>Share</h3>
-            <share-network
-              class="btn-share"
-              network="facebook"
-              tag="button"
-              :url="pageUrl"
-              :title="page.fields.title"
-              :description="page.fields.summary"
-            >
-              Share on Facebook
-            </share-network>
-            <share-network
-              class="btn-share"
-              network="twitter"
-              tag="button"
-              :url="pageUrl"
-              :title="page.fields.title"
-            >
-              Share on Twitter
-            </share-network>
-            <share-network
-              class="btn-share"
-              network="linkedin"
-              tag="button"
-              :url="pageUrl"
-              :title="page.fields.title"
-            >
-              Share on LinkedIn
-            </share-network>
-          </el-col>
-          <el-col :xs="24" :sm="{ span: 12, pull: 12 }">
-            <div class="content" v-html="parseMarkdown(htmlContent)" />
-          </el-col>
-        </el-row>
-      </div>
-    </div>
-  </div>
+    <h3>External Link</h3>
+    <p>
+      <a :href="page.fields.url" target="_blank">
+        {{ page.fields.title }}
+      </a>
+    </p>
+  </news-events-page>
 </template>
 
 <script>
 import { pathOr } from 'ramda'
 
-import MarkedMixin from '@/mixins/marked'
+import NewsEventsPage from '@/components/NewsEventsPage/NewsEventsPage'
+
 import FormatDate from '@/mixins/format-date'
-import Breadcrumb from '@/components/Breadcrumb/Breadcrumb'
-import PageHero from '@/components/PageHero/PageHero'
 
 import createClient from '@/plugins/contentful.js'
 
@@ -80,11 +29,10 @@ export default {
   name: 'NewsPage',
 
   components: {
-    Breadcrumb,
-    PageHero
+    NewsEventsPage
   },
 
-  mixins: [FormatDate, MarkedMixin],
+  mixins: [FormatDate],
 
   async asyncData({ route }) {
     try {
@@ -96,25 +44,6 @@ export default {
           fields: []
         }
       }
-    }
-  },
-
-  data() {
-    return {
-      breadcrumb: [
-        {
-          label: 'Home',
-          to: {
-            name: 'index'
-          }
-        },
-        {
-          label: 'News & Events',
-          to: {
-            name: 'news-and-events'
-          }
-        }
-      ]
     }
   },
 
@@ -136,72 +65,12 @@ export default {
     },
 
     /**
-     * Compute HTML Content for the page
-     * @returns {String}
-     */
-    htmlContent() {
-      return this.page.fields.copy || ''
-    },
-
-    /**
      * Compute and formate start date
      * @returns {String}
      */
     publishedDate: function() {
       return this.formatDate(this.page.fields.publishedDate)
-    },
-
-    /**
-     * Compute the full URL of the page
-     * @returns {String}
-     */
-    pageUrl: function() {
-      return `${process.env.ROOT_URL}${this.$route.fullPath}`
     }
   }
 }
 </script>
-
-<style lang="scss" scoped>
-@import '@/assets/_variables.scss';
-
-.content {
-  & ::v-deep {
-    color: $vestibular;
-  }
-  & ::v-deep p {
-    margin-bottom: 1em;
-  }
-  & ::v-deep img {
-    height: auto;
-    margin: 0.5em 0;
-    max-width: 100%;
-  }
-}
-
-.header {
-  margin-bottom: 3em;
-  .updated {
-    color: #aaa;
-  }
-}
-.details {
-  font-size: 0.875rem;
-  h3 {
-    font-size: 0.875rem;
-    font-weight: 500;
-    line-height: 1.5rem;
-    text-transform: uppercase;
-  }
-  img {
-    height: auto;
-    max-width: 100%;
-  }
-}
-.btn-share {
-  background: none;
-  border: none;
-  cursor: pointer;
-  padding: 0;
-}
-</style>

--- a/yarn.lock
+++ b/yarn.lock
@@ -15335,6 +15335,11 @@ vue-server-renderer@^2.6.12:
     serialize-javascript "^3.1.0"
     source-map "0.5.6"
 
+vue-social-sharing@^3.0.4:
+  version "3.0.4"
+  resolved "https://registry.yarnpkg.com/vue-social-sharing/-/vue-social-sharing-3.0.4.tgz#09d5af4872599fbf005b7ed8a52eaf926ef37eaa"
+  integrity sha512-noifuAgZIiNnsVEwGYz0kTVRdj80JkEIt1Qp1HRTLYPPQsyKVhrIMqJGVQGQjm9cp4UB51pUOxdGElMVyavvtw==
+
 vue-style-loader@^4.1.0:
   version "4.1.2"
   resolved "https://registry.yarnpkg.com/vue-style-loader/-/vue-style-loader-4.1.2.tgz#dedf349806f25ceb4e64f3ad7c0a44fba735fcf8"


### PR DESCRIPTION
# Description
The purpose of this PR is to add pages for news and events items, rather than having them link out. I have a few questions out to them on Wrike, specifically about the share button icons and author, and some decisions need to be made. In addition for the news, there's a new `copy` field that isn't filled out for any of the news items.

## Type of change

- [x] New feature (non-breaking change which adds functionality)

# How Has This Been Tested?

- On the homepage, scroll to the bottom and click on one of the events
- You should be taken to the event's page
- Go to the news and events page
- Click on an event's title, you should be taken to the event's page
- Go to the news and events page
- Find the news item "New NIH Funding Opportunity Announcement (RFA-DK-20-020)"
- You should be taken  to the news' page, and it should have placeholder copy rendered from markdown

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
