### PR TITLE
Footer links from Contentful

### DIFF
--- a/components/footer/Footer.vue
+++ b/components/footer/Footer.vue
@@ -8,7 +8,7 @@
       </div>
       <div class="footer__info--blurb">
         <p>
-          {{ footerData }}
+          {{ footerData.copy }}
         </p>
       </div>
       <div class="footer__info--social">
@@ -38,61 +38,51 @@
       <div class="footer__links--learn">
         <h3>Learn More</h3>
         <ul>
-          <li>
-            <nuxt-link :to="{ name: 'about' }">
-              About SPARC
-            </nuxt-link>
-          </li>
-          <li>
-            <a href="https://commonfund.nih.gov/sites/default/files/SPARC_material%20sharing%20policy%2026jan17_508.pdf" target="_blank">
-              Material Sharing Policy
-            </a>
-          </li>
-          <li>
-            <a href="https://commonfund.nih.gov/sparc/awards" target="_blank">
-              Funding Opportunities
-            </a>
-          </li>
-          <li>
-            <a href="https://commonfund.nih.gov/Sparc/" target="_blank">
-              NIH SPARC Program
-            </a>
-          </li>
-          <li>
-            <a href="http://status.sparc.science/" target="_blank">
-              SPARC Systems Status
-            </a>
-          </li>
-          <li>
-            <a :href="publicationsLink" target="_blank">
-              SPARC Publications
-            </a>
-          </li>
-          <li>
-            <a href="https://sparc.science/help/3vcLloyvrvmnK3Nopddrka" target="_blank">
-              SPARC Glossary
+          <li
+            v-for="learnMoreLink in footerData.learnMoreLinks"
+            :key="learnMoreLink.fields.url"
+          >
+            <a
+              :href="learnMoreLink.fields.url"
+              :target="
+                isInternalLink(learnMoreLink.fields.url || '') ? '' : '_blank'
+              "
+            >
+              {{ learnMoreLink.fields.title }}
             </a>
           </li>
         </ul>
         <h3>Help Us Improve</h3>
         <ul>
-          <li>
+          <li
+            v-for="helpUsImproveLink in footerData.helpUsImproveLinks"
+            :key="helpUsImproveLink.fields.url"
+          >
             <a
-              href="https://www.wrike.com/frontend/requestforms/index.html?token=eyJhY2NvdW50SWQiOjMyMDM1ODgsInRhc2tGb3JtSWQiOjI2NzEzMn0JNDcyNTk5ODQyNjYyOAllODRhYTBkZWQ2ODY2Y2U3OWNhZWI5ODkyZWMwNjgyNTBiZjExMDIzMjk4MGMxZGM1MGNhYzY0ZmQxOGMxN2Ji"
-              target="_blank"
+              :href="helpUsImproveLink.fields.url"
+              :target="
+                isInternalLink(helpUsImproveLink.fields.url || '')
+                  ? ''
+                  : '_blank'
+              "
             >
-              Site Feedback
+              {{ helpUsImproveLink.fields.title }}
             </a>
           </li>
         </ul>
         <h3>Stay Updated</h3>
         <ul>
-          <li>
+          <li
+            v-for="stayUpdatedLink in footerData.stayUpdatedLinks"
+            :key="stayUpdatedLink.fields.url"
+          >
             <a
-              href="https://list.nih.gov/cgi-bin/wa.exe?SUBED1=NIH-SPARC-INFO&A=1"
-              target="_blank"
+              :href="stayUpdatedLink.fields.url"
+              :target="
+                isInternalLink(stayUpdatedLink.fields.url || '') ? '' : '_blank'
+              "
             >
-              Join our E-mail list
+              {{ stayUpdatedLink.fields.title }}
             </a>
           </li>
         </ul>
@@ -127,6 +117,8 @@
 import SparcLogo from '@/components/logo/SparcLogo.vue'
 import { mapState } from 'vuex'
 
