### PR TITLE
News and events page redesign - cu-qn19eu

### DIFF
--- a/components/EventCard/EventCard.vue
+++ b/components/EventCard/EventCard.vue
@@ -6,6 +6,7 @@
     </div>
     <h3>
       <nuxt-link
+        v-if="event.fields.description"
         :to="{
           name: 'news-and-events-events-id',
           params: { id: event.sys.id }
@@ -13,6 +14,14 @@
       >
         {{ event.fields.title }}
       </nuxt-link>
+      <template v-else>
+        <a v-if="event.fields.url" :href="event.fields.url" target="_blank">
+          {{ event.fields.title }}
+        </a>
+        <div v-else>
+          {{ event.fields.title }}
+        </div>
+      </template>
     </h3>
     <div class="upcoming-event__detail">
       <svg-icon name="icon-calendar" height="16" width="16" />

--- a/components/EventCard/EventCard.vue
+++ b/components/EventCard/EventCard.vue
@@ -91,6 +91,7 @@ export default {
   padding: 1em;
   &__image {
     margin-bottom: 1rem;
+    overflow: hidden;
     padding-top: 100%;
     position: relative;
     img {

--- a/components/FeaturedEvent/FeaturedEvent.vue
+++ b/components/FeaturedEvent/FeaturedEvent.vue
@@ -3,6 +3,7 @@
     <div>
       <h3>
         <nuxt-link
+          v-if="event.fields.description"
           :to="{
             name: 'news-and-events-events-id',
             params: { id: event.sys.id }
@@ -10,6 +11,14 @@
         >
           {{ event.fields.title }}
         </nuxt-link>
+        <template v-else>
+          <a v-if="event.fields.url" :href="event.fields.url" target="_blank">
+            {{ event.fields.title }}
+          </a>
+          <div v-else>
+            {{ event.fields.title }}
+          </div>
+        </template>
       </h3>
       <div class="sparc-card__detail">
         <svg-icon name="icon-calendar" height="16" width="16" />
@@ -29,6 +38,7 @@
       <div v-html="parseMarkdown(event.fields.summary)" />
     </div>
     <nuxt-link
+      v-if="event.fields.description"
       :to="{
         name: 'news-and-events-events-id',
         params: { id: event.sys.id }
@@ -39,6 +49,12 @@
         Learn More
       </el-button>
     </nuxt-link>
+
+    <a v-else :href="event.fields.url" target="_blank" class="btn-permalink">
+      <el-button size="medium">
+        Learn More
+      </el-button>
+    </a>
   </sparc-card>
 </template>
 

--- a/components/NewsListItem/NewsListItem.vue
+++ b/components/NewsListItem/NewsListItem.vue
@@ -2,6 +2,7 @@
   <div class="news-list-item">
     <h3>
       <nuxt-link
+        v-if="item.fields.copy"
         :to="{
           name: 'news-and-events-news-id',
           params: { id: item.sys.id }
@@ -9,6 +10,13 @@
       >
         {{ item.fields.title }}
       </nuxt-link>
+      <a
+        v-else
+        :href="item.fields.url"
+        :target="isInternalLink('item.fields.url') ? '_self' : '_blank'"
+      >
+        {{ item.fields.title }}
+      </a>
     </h3>
     <p>{{ item.fields.summary }}</p>
     <p class="news-list-item__date">
@@ -19,6 +27,8 @@
 
 <script>
 import FormatDate from '@/mixins/format-date'
+
+import { isInternalLink } from '@/mixins/marked/index'
 
 export default {
   name: 'NewsListItem',
@@ -40,6 +50,10 @@ export default {
     publishedDate: function() {
       return this.formatDate(this.item.fields.publishedDate || '')
     }
+  },
+
+  methods: {
+    isInternalLink
   }
 }
 </script>

--- a/pages/news-and-events/index.vue
+++ b/pages/news-and-events/index.vue
@@ -26,7 +26,7 @@
         </div>
 
         <el-row :gutter="32">
-          <el-col :span="12">
+          <el-col :sm="12">
             <h2>Latest News</h2>
             <div class="subpage">
               <div>
@@ -43,7 +43,7 @@
               </div>
             </div>
           </el-col>
-          <el-col :span="12">
+          <el-col :sm="12">
             <h2>Events</h2>
             <tab-nav
               :tabs="eventsTabs"
@@ -248,6 +248,7 @@ h3 {
 }
 .upcoming-event {
   margin: 0 1em 2em;
+  width: 100%;
   @media (min-width: 48em) {
     width: calc(50% - 4.125em); // Account for the margins and the border
   }

--- a/pages/news-and-events/index.vue
+++ b/pages/news-and-events/index.vue
@@ -2,24 +2,29 @@
   <div class="events-page">
     <breadcrumb :breadcrumb="breadcrumb" :title="title" />
     <page-hero>
-      <h1>{{ heroData.fields.page_title }}</h1>
+      <h1>{{ page.fields.page_title }}</h1>
       <p>
-        {{ heroData.fields.heroCopy }}
+        {{ page.fields.heroCopy }}
       </p>
       <search-controls-contentful
         placeholder="Search news and events"
         path="/news-and-events"
       />
       <img
-        v-if="heroData.fields.heroImage"
+        v-if="page.fields.heroImage"
         slot="image"
         class="page-hero-img"
-        :src="heroData.fields.heroImage.fields.file.url"
+        :src="page.fields.heroImage.fields.file.url"
       />
     </page-hero>
 
     <div class="page-wrap">
       <div class="container">
+        <div v-if="Object.keys(featuredEvent).length" class="mb-40">
+          <h2>Featured Event</h2>
+          <featured-event :event="featuredEvent" />
+        </div>
+
         <h2>Events</h2>
         <tab-nav
           :tabs="eventsTabs"
@@ -117,10 +122,11 @@ import EventCard from '@/components/EventCard/EventCard.vue';
 import PageHero from '@/components/PageHero/PageHero.vue';
 import SearchControlsContentful from '@/components/SearchControlsContentful/SearchControlsContentful.vue';
 import NewsletterForm from '@/components/NewsletterForm/NewsletterForm.vue';
+import FeaturedEvent from '@/components/FeaturedEvent/FeaturedEvent.vue';
 
 import createClient from '@/plugins/contentful.js';
 
-import { Computed, Data, Methods, fetchData, fetchNews, HeroDataEntry, NewsAndEventsComponent, NewsCollection } from './model';
+import { Computed, Data, Methods, fetchData, fetchNews, PageEntry, NewsAndEventsComponent, NewsCollection } from './model';
 
 const client = createClient()
 const MAX_PAST_EVENTS = 8
@@ -136,7 +142,8 @@ export default Vue.extend<Data, Methods, Computed, never>({
     NewsListItem,
     TabNav,
     SearchControlsContentful,
-    NewsletterForm
+    NewsletterForm,
+    FeaturedEvent
   },
 
   asyncData() {
@@ -146,11 +153,11 @@ export default Vue.extend<Data, Methods, Computed, never>({
   watch: {
     '$route.query': {
       handler: async function(this: NewsAndEventsComponent) {
-        const { upcomingEvents, pastEvents, news, heroData } = await fetchData(client, this.$route.query.search as string)
+        const { upcomingEvents, pastEvents, news, page } = await fetchData(client, this.$route.query.search as string)
         this.upcomingEvents = upcomingEvents;
         this.pastEvents = pastEvents;
         this.news = news;
-        this.heroData = heroData;
+        this.page = page;
       },
       immediate: true
     }
@@ -183,12 +190,20 @@ export default Vue.extend<Data, Methods, Computed, never>({
       isShowingAllUpcomingEvents: false,
       isShowingAllPastEvents: false,
       news: {} as NewsCollection,
-      heroData: {} as HeroDataEntry,
+      page: {} as PageEntry,
       pastEventChunk: 1
     }
   },
 
   computed: {
+    /**
+     * Compute featured event
+     * @returns {Object}
+     */
+    featuredEvent: function() {
+      return this.page.fields.featuredEvent || {}
+    },
+
     /**
      * Compute upcoming events
      * Used to display four events in the upcoming tab

--- a/pages/news-and-events/index.vue
+++ b/pages/news-and-events/index.vue
@@ -28,7 +28,7 @@
         <el-row :gutter="32">
           <el-col :sm="12">
             <h2>Latest News</h2>
-            <div class="subpage">
+            <div class="subpage news-wrap">
               <div>
                 <news-list-item v-for="newsItem in news.items" :key="newsItem.sys.id" :item="newsItem" />
 
@@ -231,6 +231,11 @@ h3 {
   @media (min-width: 48em) {
     margin: 3rem 0;
   }
+  &.news-wrap {
+    @media (min-width: 48em) {
+      margin: 2rem 0 0;
+    }
+  }
 }
 .event-card {
   margin-bottom: 2em;
@@ -247,7 +252,7 @@ h3 {
   margin: 0 -1em;
 }
 .upcoming-event {
-  margin: 0 1em 2em;
+  margin: 0 1rem 1rem;
   width: 100%;
   @media (min-width: 48em) {
     width: calc(50% - 4.125em); // Account for the margins and the border

--- a/pages/news-and-events/index.vue
+++ b/pages/news-and-events/index.vue
@@ -20,70 +20,70 @@
 
     <div class="page-wrap">
       <div class="container">
-        <div v-if="Object.keys(featuredEvent).length" class="mb-40">
+        <div v-if="Object.keys(featuredEvent).length" class="mb-48">
           <h2>Featured Event</h2>
           <featured-event :event="featuredEvent" />
         </div>
 
-        <h2>Events</h2>
-        <tab-nav
-          :tabs="eventsTabs"
-          :active-tab="activeTab"
-          @set-active-tab="activeTab = $event"
-        />
-        <div class="events-wrap">
-          <template v-if="activeTab === 'upcoming'">
-            <div class="upcoming-events">
-              <event-card
-                v-for="event in displayedUpcomingEvents"
-                :key="event.sys.id"
-                :event="event"
-              />
+        <el-row :gutter="32">
+          <el-col :span="12">
+            <h2>Latest News</h2>
+            <div class="subpage">
+              <div>
+                <news-list-item v-for="newsItem in news.items" :key="newsItem.sys.id" :item="newsItem" />
+
+                <nuxt-link
+                  class="btn-load-more mt-16"
+                  :to="{
+                    name: 'news-and-events-news'
+                  }"
+                >
+                  View All News &gt;
+                </nuxt-link>
+              </div>
             </div>
+          </el-col>
+          <el-col :span="12">
+            <h2>Events</h2>
+            <tab-nav
+              :tabs="eventsTabs"
+              :active-tab="activeTab"
+              @set-active-tab="activeTab = $event"
+            />
+            <div class="events-wrap">
+              <template v-if="activeTab === 'upcoming'">
+                <div class="upcoming-events">
+                  <event-card
+                    v-for="event in upcomingEvents"
+                    :key="event.sys.id"
+                    :event="event"
+                  />
+                </div>
 
-            <div class="show-all-upcoming-events">
-              <nuxt-link
-                class="show-all-upcoming-events__btn"
-                :to="{
-                  name: 'news-and-events-events'
-                }"
-              >
-                Show All ({{ upcomingEvents.length }}) Upcoming Events
-                <svg-icon name="icon-sort-desc" height="10" width="10" />
-              </nuxt-link>
+                <div class="show-all-upcoming-events">
+                  <nuxt-link
+                    class="show-all-upcoming-events__btn"
+                    :to="{
+                      name: 'news-and-events-events'
+                    }"
+                  >
+                    Show All Events
+                  </nuxt-link>
+                </div>
+              </template>
+
+              <template v-if="activeTab === 'past'">
+                <div class="past-events">
+                  <event-card
+                    v-for="event in pastEvents"
+                    :key="event.sys.id"
+                    :event="event"
+                  />
+                </div>
+              </template>
             </div>
-          </template>
-
-          <template v-if="activeTab === 'past'">
-            <div class="past-events">
-              <event-card
-                v-for="event in displayedPastEvents"
-                :key="event.sys.id"
-                :event="event"
-              />
-            </div>
-
-            <div class="show-more-past-events">
-              <a
-                v-if="!isShowingAllPastEvents && pastEventsChunkMax > 1"
-                class="show-more-past-events__btn"
-                href="#"
-                @click.prevent="pastEventChunk += 1"
-              >
-                View More
-              </a>
-            </div>
-          </template>
-        </div>
-
-        <h2>Latest News</h2>
-        <div class="subpage">
-          <div>
-            <news-list-item v-for="newsItem in news.items" :key="newsItem.sys.id" :item="newsItem" />
-
-            <button v-if="news.total > news.items.length" class="btn-load-more mt-16" @click="getAllNews">View All News &gt;</button>
-          </div>
-        </div>
+          </el-col>
+        </el-row>
 
         <h2>Stay Connected</h2>
         <div class="subpage">
@@ -147,13 +147,13 @@ export default Vue.extend<Data, Methods, Computed, never>({
   },
 
   asyncData() {
-    return fetchData(client)
+    return fetchData(client, '', 2)
   },
 
   watch: {
     '$route.query': {
       handler: async function(this: NewsAndEventsComponent) {
-        const { upcomingEvents, pastEvents, news, page } = await fetchData(client, this.$route.query.search as string)
+        const { upcomingEvents, pastEvents, news, page } = await fetchData(client, this.$route.query.search as string, 2)
         this.upcomingEvents = upcomingEvents;
         this.pastEvents = pastEvents;
         this.news = news;
@@ -187,11 +187,8 @@ export default Vue.extend<Data, Methods, Computed, never>({
       ],
       upcomingEvents: [],
       pastEvents: [],
-      isShowingAllUpcomingEvents: false,
-      isShowingAllPastEvents: false,
       news: {} as NewsCollection,
-      page: {} as PageEntry,
-      pastEventChunk: 1
+      page: {} as PageEntry
     }
   },
 
@@ -202,36 +199,6 @@ export default Vue.extend<Data, Methods, Computed, never>({
      */
     featuredEvent: function() {
       return this.page.fields.featuredEvent || {}
-    },
-
-    /**
-     * Compute upcoming events
-     * Used to display four events in the upcoming tab
-     * @returns {Array}
-     */
-    displayedUpcomingEvents: function(this: Data) {
-      return this.isShowingAllUpcomingEvents
-        ? this.upcomingEvents
-        : this.upcomingEvents.slice(0, 4)
-    },
-
-    /**
-     * Compute maximum chunk value
-     * @returns {Number}
-     */
-    pastEventsChunkMax: function(this: Data) {
-      return Math.ceil(this.pastEvents.length / MAX_PAST_EVENTS)
-    },
-
-    /**
-     * Compute past events to display based on
-     * current chunk value
-     * @returns {Array}
-     */
-    displayedPastEvents: function (this: Data & Computed) {
-      if (this.pastEventChunk === this.pastEventsChunkMax) this.isShowingAllPastEvents = true;
-      const endChunk = this.pastEventChunk * MAX_PAST_EVENTS
-      return this.pastEvents.slice().reverse().slice(0, endChunk)
     }
   },
 
@@ -240,7 +207,7 @@ export default Vue.extend<Data, Methods, Computed, never>({
      * Get all news
      */
     getAllNews: async function() {
-      const news = await fetchNews(client, this.$route.query.search as string, this.news.total, 4)
+      const news = await fetchNews(client, this.$route.query.search as string, this.news.total, 2)
       this.news = { ...this.news, items: { ...this.news.items, ...news.items } }
     }
   }
@@ -283,9 +250,6 @@ h3 {
   margin: 0 1em 2em;
   @media (min-width: 48em) {
     width: calc(50% - 4.125em); // Account for the margins and the border
-  }
-  @media (min-width: 64em) {
-    width: calc(25% - 4.125em); // Account for the margins and the border
   }
 }
 .show-all-upcoming-events {
@@ -351,6 +315,7 @@ h3 {
   border: none;
   color: $navy;
   cursor: pointer;
+  display: block;
   font-size: 1rem;
   font-weight: 700;
   padding: 0;

--- a/pages/news-and-events/model.ts
+++ b/pages/news-and-events/model.ts
@@ -4,7 +4,7 @@ import { Route } from 'vue-router';
 import { Breadcrumb } from '@/components/Breadcrumb/model.ts';
 
 
-export const fetchData = async (client: ContentfulClientApi, query?: string) : Promise<AsyncData> => {
+export const fetchData = async (client: ContentfulClientApi, query?: string, limit?: number) : Promise<AsyncData> => {
   try {
     const todaysDate = new Date()
 
@@ -13,6 +13,7 @@ export const fetchData = async (client: ContentfulClientApi, query?: string) : P
       order: 'fields.startDate',
       'fields.startDate[gte]': todaysDate.toISOString(),
       query,
+      limit
     })
 
     const pastEvents = await client.getEntries<Event>({
@@ -20,9 +21,10 @@ export const fetchData = async (client: ContentfulClientApi, query?: string) : P
       order: 'fields.startDate',
       'fields.startDate[lt]': todaysDate.toISOString(),
       query,
+      limit
     })
 
-    const news = await fetchNews(client, query, 4)
+    const news = await fetchNews(client, query, limit)
 
     const page = await client.getEntry<PageData>(process.env.ctf_news_and_events_page_id ?? '')
 
@@ -108,18 +110,12 @@ export interface Data {
   eventsTabs: Tab[],
   upcomingEvents: EventsEntry[],
   pastEvents: EventsEntry[],
-  isShowingAllUpcomingEvents: boolean,
-  isShowingAllPastEvents: boolean,
   news: NewsCollection,
-  page: PageEntry,
-  pastEventChunk: number
+  page: PageEntry
 }
 
 
 export interface Computed {
-  displayedUpcomingEvents: EventsEntry[],
-  pastEventsChunkMax: number,
-  displayedPastEvents: EventsEntry[],
   featuredEvent: Entry<Event>
 }
 export interface Methods {

--- a/pages/news-and-events/model.ts
+++ b/pages/news-and-events/model.ts
@@ -24,13 +24,13 @@ export const fetchData = async (client: ContentfulClientApi, query?: string) : P
 
     const news = await fetchNews(client, query, 4)
 
-    const heroData = await client.getEntry<HeroData>(process.env.ctf_news_and_events_page_id ?? '')
+    const page = await client.getEntry<PageData>(process.env.ctf_news_and_events_page_id ?? '')
 
     return {
       upcomingEvents: upcomingEvents.items,
       pastEvents: pastEvents.items,
       news,
-      heroData
+      page
     }
   } catch (e) {
     console.error(e)
@@ -38,7 +38,7 @@ export const fetchData = async (client: ContentfulClientApi, query?: string) : P
       upcomingEvents: [],
       pastEvents: [],
       news: {} as unknown as NewsCollection,
-      heroData: {} as unknown as Entry<HeroData>
+      page: {} as unknown as PageEntry
     }
   }
 }
@@ -58,15 +58,16 @@ export const fetchNews = async (client: ContentfulClientApi, query?: string, lim
   }
 }
 
-export type AsyncData = Pick<Data, "upcomingEvents" | "pastEvents" | "news" | "heroData">
+export type AsyncData = Pick<Data, "upcomingEvents" | "pastEvents" | "news" | "page">
 
-export interface HeroData {
+export interface PageData {
+  featuredEvent?: Entry<Event>;
   page_title?: string;
   heroCopy?: string;
   heroImage?: Asset;
 }
 
-export type HeroDataEntry = Entry<HeroData>
+export type PageEntry = Entry<PageData>
 
 
 export interface Event {
@@ -110,7 +111,7 @@ export interface Data {
   isShowingAllUpcomingEvents: boolean,
   isShowingAllPastEvents: boolean,
   news: NewsCollection,
-  heroData: HeroDataEntry,
+  page: PageEntry,
   pastEventChunk: number
 }
 
@@ -118,7 +119,8 @@ export interface Data {
 export interface Computed {
   displayedUpcomingEvents: EventsEntry[],
   pastEventsChunkMax: number,
-  displayedPastEvents: EventsEntry[]
+  displayedPastEvents: EventsEntry[],
+  featuredEvent: Entry<Event>
 }
 export interface Methods {
   getAllNews: (this: NewsAndEventsComponent) => void;


### PR DESCRIPTION
# Description

The purpose of this PR is to do the following with the news and events page
- Redesign
- Only show 2 news and 2 events, and linking to their landing pages
- Add Featured Event at the top
- Only link to a news or event details page if there is content. If there isn't, link to the external URL.

## Type of change
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)

# How Has This Been Tested?

- Go to the [news and events page](http://localhost:3000/news-and-events)
- Featured news should be at the top and its links should go to the details page
- Latest news and Events should be in two columns beside each other, and the events tabs should work
- The featured event should not be listed in the Events
- News or events should only go to the details page if there is content. If there isn't, link to the external URL.
- Clicking on "View all news" doesn't work yet, as there is no News landing page, but the code is in place
- Clicking on the "view all events" link should take you to the events landing page

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added unit tests that prove my fix is effective or that my feature works
