### PR TITLE
Embargoed datasets - cu-q10rjt

### DIFF
--- a/components/SearchResults/DatasetSearchResults.vue
+++ b/components/SearchResults/DatasetSearchResults.vue
@@ -26,7 +26,7 @@
         </nuxt-link>
       </template>
     </el-table-column>
-    <el-table-column prop="banner" label="Image" width="148">
+    <el-table-column prop="banner" label="Image" width="160">
       <template slot-scope="scope">
         <nuxt-link
           :to="{
@@ -36,6 +36,7 @@
               type: $route.query.type
             }
           }"
+          class="img-dataset"
         >
           <img
             :src="scope.row.banner"
@@ -43,6 +44,9 @@
             height="128"
             width="128"
           />
+          <sparc-pill v-if="scope.row.embargo">
+            Embargoed
+          </sparc-pill>
         </nuxt-link>
       </template>
     </el-table-column>
@@ -78,6 +82,7 @@
 </template>
 
 <script>
+import SparcPill from '@/components/SparcPill/SparcPill.vue'
 import FormatDate from '@/mixins/format-date'
 import StorageMetrics from '@/mixins/bf-storage-metrics'
 import { onSortChange } from '@/pages/data/utils'
@@ -85,6 +90,8 @@ import { pathOr } from 'ramda'
 
 export default {
   name: 'DatasetSearchResults',
+
+  components: { SparcPill },
 
   mixins: [FormatDate, StorageMetrics],
 
@@ -127,5 +134,18 @@ export default {
 <style lang="scss" scoped>
 .el-table {
   width: 100%;
+}
+.img-dataset {
+  display: block;
+  position: relative;
+  .sparc-pill {
+    font-size: 0.75rem;
+    position: absolute;
+    right: 0.25rem;
+    top: 0.5rem;
+  }
+  img {
+    display: block;
+  }
 }
 </style>

--- a/components/SparcPill/SparcPill.vue
+++ b/components/SparcPill/SparcPill.vue
@@ -1,0 +1,26 @@
+<template>
+  <div class="sparc-pill">
+    <slot />
+  </div>
+</template>
+
+<script>
+export default {
+  name: 'SparcPill'
+}
+</script>
+
+<style lang="scss" scoped>
+@import '../../assets/_variables.scss';
+.sparc-pill {
+  background: $median;
+  border-radius: 15px;
+  color: #fff;
+  font-size: 0.875rem;
+  max-width: 100%;
+  overflow: hidden;
+  padding: 0 0.65rem;
+  text-overflow: ellipsis;
+  width: fit-content;
+}
+</style>

--- a/pages/datasets/_datasetId.vue
+++ b/pages/datasets/_datasetId.vue
@@ -6,8 +6,11 @@
       :description="datasetDescription"
       :breadcrumb="breadcrumb"
     >
-      <div slot="banner image">
+      <div slot="banner image" class="img-dataset">
         <dataset-banner-image :src="getDatasetImage" />
+        <sparc-pill v-if="datasetInfo.embargo">
+          Embargoed
+        </sparc-pill>
       </div>
       <div slot="meta content" class="details-header__container--content-links">
         <div class="dataset-meta">
@@ -202,6 +205,7 @@ import DatasetFilesInfo from '@/components/DatasetDetails/DatasetFilesInfo.vue'
 import ImagesGallery from '@/components/ImagesGallery/ImagesGallery.vue'
 import VersionHistory from '@/components/VersionHistory/VersionHistory.vue'
 import DatasetVersionMessage from '@/components/DatasetVersionMessage/DatasetVersionMessage.vue'
+import SparcPill from '@/components/SparcPill/SparcPill.vue'
 
 import Request from '@/mixins/request'
 import DateUtils from '@/mixins/format-date'
@@ -401,7 +405,8 @@ export default {
     DatasetFilesInfo,
     ImagesGallery,
     VersionHistory,
-    DatasetVersionMessage
+    DatasetVersionMessage,
+    SparcPill
   },
 
   mixins: [Request, DateUtils, FormatStorage],
@@ -1182,5 +1187,19 @@ export default {
 }
 .scaffold {
   height: 500px;
+}
+
+.img-dataset {
+  display: block;
+  position: relative;
+  .sparc-pill {
+    font-size: 0.75rem;
+    position: absolute;
+    right: 0.25rem;
+    top: 0.5rem;
+  }
+  img {
+    display: block;
+  }
 }
 </style>

--- a/pages/datasets/_datasetId.vue
+++ b/pages/datasets/_datasetId.vue
@@ -109,9 +109,12 @@
           </button>
         </div>
         <div v-else>
-          <button class="dataset-button" @click="isDownloadModalVisible = true">
+          <el-button
+            class="dataset-button"
+            @click="isDownloadModalVisible = true"
+          >
             Get Dataset
-          </button>
+          </el-button>
           <el-button class="citation-button" @click="scrollToCitations">
             Cite Dataset
           </el-button>

--- a/pages/datasets/_datasetId.vue
+++ b/pages/datasets/_datasetId.vue
@@ -52,6 +52,10 @@
             </template>
           </div>
         </div>
+        <p v-if="datasetInfo.embargo" class="embargo-release-date">
+          Release date: {{ formatDate(datasetInfo.embargoReleaseDate) }}
+        </p>
+
         <template v-if="datasetInfo.embargo === false">
           <div class="header-stats-section">
             <div class="header-stats-block">
@@ -1223,5 +1227,9 @@ export default {
   img {
     display: block;
   }
+}
+.embargo-release-date {
+  font-size: 0.875rem;
+  margin: 1.5rem 0 0;
 }
 </style>

--- a/pages/datasets/_datasetId.vue
+++ b/pages/datasets/_datasetId.vue
@@ -52,87 +52,100 @@
             </template>
           </div>
         </div>
-        <div class="header-stats-section">
-          <div class="header-stats-block">
-            <svg-icon class="mr-8" name="icon-files" height="20" width="20" />
-            <div>
-              <template v-if="datasetFiles > 0">
-                <strong>
-                  {{ datasetFiles }}
-                </strong>
-                Files
-              </template>
+        <template v-if="datasetInfo.embargo === false">
+          <div class="header-stats-section">
+            <div class="header-stats-block">
+              <svg-icon class="mr-8" name="icon-files" height="20" width="20" />
+              <div>
+                <template v-if="datasetFiles > 0">
+                  <strong>
+                    {{ datasetFiles }}
+                  </strong>
+                  Files
+                </template>
 
-              <template v-else>
-                No Files
-              </template>
+                <template v-else>
+                  No Files
+                </template>
+              </div>
             </div>
-          </div>
-          <div v-if="datasetType !== 'simulation'" class="header-stats-block">
-            <svg-icon class="mr-8" name="icon-storage" height="20" width="20" />
-            <div>
-              <strong>{{ datasetStorage.number }}</strong>
-              {{ datasetStorage.unit }}
+            <div v-if="datasetType !== 'simulation'" class="header-stats-block">
+              <svg-icon
+                class="mr-8"
+                name="icon-storage"
+                height="20"
+                width="20"
+              />
+              <div>
+                <strong>{{ datasetStorage.number }}</strong>
+                {{ datasetStorage.unit }}
+              </div>
             </div>
-          </div>
-          <div class="header-stats-block">
-            <svg-icon class="mr-8" name="icon-license" height="20" width="20" />
-            <div>
-              <template v-if="datasetLicense">
-                <el-tooltip
-                  class="item"
-                  effect="dark"
-                  :content="datasetLicenseName"
-                  placement="top"
-                  :visible-arrow="false"
-                >
-                  <a :href="licenseLink" target="_blank">
-                    {{ datasetLicense }}
-                  </a>
-                </el-tooltip>
-              </template>
+            <div class="header-stats-block">
+              <svg-icon
+                class="mr-8"
+                name="icon-license"
+                height="20"
+                width="20"
+              />
+              <div>
+                <template v-if="datasetLicense">
+                  <el-tooltip
+                    class="item"
+                    effect="dark"
+                    :content="datasetLicenseName"
+                    placement="top"
+                    :visible-arrow="false"
+                  >
+                    <a :href="licenseLink" target="_blank">
+                      {{ datasetLicense }}
+                    </a>
+                  </el-tooltip>
+                </template>
 
-              <template v-else>
-                No License Selected
-              </template>
+                <template v-else>
+                  No License Selected
+                </template>
+              </div>
             </div>
           </div>
-        </div>
-        <div v-if="datasetType === 'simulation'">
-          <button class="dataset-button">
+          <div v-if="datasetType === 'simulation'">
             <a
               :href="`https://osparc.io/study/${getSimulationId}`"
               target="_blank"
+              class="dataset-button-link"
             >
-              Run Simulation
+              <el-button class="dataset-button">
+                Run Simulation
+              </el-button>
             </a>
-          </button>
-        </div>
-        <div v-else>
-          <el-button
-            class="dataset-button"
-            @click="isDownloadModalVisible = true"
-          >
-            Get Dataset
-          </el-button>
-          <el-button class="citation-button" @click="scrollToCitations">
-            Cite Dataset
-          </el-button>
-          <nuxt-link
-            :to="{
-              name: 'help-helpId',
-              params: {
-                helpId: ctfDatasetFormatInfoPageId
-              }
-            }"
-            class="dataset-link"
-          >
-            SPARC Dataset Structure
-          </nuxt-link>
-        </div>
+          </div>
+          <div v-else>
+            <el-button
+              class="dataset-button"
+              @click="isDownloadModalVisible = true"
+            >
+              Get Dataset
+            </el-button>
+            <el-button class="citation-button" @click="scrollToCitations">
+              Cite Dataset
+            </el-button>
+            <nuxt-link
+              :to="{
+                name: 'help-helpId',
+                params: {
+                  helpId: ctfDatasetFormatInfoPageId
+                }
+              }"
+              class="dataset-link"
+            >
+              SPARC Dataset Structure
+            </nuxt-link>
+          </div>
+        </template>
       </div>
     </details-header>
