### PR TITLE
Sprint 8 feedback cu-kmz5pr

### DIFF
--- a/components/DatasetDetails/DatasetAboutInfo.vue
+++ b/components/DatasetDetails/DatasetAboutInfo.vue
@@ -3,7 +3,7 @@
     <div class="dataset-about-info__container">
       <h3>Last Updated</h3>
       <p>{{ updatedDate }}</p>
-      <h3>Contact Information</h3>
+      <h3>Corresponding Author</h3>
       <p>
         {{ datasetOwnerName }}<br />
         {{ datasetOwnerEmail }}
@@ -69,8 +69,7 @@
                 The dataset citation generator (<a
                   href="https://citation.crosscite.org/"
                   target="_blank"
-                  >https://citation.crosscite.org/</a
-                >) encountered an internal error and was unable to complete your
+                >https://citation.crosscite.org/</a>) encountered an internal error and was unable to complete your
                 request.<br />
                 Please come back later.
               </p>

--- a/pages/help/_helpId.vue
+++ b/pages/help/_helpId.vue
@@ -63,10 +63,11 @@ export default {
     const helpItem = await getHelpItem(params.helpId)
 
     // Redirect to the friendly URL page, if this page has a slug
-    if (helpItem.fields.slug) {
+    const slug = helpItem.fields.slug
+    if (slug && params.helpId !== slug) {
       redirect({
         name: 'help-helpId',
-        params: { helpId: helpItem.fields.slug }
+        params: { helpId: slug }
       })
     }
 

--- a/pages/help/_helpId.vue
+++ b/pages/help/_helpId.vue
@@ -59,11 +59,20 @@ export default {
 
   mixins: [MarkedMixin],
 
-  async asyncData({ params }) {
+  async asyncData({ params, redirect }) {
+    const helpItem = await getHelpItem(params.helpId)
+
+    // Redirect to the friendly URL page, if this page has a slug
+    if (helpItem.fields.slug) {
+      redirect({
+        name: 'help-helpId',
+        params: { helpId: helpItem.fields.slug }
+      })
+    }
+
     const allHelpData = await client.getEntry(process.env.ctf_support_page_id, {
       include: 2
     })
-    const helpItem = await getHelpItem(params.helpId)
 
     return {
       helpHeroData: allHelpData.fields,


### PR DESCRIPTION
# Description

The purpose of this PR is to address feedback for sprint 8 for the following: 
- Change heading in Dataset's About tab to "Corresponding Author"
- Add a redirect for help pages that have a slug when going to that page using the ID

## Type of change

- [x] New feature (non-breaking change which adds functionality)

# How Has This Been Tested?

## Change heading in Dataset's About tab to "Corresponding Author"
- Go to [a dataset](http://localhost:3000/datasets/104?type=dataset) and open its About tab
- The heading about the author's name and email should be "Corresponding Author"

## Add a redirect for help pages that have a slug when going to that page using the ID
- Go to [a help entry that does not have a slug](http://localhost:3000/help/9JZsVzj2xZUMQuzx4RuU7)
- The page should load as normal
- Go to a help entry that does have a slug, but with the ID in the URL: http://localhost:3000/help/46cO5KyU0TwwM6vRo806mJ
- You should be redirected to the URL with the slug, and the page should load normally.

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added unit tests that prove my fix is effective or that my feature works
