### PR TITLE
Find data history for search CU-jjvc2p

### DIFF
--- a/pages/data/index.vue
+++ b/pages/data/index.vue
@@ -393,6 +393,17 @@ export default {
 
       this.$router.replace({ query: { type: firstTabType } })
     } else {
+      /**
+       * Set the searchData from query params
+       * Need to convert skip and limit from strings to numbers
+       */
+      const queryParams = {
+        skip: Number(this.$route.query.skip || searchData.skip),
+        limit: Number(this.$route.query.limit || searchData.limit),
+        q: this.$route.query.q || ''
+      }
+
+      this.searchData = { ...this.searchData, ...queryParams }
       this.fetchResults()
     }
     if (window.innerWidth <= 768) this.titleColumnWidth = 150
@@ -406,11 +417,13 @@ export default {
      */
     updateDataSearchLimit: function(limit) {
       this.searchData.skip = 0
-      if (limit === 'View All') {
-        this.searchData.limit = this.searchData.total
-      } else {
-        this.searchData.limit = limit
-      }
+
+      const newLimit = limit === 'View All' ? this.searchData.total : limit
+
+      this.searchData.limit = newLimit
+      this.$router.replace({
+        query: { ...this.$route.query, limit: newLimit, skip: 0 }
+      })
       this.fetchResults()
     },
 
@@ -606,6 +619,10 @@ export default {
     onPaginationPageChange: function(page) {
       const offset = (page - 1) * this.searchData.limit
       this.searchData.skip = offset
+
+      this.$router.replace({
+        query: { ...this.$route.query, skip: offset }
+      })
 
       this.fetchResults()
     },


### PR DESCRIPTION
# Description

The purpose of this PR is to add browser history for the find data page.

##  TIcket
[CU-jjvc2p](https://app.clickup.com/t/jjvc2p)
[579582035](https://www.wrike.com/workspace.htm?acc=3203588#/task-view?id=579582035&pid=441356195&cid=441356195)

## Type of change

- [x] New feature (non-breaking change which adds functionality)

# How Has This Been Tested?

- Go to the find data page
- Add a search term
- Adjust results per page
- Go to a new page
- Open a dataset
- Use the browser's back button, and you should be taken back to the find data page with the same search term, page and results per page

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
