### PR TITLE
Add support to parse markdown in hero

### DIFF
--- a/pages/news-and-events/index.vue
+++ b/pages/news-and-events/index.vue
@@ -3,9 +3,9 @@
     <breadcrumb :breadcrumb="breadcrumb" :title="title" />
     <page-hero>
       <h1>{{ page.fields.page_title }}</h1>
-      <p>
-        {{ page.fields.heroCopy }}
-      </p>
+      <!-- eslint-disable vue/no-v-html -->
+      <!-- marked will sanitize the HTML injected -->
+      <div v-html="parseMarkdown(page.fields.heroCopy)" />
       <search-controls-contentful
         placeholder="Search news and events"
         path="/news-and-events"
@@ -124,6 +124,8 @@ import SearchControlsContentful from '@/components/SearchControlsContentful/Sear
 import NewsletterForm from '@/components/NewsletterForm/NewsletterForm.vue';
 import FeaturedEvent from '@/components/FeaturedEvent/FeaturedEvent.vue';
 
+import MarkedMixin from '@/mixins/marked'
+
 import createClient from '@/plugins/contentful.js';
 
 import { Computed, Data, Methods, fetchData, fetchNews, PageEntry, NewsAndEventsComponent, NewsCollection } from './model';
@@ -133,6 +135,10 @@ const MAX_PAST_EVENTS = 8
 
 export default Vue.extend<Data, Methods, Computed, never>({
   name: 'EventPage',
+
+  mixins: [
+    MarkedMixin
+  ],
 
   components: {
     Breadcrumb,


### PR DESCRIPTION
# Description

The purpose of this PR is to add support to parse markdown in hero of the news and events page. This will be used to link to the Submit News form.

## Type of change

- [x] New feature (non-breaking change which adds functionality)

# How Has This Been Tested?

- Go to the [news and events page](http://localhost:3000/news-and-events)
- The hero copy should be above the search bar in the hero, and the word "request" should be linked to the Wrike form.

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
