### PR TITLE
Update hero copy style

### DIFF
--- a/pages/maps/index.vue
+++ b/pages/maps/index.vue
@@ -3,15 +3,14 @@
     <breadcrumb :breadcrumb="breadcrumb" :title="title" />
     <page-hero>
       <h1>Maps</h1>
-      <div class="sideText">
-         SPARC is creating a detailed PNS map based on SPARC data and 
-         information available from the literature. The map you see 
-         represents the current state of the SPARC connectivity 
-         database and is not comprehensive. New connectivity will be 
-         added as the SPARC program progresses.
-      </div>
+      <p>
+        SPARC is creating a detailed PNS map based on SPARC data and information
+        available from the literature. The map you see represents the current
+        state of the SPARC connectivity database and is not comprehensive. New
+        connectivity will be added as the SPARC program progresses.
+      </p>
     </page-hero>
-    <div class="page-wrap portalmapcontainer" ref="mappage">
+    <div ref="mappage" class="page-wrap portalmapcontainer">
       <client-only placeholder="Loading...">
         <div class="mapClass">
           <MapContent />
@@ -22,62 +21,46 @@
 </template>
 
 <script>
-import Breadcrumb from "@/components/Breadcrumb/Breadcrumb.vue";
-import PageHero from "@/components/PageHero/PageHero.vue";
+import Breadcrumb from '@/components/Breadcrumb/Breadcrumb.vue'
+import PageHero from '@/components/PageHero/PageHero.vue'
 export default {
-  name: "Maps",
+  name: 'MapsPage',
 
   components: {
     Breadcrumb,
     PageHero,
     MapContent: process.client
-      ? () => import("@abi-software/mapintegratedvuer").then(m => m.MapContent)
+      ? () => import('@abi-software/mapintegratedvuer').then(m => m.MapContent)
       : null
   },
 
   data() {
     return {
       resources: [],
-      title: "Maps",
+      title: 'Maps',
       breadcrumb: [
         {
           to: {
-            name: "index"
+            name: 'index'
           },
-          label: "Home"
+          label: 'Home'
         }
       ]
-    };
+    }
   },
 
   methods: {}
-};
+}
 </script>
 
 <style lang="scss" scoped>
-@import "@/assets/_variables.scss";
+@import '@/assets/_variables.scss';
 .maps {
-
-  .sideText {
-    top: 0px;
-    font-size: 0.8em;
-    position: absolute;
-    line-height: 1.2em;
-    width: 50em;
-    margin-left: 6em;
-  }
-
-  .sideTextRight {
-    top: 0px;
-    padding-left: 8px;
-    background-color: lightblue;
-    color: black;
-    font-size: 0.7em;
-    position: absolute;
-    line-height: 1.2em;
-    left: 57em;
-    width: 23em;
-    text-align:center;
+  .page-hero__copy p {
+    @media (min-width: 48em) {
+      font-size: 0.9375rem;
+      line-height: 1.5rem;
+    }
   }
 
   .portalmapcontainer {
@@ -108,14 +91,15 @@ export default {
 }
 </style>
 <style lang="scss">
-  .mapClass {
-    position: relative;
-    width: 100%;
-    height: 100%;
-    border: solid 1px #dcdfe6;
-    box-shadow: 0 1px 8px 0 rgba(0, 0, 0, 0.06);
-    @import "~@abi-software/mapintegratedvuer/dist/mapintegratedvuer"
-  }
+.mapClass {
+  position: relative;
+  width: 100%;
+  height: 100%;
+  border: solid 1px #dcdfe6;
+  box-shadow: 0 1px 8px 0 rgba(0, 0, 0, 0.06);
+  @import '~@abi-software/mapintegratedvuer/dist/mapintegratedvuer';
+}
 </style>
-<style  src="@abi-software/mapintegratedvuer/assets/mapicon-species-style.css">
-</style>
+<style
+  src="@abi-software/mapintegratedvuer/assets/mapicon-species-style.css"
+></style>


### PR DESCRIPTION
# Description

The purpose of this PR is to update the hero style for the Maps page.

![localhost_3000_maps(Laptop with HiDPI screen)](https://user-images.githubusercontent.com/1493195/106521514-5188bb80-64ac-11eb-9d8e-35c97a59bb79.png)


## Type of change

- [x] New feature (non-breaking change which adds functionality)

# How Has This Been Tested?

- Go to the maps page
- The hero copy should be font-size 15 and appear under the heading.

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
