### PR TITLE
Account for draft help documents that may not have data

### DIFF
--- a/components/HelpCard/HelpCard.vue
+++ b/components/HelpCard/HelpCard.vue
@@ -2,12 +2,12 @@
   <div class="help-card">
     <h3>
       <nuxt-link class="help-link"
-        :to="{ name: 'help-helpId', params: { helpId: helpItem.fields.slug || helpItem.sys.id } }"
+        :to="{ name: 'help-helpId', params: { helpId: helpItem.fields ? helpItem.fields.slug : helpItem.sys.id } }"
       >
-        {{ helpItem.fields.title || '' }}
+        {{ helpItem.fields ? helpItem.fields.title : '' }}
       </nuxt-link>
     </h3>
-    <p v-html="highlightText(searchTerms, helpItem.fields.summary || '')" />
+    <p v-html="highlightText(searchTerms, helpItem.fields ? helpItem.fields.summary : '')" />
   </div>
 </template>
 


### PR DESCRIPTION
# Description

The purpose of this PR is to fix a bug when draft help documents don't have data, the page would crash.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
# How Has This Been Tested?

- Go to the [help page](http://localhost:3000/help)
- Scroll down to the last item of the General section
- Click on "Other SPARC Policies"
- You should see a page for Other SPARC Policies

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added unit tests that prove my fix is effective or that my feature works
