### PR TITLE
feat(Help Articles): slug support - cu-jjvc2p

### DIFF
--- a/components/AccessibilityDialog/AccessibilityDialog.vue
+++ b/components/AccessibilityDialog/AccessibilityDialog.vue
@@ -1,66 +1,79 @@
 <template>
   <el-dialog
-   :visible="visible"
-   :show-close="false"
-   @close="closeDialog"
-   :append-to-body="true"
+    :visible="visible"
+    :show-close="false"
+    :append-to-body="true"
+    @close="closeDialog"
   >
-
-  <div slot="title" class="bf-dialog-header">
-    <span class="bf-dialog-header-title">Accessibility Standards</span>
-  </div>
-
-  <div class="bf-dialog-body">
-    <div>
-      <p>The SPARC Portal is partially conformant with <a href="https://www.w3.org/WAI/standards-guidelines/wcag/" alt="WCAG Guidelines" target="blank">WCAG</a> guidelines. Partially conformant
-      means that some parts of the content do not fully conform to the accessibility standard.</p>
-      <p>We welcome your feedback on the accessibility of SPARC Portal.
-      Please let us know if you encounter accessibility barriers on SPARC Portal:</p>
-        <ul>
-            <li>Email: <a href="mailto:support@sparc.science">support@sparc.science</a></li>
-        </ul>
-     <p>We try to respond to feedback within 3-5 business days.</p>
+    <div slot="title" class="bf-dialog-header">
+      <span class="bf-dialog-header-title">Accessibility Standards</span>
     </div>
-  </div>
 
-  <div slot="footer" class="dialog-footer">
-    <el-button class="secondary" @click="closeDialog">
-      Close
-    </el-button>
-  </div>
- </el-dialog>
+    <div class="bf-dialog-body">
+      <div>
+        <p>
+          The SPARC Portal is partially conformant with
+          <a
+            href="https://www.w3.org/WAI/standards-guidelines/wcag/"
+            alt="WCAG Guidelines"
+            target="blank"
+            >WCAG</a
+          >
+          guidelines. Partially conformant means that some parts of the content
+          do not fully conform to the accessibility standard.
+        </p>
+        <p>
+          We welcome your feedback on the accessibility of SPARC Portal. Please
+          Please let us know if you encounter accessibility barriers on SPARC
+          Portal:
+        </p>
+        <ul>
+          <li>
+            Email:
+            <a href="mailto:support@sparc.science">support@sparc.science</a>
+          </li>
+        </ul>
+        <p>We try to respond to feedback within 3-5 business days.</p>
+      </div>
+    </div>
+
+    <div slot="footer" class="dialog-footer">
+      <el-button class="secondary" @click="closeDialog">
+        Close
+      </el-button>
+    </div>
+  </el-dialog>
 </template>
 
 <script>
-  export default {
-   name: 'Accessibility Dialog',
-    props: {
-        visible: {
-          type: Boolean,
-          default: false
-        },
-    },
+export default {
+  name: 'AccessibilityDialog',
+  props: {
+    visible: {
+      type: Boolean,
+      default: false
+    }
+  },
 
-    methods: {
-      /**
-        * Closes the dialog
-      */
-      closeDialog: function() {
-        this.$emit('close')
-      }
-    },
+  methods: {
+    /**
+     * Closes the dialog
+     */
+    closeDialog: function() {
+      this.$emit('close')
+    }
   }
+}
 </script>
 
 <style lang="scss" scoped>
-
 ::v-deep .el-dialog {
   width: 75%;
 }
 .bf-dialog-header {
-    text-align: center;
+  text-align: center;
 }
 .dialog-footer {
-    justify-content: center;
+  justify-content: center;
 }
 </style>

--- a/components/HelpCard/HelpCard.vue
+++ b/components/HelpCard/HelpCard.vue
@@ -2,7 +2,7 @@
   <div class="help-card">
     <h3>
       <nuxt-link class="help-link"
-        :to="{ name: 'help-helpId', params: { helpId: helpItem.sys.id } }"
+        :to="{ name: 'help-helpId', params: { helpId: helpItem.fields.slug || helpItem.sys.id } }"
       >
         {{ helpItem.fields.title || '' }}
       </nuxt-link>

--- a/pages/help/_helpId.vue
+++ b/pages/help/_helpId.vue
@@ -33,6 +33,22 @@ import createClient from '@/plugins/contentful.js'
 
 const client = createClient()
 
+const getHelpItem = async id => {
+  try {
+    const isSlug = id.split('-').length > 1
+
+    const item = isSlug
+      ? await client.getEntries({
+          content_type: process.env.ctf_help_id,
+          'fields.slug': id
+        })
+      : await client.getEntry(id)
+    return isSlug ? item.items[0] : item
+  } catch (error) {
+    return {}
+  }
+}
+
 export default {
   name: 'EventPage',
 
@@ -43,34 +59,30 @@ export default {
 
   mixins: [MarkedMixin],
 
-  asyncData(env) {
-    return Promise.all([
-      client.getEntry(process.env.ctf_support_page_id, { include: 2 }),
-      client.getEntry(env.params.helpId)
-    ])
-      .then(([allHelpData, helpItem]) => {
-        return {
-          helpHeroData: allHelpData.fields,
-          helpItem: helpItem,
-          breadcrumb: [
-            {
-              label: 'Home',
-              to: {
-                name: 'index'
-              }
-            },
-            {
-              label: allHelpData.fields.title,
-              to: {
-                name: 'help'
-              }
-            }
-          ]
+  async asyncData({ params }) {
+    const allHelpData = await client.getEntry(process.env.ctf_support_page_id, {
+      include: 2
+    })
+    const helpItem = await getHelpItem(params.helpId)
+
+    return {
+      helpHeroData: allHelpData.fields,
+      helpItem: helpItem,
+      breadcrumb: [
+        {
+          label: 'Home',
+          to: {
+            name: 'index'
+          }
+        },
+        {
+          label: allHelpData.fields.title,
+          to: {
+            name: 'help'
+          }
         }
-      })
-      .catch(() => {
-        throw Error
-      })
+      ]
+    }
   },
 
   computed: {


### PR DESCRIPTION
# Description

The purpose of this PR is to add a slug to help articles in contentful, and support querying them by the URL. This will allow users to link to the URL with the slug instead of the ID.

## Type of change

- [x] New feature (non-breaking change which adds functionality)

# How Has This Been Tested?

- Go to the "Need Help?" page
- Click on  "Getting Started"
- Help article should load
- Go to the "Need Help?" page
- Click on "Knowledge Management and Curation Core (K-Core) Information"
- Help article should load, and the URL  should have the slug in it
- 
# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
