### PR TITLE
Conditional events details page and Featured Event fix -  cu-qn19eu

### DIFF
--- a/components/EventCard/EventCard.vue
+++ b/components/EventCard/EventCard.vue
@@ -6,7 +6,7 @@
     </div>
     <h3>
       <nuxt-link
-        v-if="event.fields.description"
+        v-if="event.fields.requiresADetailsPage"
         :to="{
           name: 'news-and-events-events-id',
           params: { id: event.sys.id }

--- a/components/FeaturedEvent/FeaturedEvent.vue
+++ b/components/FeaturedEvent/FeaturedEvent.vue
@@ -3,7 +3,7 @@
     <div>
       <h3>
         <nuxt-link
-          v-if="event.fields.description"
+          v-if="event.fields.requiresADetailsPage"
           :to="{
             name: 'news-and-events-events-id',
             params: { id: event.sys.id }
@@ -38,7 +38,7 @@
       <div v-html="parseMarkdown(event.fields.summary)" />
     </div>
     <nuxt-link
-      v-if="event.fields.description"
+      v-if="event.fields.requiresADetailsPage"
       :to="{
         name: 'news-and-events-events-id',
         params: { id: event.sys.id }

--- a/pages/news-and-events/events/index.vue
+++ b/pages/news-and-events/events/index.vue
@@ -92,9 +92,9 @@ const MAX_PAST_EVENTS = 8
  */
 const getFeaturedEvent = async () => {
   try {
-    const newsAndEventsPage = await client.getEntry({
-      id: process.env.ctf_news_and_events_page_id
-    })
+    const newsAndEventsPage = await client.getEntry(
+      process.env.ctf_news_and_events_page_id
+    )
 
     return pathOr({}, ['fields', 'featuredEvent'], newsAndEventsPage)
   } catch (error) {


### PR DESCRIPTION
# Description

The purpose of this PR is to:
- Add logic to support the new `requiresADetailsPage` field in Contentful. This will be used to determine if an event should look to its detail page or its URL
- Fix featured event on Events landing page. This was currently not being displayed because the Contentful query was incorrect.

## Type of change

Delete those that don't apply.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

# How Has This Been Tested?
- Go to the [events landing page](http://localhost:3000/news-and-events/events)
- The featured event should be at the top
- Clicking on the featured events name or "Learn More" button should take you to the event's URL in a new tab
- Clicking on an event's name should take you to the event's URL in a new tab

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added unit tests that prove my fix is effective or that my feature works
