### PR TITLE
Allow native files to open in browser

### DIFF
--- a/components/FilesTable/FilesTable.vue
+++ b/components/FilesTable/FilesTable.vue
@@ -64,15 +64,13 @@
                   class="file-icon el-icon-picture-outline"
                 />
                 <i v-else class="file-icon el-icon-document" />
-                <div v-if="isMicrosoftFileType(scope)">
+                <div v-if="isFileOpenable(scope)">
                   <a href="#" @click.prevent="openFile(scope)">
                     {{ scope.row.name }}
                   </a>
                 </div>
                 <div v-else-if="isScaffoldMetaFile(scope)">
-                  <nuxt-link
-                    :to="getScaffoldLink(scope)"
-                  >
+                  <nuxt-link :to="getScaffoldLink(scope)">
                     {{ scope.row.name }}
                   </nuxt-link>
                 </div>
@@ -131,7 +129,7 @@
                   Download
                 </el-dropdown-item>
                 <el-dropdown-item
-                  v-if="isMicrosoftFileType(scope)"
+                  v-if="isFileOpenable(scope)"
                   :command="{
                     type: 'openFile',
                     scope
@@ -139,7 +137,8 @@
                 >
                   Open
                 </el-dropdown-item>
-                <el-dropdown-item v-if="isScaffoldMetaFile(scope)"
+                <el-dropdown-item
+                  v-if="isScaffoldMetaFile(scope)"
                   :command="{
                     type: 'openScaffold',
                     scope
@@ -174,6 +173,15 @@ import BfDownloadFile from '@/components/BfDownloadFile/BfDownloadFile'
 
 import FormatStorage from '@/mixins/bf-storage-metrics/index'
 import RequestDownloadFile from '@/mixins/request-download-file'
+
+const contentTypes = {
+  pdf: 'application/pdf',
+  text: 'text/plain',
+  jpeg: 'image/jpeg',
+  png: 'image/png',
+  svg: 'img/svg+xml',
+  mp4: 'video/mp4'
+}
 
 export default {
   name: 'FilesTable',
@@ -253,6 +261,23 @@ export default {
   },
 
   methods: {
+    /**
+     * Check if the file is openable
+     * MS Office files and native browser files
+     * - Documents (pdf, text)
+     * - Images (jpg, png)
+     * - Video (MP4)
+     * - Vector Drawings (svg)
+     */
+    isFileOpenable(scope) {
+      const allowableExtensions = Object.keys(contentTypes).map(key => key)
+      const fileType = scope.row.fileType.toLowerCase()
+      return (
+        this.isMicrosoftFileType(scope) ||
+        allowableExtensions.includes(fileType)
+      )
+    },
+
     handleSelectionChange(val) {
       this.selected = val
     },
@@ -389,12 +414,17 @@ export default {
         pathOr('', ['row', 'uri'])
       )(scope)
 
-      const requestUrl = `${process.env.portal_api}/download?key=${filePath}`
+      const fileType = scope.row.fileType.toLowerCase()
+      const contentType = contentTypes[fileType]
+
+      const requestUrl = `${process.env.portal_api}/download?key=${filePath}&contentType=${contentType}`
 
       this.$axios.$get(requestUrl).then(response => {
         const url = response
         const encodedUrl = encodeURIComponent(url)
-        const finalURL = `https://view.officeapps.live.com/op/view.aspx?src=${encodedUrl}`
+        const finalURL = this.isMicrosoftFileType(scope)
+          ? `https://view.officeapps.live.com/op/view.aspx?src=${encodedUrl}`
+          : url
         window.open(finalURL, '_blank')
       })
     },
@@ -428,7 +458,11 @@ export default {
      */
     isScaffoldMetaFile: function(scope) {
       let path = scope.row.path.toLowerCase()
-      return path.includes('scaffold') && path.includes('meta') && path.includes('json')
+      return (
+        path.includes('scaffold') &&
+        path.includes('meta') &&
+        path.includes('json')
+      )
     },
 
     /**


### PR DESCRIPTION
# Description

The purpose of this PR is to allow users to open native files in a browser.

## Tickets
https://app.clickup.com/t/m1339z
https://www.wrike.com/open.htm?id=550853064

## Type of change

- [x] New feature (non-breaking change which adds functionality)

# How Has This Been Tested?

Go to the following datasets and the path in the files tab to test each file type.

- jpg: http://localhost:3000/datasets/12?type=dataset - files / source / Dorsal
- text: http://localhost:3000/datasets/12?type=dataset - files
- pdf: http://localhost:3000/datasets/86?type=dataset - files/primary
- mp4: http://localhost:3000/datasets/54?type=dataset - files /derivative /sam-P21 BAT /ses-B3tub
- png: http://localhost:3000/datasets/12?type=dataset - files /docs /Interactive map /Images


# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added unit tests that prove my fix is effective or that my feature works
