### PR TITLE
feat(Datasets): Add banner when viewing older version

### DIFF
--- a/components/DatasetVersionMessage/DatasetVersionMessage.vue
+++ b/components/DatasetVersionMessage/DatasetVersionMessage.vue
@@ -1,0 +1,114 @@
+<template>
+  <div
+    :class="
+      datasetDetails.embargo ? 'version-message-fixed' : 'version-message'
+    "
+    class="el-message el-message--info"
+  >
+    <p v-if="!datasetDetails.embargo" class="el-message__content">
+      {{ messageCopy }} version {{ currentVersion }} of this dataset. A
+      <nuxt-link
+        :to="{
+          name: 'datasets-datasetId',
+          params: {
+            datasetId: datasetDetails.id
+          }
+        }"
+      >
+        more recent version
+      </nuxt-link>
+      is available.
+    </p>
+    <p v-else class="el-message__content">
+      This dataset is under embargo and will be made publicly available on
+      {{ embargoedReleaseDate }}
+    </p>
+  </div>
+</template>
+
+<script>
+import { propOr } from 'ramda'
+import FormatDate from '../../mixins/format-date'
+export default {
+  name: 'DatasetVersionMessage',
+
+  mixins: [FormatDate],
+
+  props: {
+    currentVersion: {
+      type: Number,
+      default: 1
+    },
+    datasetDetails: {
+      type: Object,
+      default: () => {}
+    },
+    isTombStone: {
+      type: Boolean,
+      default: false
+    }
+  },
+
+  computed: {
+    /**
+     * Copy to show in the message
+     * depeneding on whether the user is
+     * on the tombstone page or not
+     * @returns {String}
+     */
+    messageCopy() {
+      return this.isTombStone ? 'You are attempting to view' : 'You are viewing'
+    },
+
+    /**
+     * Get formatted embargoed date
+     * @return {String}
+     */
+    embargoedReleaseDate() {
+      const date = propOr('', 'embargoReleaseDate', this.datasetDetails)
+      return this.formatCalendarDate(date)
+    }
+  }
+}
+</script>
+
+<style lang="scss" scoped>
+@import '../../assets/_variables.scss';
+.version-message {
+  background: $app-primary-color;
+  color: #fff;
+  min-width: 17.5rem;
+  padding: 1rem;
+  position: absolute;
+  top: 98px;
+  z-index: 99;
+  @media (min-width: 48rem) {
+    top: 96px;
+    white-space: nowrap;
+  }
+  @media (min-width: 64rem) {
+    top: 195px;
+  }
+  .el-message__content {
+    color: #fff;
+  }
+}
+a {
+  color: #fff;
+  // Removes the underlined space at the end
+  // of the nuxt link to the latest version
+  display: inline-block;
+  text-decoration: underline;
+  &:hover,
+  &:focus {
+    text-decoration: none;
+  }
+}
+
+.version-message-fixed {
+  box-sizing: border-box;
+  top: 195px;
+  max-width: 600px;
+  width: 100%;
+}
+</style>

--- a/pages/datasets/_datasetId.vue
+++ b/pages/datasets/_datasetId.vue
@@ -177,6 +177,12 @@
       :versions="versions"
       @close-version-dialog="closeVersionModal"
     />
+
+    <dataset-version-message
+      v-if="!isLatestVersion"
+      :current-version="datasetInfo.version"
+      :dataset-details="datasetInfo"
+    />
   </div>
 </template>
 
@@ -195,6 +201,7 @@ import DatasetDescriptionInfo from '@/components/DatasetDetails/DatasetDescripti
 import DatasetFilesInfo from '@/components/DatasetDetails/DatasetFilesInfo.vue'
 import ImagesGallery from '@/components/ImagesGallery/ImagesGallery.vue'
 import VersionHistory from '@/components/VersionHistory/VersionHistory.vue'
+import DatasetVersionMessage from '@/components/DatasetVersionMessage/DatasetVersionMessage.vue'
 
 import Request from '@/mixins/request'
 import DateUtils from '@/mixins/format-date'
@@ -393,7 +400,8 @@ export default {
     DatasetDescriptionInfo,
     DatasetFilesInfo,
     ImagesGallery,
-    VersionHistory
+    VersionHistory,
+    DatasetVersionMessage
   },
 
   mixins: [Request, DateUtils, FormatStorage],
@@ -470,6 +478,19 @@ export default {
   },
 
   computed: {
+    /**
+     * Compute if the dataset is the latest version
+     * @returns {Boolean}
+     */
+    isLatestVersion() {
+      if (this.versions.length) {
+        const latestVersion = compose(propOr(1, 'version'), head)(this.versions)
+        return this.datasetInfo.version === latestVersion
+      }
+
+      return true
+    },
+
     /**
      * Returns simulation id for run simulation button
      * @returns {String}


### PR DESCRIPTION
# Description
The purpose of this PR is to add a banner image when viewing an older version of a dataset.

![localhost_3000_datasets_43_type=dataset(Laptop with MDPI screen)](https://user-images.githubusercontent.com/1493195/110961056-6105ea80-831d-11eb-92db-1db84baf4221.png)

## Type of change

- [x] New feature (non-breaking change which adds functionality)

# How Has This Been Tested?

- Go to [an older version of a dataset](http://localhost:3000/datasets/43/version/2?type=dataset)
- The banner should be visible at the top
- Click on  "more recent version" link in this banner
- You should be taken to the most recent version of the dataset
- Banner should not be visible

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added unit tests that prove my fix is effective or that my feature works
