### PR TITLE
Dataset versions - cu-m130t1

### DIFF
--- a/components/VersionHistory/VersionHistory.vue
+++ b/components/VersionHistory/VersionHistory.vue
@@ -1,0 +1,179 @@
+<template>
+  <el-dialog
+    :visible="visible"
+    :show-close="false"
+    class="version-history-dialog"
+    width="772px"
+    height="600px"
+    @close="closeDialog"
+  >
+    <bf-dialog-header slot="title" title="Version History" />
+
+    <div class="version-history-container">
+      <el-row class="table-header" type="flex" justify="center">
+        <el-col :span="6">
+          Version
+        </el-col>
+        <el-col :span="6">
+          Date Published
+        </el-col>
+        <el-col :span="10" :push="2">
+          DOI
+        </el-col>
+      </el-row>
+      <el-row
+        v-for="version in versions"
+        :key="version.doi"
+        class="table-rows"
+        type="flex"
+        justify="center"
+      >
+        <el-col :span="6">
+          <router-link
+            :to="{
+              name: 'version',
+              params: {
+                version: version.version,
+                datasetId
+              },
+              query: {
+                type: 'dataset'
+              }
+            }"
+            @click.native="$emit('update:visible', false)"
+          >
+            Version {{ version.version }}
+          </router-link>
+        </el-col>
+        <el-col :span="6">
+          {{ formatDate(version.updatedAt) }}
+        </el-col>
+        <el-col :span="10" :push="2">
+          {{ version.doi }}
+        </el-col>
+      </el-row>
+    </div>
+  </el-dialog>
+</template>
+
+<script>
+import BfDialogHeader from '@/components/bf-dialog-header/BfDialogHeader.vue'
+
+import FormatDate from '@/mixins/format-date'
+
+export default {
+  name: 'VersionHistory',
+
+  components: {
+    BfDialogHeader
+  },
+
+  mixins: [FormatDate],
+
+  props: {
+    visible: {
+      type: Boolean,
+      default: false
+    },
+
+    datasetId: {
+      type: Number,
+      default: 0
+    },
+
+    latestVersion: {
+      type: Number,
+      default: 0
+    },
+
+    versions: {
+      type: Array,
+      default: () => []
+    }
+  },
+
+  methods: {
+    /**
+     * Closes the dialog
+     */
+    closeDialog() {
+      this.$emit('close-version-dialog')
+      // scroll version history list to top
+      const scrollEl = this.$el.querySelector('.el-dialog__body')
+      scrollEl.scrollTop = 0
+    }
+  }
+}
+</script>
+
+<style lang="scss" scoped>
+.version-history-dialog {
+  .version-history-container {
+    height: 290px;
+
+    .table-header {
+      background-color: #f9f9f9;
+      height: 40px;
+      // width: 616px;
+      padding-left: 24px;
+      color: #404554;
+      font-weight: 600;
+      font-size: 14px;
+      line-height: 16px;
+      padding-top: 12px;
+      margin-left: 0px !important;
+    }
+
+    .table-rows {
+      height: 40px;
+      // width: 616px;
+      padding-left: 24px;
+      color: #000000;
+      font-size: 14px;
+      line-height: 16px;
+      padding-top: 14px;
+      border-top: solid 1px #dadada;
+      margin-left: 0px !important;
+
+      a {
+        text-decoration: underline;
+
+        &:focus {
+          color: #1c46bd;
+        }
+      }
+    }
+  }
+
+  ::v-deep .el-dialog {
+    width: 616px !important;
+    height: 350px;
+    .el-dialog__header {
+      background-color: #f1f1f3;
+      padding-top: 16px;
+      border-radius: 4px 4px 0px 0px;
+      padding-bottom: 8px;
+
+      .bf-dialog-header {
+        .bf-dialog-header-title {
+          font-size: 14px;
+          font-weight: bold;
+          line-height: 16px;
+        }
+
+        .icon-close {
+          margin-bottom: 5px;
+          .svg-icon {
+            width: 16px !important;
+            height: 16px !important;
+          }
+        }
+      }
+    }
+    .el-dialog__body {
+      padding: 0px 0px;
+      overflow: scroll;
+    }
+  }
+}
+</style>

