### PR TITLE
Use fetch hook for loading state if a permalink id is provided on maps page

### DIFF
--- a/pages/maps/index.vue
+++ b/pages/maps/index.vue
@@ -61,7 +61,7 @@ export default {
   methods: {
     updateUUID: function() {
       let xmlhttp = new XMLHttpRequest();
-      let url = this.api + `/map/getshareid`;
+      let url = this.api + `map/getshareid`;
       let state = this.$refs.map.getState();
       xmlhttp.open('POST', url, true);
       //Send the proper header information along with the request
@@ -77,6 +77,11 @@ export default {
     }
   },
   beforeMount: function() {
+    this.api = process.env.portal_api;
+    let lastChar = this.api.substr(-1);
+    if (lastChar != '/') {
+      this.api = this.api + '/';
+    }
     this.uuid = this.$route.query.id;
     if (window) {
       this.prefix = window.location.origin + window.location.pathname;


### PR DESCRIPTION
# Description

Use fetch hook to fetch the data if permalink id is provided on maps page.

## Type of change

- [ ] New feature (non-breaking change which adds functionality)

# How Has This Been Tested?

It is running on mapcore-demo.org/current/maps. I do not observe any problem when creating/loading a permalink.
It passes the unit test.

# Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added unit tests that prove my fix is effective or that my feature works
