### PR TITLE
Contact form - Account for email already existing in Mailchimp

### DIFF
--- a/components/ContactUsForms/NewsletterMixin.js
+++ b/components/ContactUsForms/NewsletterMixin.js
@@ -20,7 +20,8 @@ export default {
           last_name: this.form.lastName
         })
         .then(response => {
-          if (response.data.status > 200) {
+          const { title } = response.data
+          if (response.data.status > 200 && title !== 'Member Exists') {
             this.hasError = true
           } else {
             this.$emit('submit', this.form.firstName)


### PR DESCRIPTION
# Description

The purpose of this PR is to account for email already existing in Mailchimp. Before, the form would not submit and display an error.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

- Go to the [Contact form](http://localhost:3000/contact-us?type=general)
- Enter information, including your first, last, email and checking "newsletter" check
- Open network tab to see the `/mailchimp` response
- If your email was already added to the list, you will see this data in the response and the form should be in the submitted state
- If your email was not in that list, submit it again to test

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added unit tests that prove my fix is effective or that my feature works