--- a/components/VersionHistory/VersionHistory.vue
+++ b/components/VersionHistory/VersionHistory.vue
@@ -110,28 +110,20 @@ export default {
 .version-history-dialog {
   .version-history-container {
     height: 290px;
+    font-size: 0.875rem;
+    line-height: 1rem;
 
     .table-header {
       background-color: #f9f9f9;
-      height: 40px;
-      // width: 616px;
-      padding-left: 24px;
       color: #404554;
       font-weight: 600;
-      font-size: 14px;
-      line-height: 16px;
-      padding-top: 12px;
+      padding: 0.75rem 1.5rem;
       margin-left: 0px !important;
     }
 
     .table-rows {
-      height: 40px;
-      // width: 616px;
-      padding-left: 24px;
       color: #000000;
-      font-size: 14px;
-      line-height: 16px;
-      padding-top: 14px;
+      padding: 0.75rem 1.5rem;
       border-top: solid 1px #dadada;
       margin-left: 0px !important;
 
@@ -150,28 +142,28 @@ export default {
     height: 350px;
     .el-dialog__header {
       background-color: #f1f1f3;
-      padding-top: 16px;
-      border-radius: 4px 4px 0px 0px;
-      padding-bottom: 8px;
+      padding-top: 1rem;
+      border-radius: 0.25rem 0.25rem 0px 0px;
+      padding-bottom: 0.5rem;
 
       .bf-dialog-header {
         .bf-dialog-header-title {
-          font-size: 14px;
+          font-size: 0.875rem;
           font-weight: bold;
-          line-height: 16px;
+          line-height: 1rem;
         }
 
         .icon-close {
-          margin-bottom: 5px;
+          margin-bottom: 0.3125rem;
           .svg-icon {
-            width: 16px !important;
-            height: 16px !important;
+            width: 1rem !important;
+            height: 1rem !important;
           }
         }
       }
     }
     .el-dialog__body {
-      padding: 0px 0px;
+      padding: 0;
       overflow: scroll;
     }
   }

--- a/nuxt.config.js
+++ b/nuxt.config.js
@@ -29,7 +29,8 @@ export default {
   },
   env: {
     portal_api: process.env.PORTAL_API_HOST || 'http://localhost:8000',
-    flatmap_api: process.env.FLATMAP_API_HOST || 'https://mapcore-demo.org/flatmaps/',
+    flatmap_api:
+      process.env.FLATMAP_API_HOST || 'https://mapcore-demo.org/flatmaps/',
     crosscite_api_host:
       process.env.CROSSCITE_API_HOST || 'https://citation.crosscite.org',
     discover_api_host:
@@ -91,6 +92,11 @@ export default {
       routes.push({
         path: '/submit_data.html',
         redirect: '/help/7k8nEPuw3FjOq2HuS8OVsd'
+      })
+      routes.push({
+        name: 'version',
+        path: '/datasets/:datasetId/version/:version',
+        component: '@/pages/datasets/_datasetId.vue'
       })
     }
   },

--- a/pages/datasets/_datasetId.vue
+++ b/pages/datasets/_datasetId.vue
@@ -13,12 +13,16 @@
         <div class="dataset-meta">
           <div class="dataset-updated-date">
             Last updated on {{ lastUpdatedDate }}
-            <template v-if="datasetType === 'dataset'">
-              (<a
+            <template v-if="datasetType !== 'simulation'">
+              (
+              <a
                 href="#"
                 class="version-link"
                 @click.prevent="isVersionModalVisible = true"
-                >{{ versionRevisionText }}</a>)
+              >
+                {{ versionRevisionText }}
+              </a>
+              )
             </template>
           </div>
         </div>
@@ -1088,6 +1092,7 @@ export default {
 }
 
 .details-header__container--content-links .version-link {
+  display: inline-block;
   font-size: 0.875rem;
   font-weight: 400;
   line-height: 1rem;

--- a/pages/datasets/_datasetId.vue
+++ b/pages/datasets/_datasetId.vue
@@ -18,8 +18,7 @@
                 href="#"
                 class="version-link"
                 @click.prevent="isVersionModalVisible = true"
-              >{{ versionRevisionText }}</a
-              >)
+                >{{ versionRevisionText }}</a>)
             </template>
           </div>
         </div>
@@ -1088,7 +1087,10 @@ export default {
   }
 }
 
-.version-link {
+.details-header__container--content-links .version-link {
+  font-size: 0.875rem;
+  font-weight: 400;
+  line-height: 1rem;
   margin: 0 !important;
 }
 .dataset-updated-date {

--- a/pages/datasets/_datasetId.vue
+++ b/pages/datasets/_datasetId.vue
@@ -13,6 +13,14 @@
         <div class="dataset-meta">
           <div class="dataset-updated-date">
             Last updated on {{ lastUpdatedDate }}
+            <template v-if="datasetType === 'dataset'">
+              (<a
+                href="#"
+                class="version-link"
+                @click.prevent="isVersionModalVisible = true"
+              >{{ versionRevisionText }}</a
+              >)
+            </template>
           </div>
         </div>
         <div class="dataset-owners">
@@ -159,6 +167,13 @@
       :download-size="getDownloadSize"
       @close-download-dialog="isDownloadModalVisible = false"
     />
+    <version-history
+      :visible.sync="isVersionModalVisible"
+      :dataset-id="datasetInfo.id"
+      :latest-version="datasetInfo.latestVersion"
+      :versions="versions"
+      @close-version-dialog="closeVersionModal"
+    />
   </div>
 </template>
 
@@ -176,6 +191,7 @@ import DatasetAboutInfo from '@/components/DatasetDetails/DatasetAboutInfo.vue'
 import DatasetDescriptionInfo from '@/components/DatasetDetails/DatasetDescriptionInfo.vue'
 import DatasetFilesInfo from '@/components/DatasetDetails/DatasetFilesInfo.vue'
 import ImagesGallery from '@/components/ImagesGallery/ImagesGallery.vue'
+import VersionHistory from '@/components/VersionHistory/VersionHistory.vue'
 
 import Request from '@/mixins/request'
 import DateUtils from '@/mixins/format-date'
@@ -229,12 +245,15 @@ const getOrganEntries = async () => {
 /**
  * Get Dataset details
  * @param {Number} datasetId
+ * @param {Number} version
  * @param {String} datasetType
  * @param {Function} $axios
  * @returns {Object}
  */
-const getDatasetDetails = async (datasetId, datasetType, $axios) => {
-  const datasetUrl = `${process.env.discover_api_host}/datasets/${datasetId}`
+const getDatasetDetails = async (datasetId, version, datasetType, $axios) => {
+  const url = `${process.env.discover_api_host}/datasets/${datasetId}`
+  const datasetUrl = version ? `${url}/versions/${version}` : url
+
   const simulationUrl = `${process.env.portal_api}/sim/dataset/${datasetId}`
 
   try {
@@ -257,6 +276,23 @@ const getDatasetDetails = async (datasetId, datasetType, $axios) => {
     return datasetDetails
   } catch (error) {
     return {}
+  }
+}
+
+/**
+ * Get all the versions of the datasets
+ * @param {Number} datasetId
+ * @param {Object} $axios
+ * @returns {Array}
+ */
+const getDatasetVersions = (datasetId, $axios) => {
+  try {
+    const url = `${process.env.discover_api_host}/datasets/${datasetId}/versions`
+    return $axios.$get(url).then(response => {
+      return response.sort((a, b) => a.verson - b.version)
+    })
+  } catch (error) {
+    return []
   }
 }
 
@@ -353,7 +389,8 @@ export default {
     DatasetAboutInfo,
     DatasetDescriptionInfo,
     DatasetFilesInfo,
-    ImagesGallery
+    ImagesGallery,
+    VersionHistory
   },
 
   mixins: [Request, DateUtils, FormatStorage],
@@ -365,9 +402,12 @@ export default {
 
     const datasetDetails = await getDatasetDetails(
       datasetId,
+      route.params.version,
       route.query.type,
       $axios
     )
+
+    const versions = await getDatasetVersions(datasetId, $axios)
 
     const {
       imagesData,
@@ -385,7 +425,8 @@ export default {
       scaffoldData,
       plotData,
       videoData,
-      tabs: tabsData
+      tabs: tabsData,
+      versions
     }
   },
 
@@ -420,7 +461,8 @@ export default {
         }
       ],
       subtitles: [],
-      ctfDatasetFormatInfoPageId: process.env.ctf_dataset_format_info_page_id
+      ctfDatasetFormatInfoPageId: process.env.ctf_dataset_format_info_page_id,
+      isVersionModalVisible: false
     }
   },
 
@@ -687,6 +729,18 @@ export default {
      */
     scaffold: function() {
       return Scaffolds[this.organType.toLowerCase()]
+    },
+
+    /**
+     * computes the right text based on the version and revision
+     * @returns {String}
+     */
+    versionRevisionText() {
+      const versionText = `Version ${this.datasetInfo.version}`
+      const revisionText = this.datasetInfo.revision
+        ? `, Revision ${this.datasetInfo.revision}`
+        : ''
+      return versionText + revisionText
     }
   },
 
@@ -819,6 +873,13 @@ export default {
       } else {
         this.getCitationsArea().scrollIntoView()
       }
+    },
+
+    /**
+     * Closes the version history modal
+     */
+    closeVersionModal: function() {
+      this.isVersionModalVisible = false
     }
   },
 
@@ -1027,6 +1088,9 @@ export default {
   }
 }
 
+.version-link {
+  margin: 0 !important;
+}
 .dataset-updated-date {
   line-height: 24px;
   color: black;


### PR DESCRIPTION
# Description

The purpose of this PR is to add the ability to see different versions of a dataset.

## Tickets
https://app.clickup.com/t/m130t1
https://www.wrike.com/open.htm?id=603833242

## Type of change

- [x] New feature (non-breaking change which adds functionality)

# How Has This Been Tested?

- Go  to [this dataset](http://localhost:3000/datasets/43?type=dataset)
- You should see the latest version, version 5
- Note the files and description of the dataset
- Click on "Version 5" in the header 
- Version dialog should open up
- Click on "Version 1"
- You should be taken to version 1 of that dataset, and the description and files should show the data from version 1
- A simulation should not have the version shown.

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
