### PR TITLE
Cap "Portal" in hero for news and events landing pages

### DIFF
--- a/pages/news-and-events/events/index.vue
+++ b/pages/news-and-events/events/index.vue
@@ -4,7 +4,7 @@
     <page-hero>
       <h1>Events</h1>
       <p>
-        Check out the latest events associated with the SPARC portal
+        Check out the latest events associated with the SPARC Portal
       </p>
     </page-hero>
     <div class="page-wrap">

--- a/pages/news-and-events/news/index.vue
+++ b/pages/news-and-events/news/index.vue
@@ -4,7 +4,7 @@
     <page-hero>
       <h1>Latest News</h1>
       <p>
-        Check out the latest announcements about the SPARC portal and the latest
+        Check out the latest announcements about the SPARC Portal and the latest
         news about the SPARC program.
       </p>
     </page-hero>


### PR DESCRIPTION
# Description

The purpose of this PR is to Cap "Portal" in hero for news and events landing pages.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

Go to each news and events landing pages and "SPARC Portal" should appear in the hero.

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