-    <div class="container">
+    <div v-if="datasetInfo.embargo === false" class="container">
       <detail-tabs
         :tabs="tabs"
         :active-tab="activeTab"
@@ -1096,6 +1109,12 @@ export default {
         color: #ffffff;
         font-weight: 500;
         text-transform: uppercase;
+        a {
+          color: #fff;
+        }
+      }
+      .dataset-button-link {
+        margin: 0;
       }
       .citation-button {
         margin-left: 0.5rem;


### PR DESCRIPTION
# Description

The purpose of this PR is to add the ability to see embargoed datasets on the SPARC Portal.

## Type of change

- [x] New feature (non-breaking change which adds functionality)

# How Has This Been Tested?

- Go directly to [an embargoed dataset](http://localhost:3000/datasets/87?type=dataset)
- You should only see the following: Dataset metadata and release date (i.e. title, subtitle, contributors, authors, summary, etc.) and no files or scientific metadata
- Go to [a published dataset](http://localhost:3000/datasets/109?type=dataset) and you should see all data
- Go to [a simulation](http://localhost:3000/datasets/84?type=simulation) and you should see all the data
- Open  `/pages/data/index.vue` and change line 297 from `: 'organization=SPARC%20Consortium'` to `: ''`. This will allow embargoed datasets to be returned (there are no embargoed datasets in the SPARC Consortium)
- Checking "Embargoed" should show the embargoed datasets

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added unit tests that prove my fix is effective or that my feature works