+import { isInternalLink } from '@/mixins/marked/index'
+
 export default {
   name: 'SparcFooter',
   components: {
@@ -146,6 +138,10 @@ export default {
     publicationsLink: function() {
       return 'https://pubmed.ncbi.nlm.nih.gov/?term=(OD023873[gr])+OR+(OD023857[gr])+OR+(OD026580[gr])+OR+(OD025308[gr])+OR+(OD026545[gr])+OR+(TR002205[gr])+OR+(OD023854[gr])+OR+(OD025349[gr])+OR+(OD023848[gr])+OR+(OD025348[gr])+OR+(OD023850[gr])+OR+(NS113868[gr])+OR+(OD028183[gr])+OR+(OD023864[gr])+OR+(NS113873[gr])+OR+(OD028203[gr])+OR+(OD023872[gr])+OR+(OD023852[gr])+OR+(OD028191[gr])+OR+(OD024907[gr])+OR+(OD023847[gr])+OR+(DK116320[gr])+OR+(OD028201[gr])+OR+(OD026539[gr])+OR+(OD026577[gr])+OR+(OD023859[gr])+OR+(OD024899[gr])+OR+(OD025297[gr])+OR+(OD025307[gr])+OR+(TR002208[gr])+OR+(OD028190[gr])+OR+(OD024909[gr])+OR+(OD025306[gr])+OR+(DK116317[gr])+OR+(OD024898[gr])+OR+(OD023861[gr])+OR+(OD023871[gr])+OR+(DK116312[gr])+OR+(OD024912[gr])+OR+(OD025340[gr])+OR+(NS113869[gr])+OR+(OD026585[gr])+OR+(OD023860[gr])+OR+(OD025342[gr])+OR+(DK116311[gr])+OR+(OD026582[gr])+OR+(OD023867[gr])+OR+(OD023853[gr])+OR+(OD025347[gr])+OR+(OD024908[gr])+OR+(NS113871[gr])+OR+(NS113867[gr])+OR+(EB021716[gr])+OR+(EB021760[gr])+OR+(EB021780[gr])+OR+(EB021799[gr])+OR+(TR001925[gr])+OR+(18017[gr])+OR+(EB021787[gr])+OR+(EB021792[gr])+OR+(EB021759[gr])+OR+(EB021772[gr])+OR+(EB021793[gr])+OR+(TR001926[gr])+OR+(EB021790[gr])+OR+(TR001920[gr])+OR+(EB021877[gr])+OR+(OD023849[gr])+OR+(EB021789[gr])&sort='
     }
+  },
+
+  methods: {
+    isInternalLink
   }
 }
 </script>

--- a/mixins/marked/index.js
+++ b/mixins/marked/index.js
@@ -8,12 +8,19 @@ const renderer = new marked.Renderer()
 const linkRenderer = renderer.link
 const tableRenderer = renderer.table
 
-const isAnchor = str => {
+export const isAnchor = str => {
   return /(?:^|\s)(#[^ ]+)/i.test(str)
 }
 
-const isInternalLink = str => {
-  return isAnchor(str) ? true : str.includes(process.env.ROOT_URL)
+/**
+ * Compute if the link is an external link
+ * @param {String} str
+ * @returns {Boolean}
+ */
+export const isInternalLink = str => {
+  return isAnchor(str)
+    ? true
+    : str.includes(process.env.ROOT_URL) || str.startsWith('/')
 }
 
 renderer.link = function(href, title, text) {

--- a/store/index.js
+++ b/store/index.js
@@ -29,7 +29,7 @@ export const actions = {
     try {
       const client = createClient()
       const response = await client.getEntry(process.env.ctf_footer_copy_id)
-      commit('SET_FOOTER_DATA', response.fields.copy)
+      commit('SET_FOOTER_DATA', response.fields)
 
       // Load GDPR cookie info
       const hasAcceptedGDPR = this.$cookies.get('GDPR:accepted')


### PR DESCRIPTION
# Description
The purpose of this PR is to load the footer links from Contentful.

I added some sections to the entry in Contentful that we were using for the footer copy. Here, we can select what Footer Links we want to have in the footer, and in what order they should appear.
https://app.contentful.com/spaces/6bya4tyw8399/entries/wpik0A2sDOy9IQEoKpkKG

<img width="1792" alt="Screen Shot 2021-01-29 at 2 31 04 PM" src="https://user-images.githubusercontent.com/1493195/106319119-f1d9a880-623e-11eb-9218-b23cd7c25aca.png">

## Type of change

- [x] New feature (non-breaking change which adds functionality)

# How Has This Been Tested?

- The links in the footer should match the links in production
- Go to [this help article](http://localhost:3000/help/3vcLloyvrvmnK3Nopddrka)
- External links should open in new tabs
- Anchor links (Like the link for MAP-CORE) should function normally

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
