### PR TITLE
Show image for lead institution

### DIFF
--- a/components/SearchResults/ProjectSearchResults.vue
+++ b/components/SearchResults/ProjectSearchResults.vue
@@ -33,9 +33,18 @@
     </el-table-column>
     <el-table-column
       prop="fields.institution.fields.name"
-      label="Institution"
+      label="Lead Institution"
       width="200"
-    />
+    >
+      <template slot-scope="scope">
+        <img
+          class="img-project"
+          :src="getImageSrc(scope)"
+          :alt="getImageAlt(scope)"
+        />
+        {{ scope.row.fields.institution.fields.name }}
+      </template>
+    </el-table-column>
     <el-table-column
       sortable="custom"
       prop="fields.awardId"
@@ -103,7 +112,7 @@ export default {
     getImageAlt: function(scope) {
       return scope.row.fields.institution.fields.logo
         ? scope.row.fields.institution.fields.logo.fields.file.description
-        : ''
+        : `Logo for ${scope.row.fields.institution.fields.name}`
     },
 
     /**


### PR DESCRIPTION
# Description

The purpose of this PR is to show the image for the lead institution on the projects page.

![localhost_3000_about(Laptop with HiDPI screen) (1)](https://user-images.githubusercontent.com/1493195/109195701-d93eae80-7768-11eb-8eec-a7a272a1f11c.png)

## Tickets
https://app.clickup.com/t/m12z79
https://www.wrike.com/open.htm?id=489589055

## Type of change

- [x] New feature (non-breaking change which adds functionality)

# How Has This Been Tested?

- Go to the [projects page](http://localhost:3000/data?type=sparcAward)
- Images should be listed for institutions in the Lead Institution column

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added unit tests that prove my fix is effective or that my feature works
