### PR TITLE
Fix projects table sorting on organ page

### DIFF
--- a/components/SearchResults/ProjectSearchResults.vue
+++ b/components/SearchResults/ProjectSearchResults.vue
@@ -9,6 +9,7 @@
       sortable="custom"
       prop="fields.title"
       label="Title"
+      :sort-orders="sortOrders"
       :width="titleColumnWidth"
     >
       <template slot-scope="scope">
@@ -74,6 +75,12 @@ export default {
     titleColumnWidth: {
       type: Number,
       default: () => 300
+    }
+  },
+
+  data() {
+    return {
+      sortOrders: ['ascending', 'descending']
     }
   },
 


### PR DESCRIPTION
# Description

The purpose of this PR is to fix the sorting functionality of the projects table on an organ's page.

## Ticket
https://app.clickup.com/t/fryx0p

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
# How Has This Been Tested?

- Go to [an organ](http://localhost:3000/organs/54xPL40EaKrarCqBkAFExU)
- Projects table should be an option if the organ has projects
- Go to the projects tab, and projects should be shown
- Clicking on the heading of the title, NIH Award or principal investigator should sort the table

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
