### PR TITLE
QA news events - cu-q10kg4

### DIFF
--- a/pages/news-and-events/events/index.vue
+++ b/pages/news-and-events/events/index.vue
@@ -55,14 +55,18 @@
               />
             </div>
 
-            <div class="show-more-past-events">
+            <div class="show-all-upcoming-events">
               <a
-                v-if="!isShowingAllPastEvents && pastEventsChunkMax > 1"
-                class="show-more-past-events__btn"
+                v-if="
+                  !isShowingAllPastEvents &&
+                    pastEvents.length != displayedPastEvents.length
+                "
+                class="show-all-upcoming-events__btn"
                 href="#"
-                @click.prevent="pastEventChunk += 1"
+                @click.prevent="isShowingAllPastEvents = true"
               >
-                View More
+                Show All ({{ pastEvents.length }}) Past Events
+                <svg-icon name="icon-sort-desc" height="10" width="10" />
               </a>
             </div>
           </template>
@@ -210,8 +214,7 @@ export default {
       upcomingEvents: [],
       pastEvents: [],
       isShowingAllUpcomingEvents: false,
-      isShowingAllPastEvents: false,
-      pastEventChunk: 1
+      isShowingAllPastEvents: false
     }
   },
 
@@ -228,26 +231,14 @@ export default {
     },
 
     /**
-     * Compute maximum chunk value
-     * @returns {Number}
-     */
-    pastEventsChunkMax: function() {
-      return Math.ceil(this.pastEvents.length / MAX_PAST_EVENTS)
-    },
-
-    /**
      * Compute past events to display based on
      * current chunk value
      * @returns {Array}
      */
     displayedPastEvents: function() {
-      if (this.pastEventChunk === this.pastEventsChunkMax)
-        this.isShowingAllPastEvents = true
-      const endChunk = this.pastEventChunk * MAX_PAST_EVENTS
-      return this.pastEvents
-        .slice()
-        .reverse()
-        .slice(0, endChunk)
+      return this.isShowingAllPastEvents
+        ? this.pastEvents
+        : this.pastEvents.slice(0, 4)
     }
   },
 
@@ -325,19 +316,6 @@ h3 {
   }
 }
 
-.show-more-past-events {
-  text-align: center;
-  &__btn {
-    display: inline-flex;
-    border: 1px solid $dark-gray;
-    border-radius: 5px;
-    text-decoration: none;
-    padding: 8px 10px;
-    font-size: 11pt;
-    font-weight: bold;
-    color: $dark-gray;
-  }
-}
 .events-wrap {
   margin-bottom: 2.625em;
 }

--- a/pages/news-and-events/events/index.vue
+++ b/pages/news-and-events/events/index.vue
@@ -18,7 +18,7 @@
         <tab-nav
           :tabs="eventsTabs"
           :active-tab="activeTab"
-          @set-active-tab="activeTab = $event"
+          @set-active-tab="setActiveTab"
         />
         <div class="events-wrap">
           <template v-if="activeTab === 'upcoming'">
@@ -248,6 +248,29 @@ export default {
         .slice()
         .reverse()
         .slice(0, endChunk)
+    }
+  },
+
+  watch: {
+    '$route.query.tab': {
+      handler(val) {
+        if (val) {
+          this.activeTab = val
+        }
+      },
+      immediate: true
+    }
+  },
+
+  methods: {
+    /**
+     * Set active tab by changing the router query param
+     * @param {String} tab
+     */
+    setActiveTab(tab) {
+      this.$router.push({
+        query: { tab }
+      })
     }
   }
 }

--- a/pages/news-and-events/index.vue
+++ b/pages/news-and-events/index.vue
@@ -54,7 +54,7 @@
               <template v-if="activeTab === 'upcoming'">
                 <div class="upcoming-events">
                   <event-card
-                    v-for="event in upcomingEvents"
+                    v-for="event in upcomingEvents.items"
                     :key="event.sys.id"
                     :event="event"
                   />
@@ -67,7 +67,7 @@
                       name: 'news-and-events-events'
                     }"
                   >
-                    Show All Events
+                    Show All ({{ upcomingEvents.total }}) Events
                   </nuxt-link>
                 </div>
               </template>
@@ -75,10 +75,21 @@
               <template v-if="activeTab === 'past'">
                 <div class="past-events">
                   <event-card
-                    v-for="event in pastEvents"
+                    v-for="event in pastEvents.items"
                     :key="event.sys.id"
                     :event="event"
                   />
+                </div>
+
+                <div class="show-all-upcoming-events">
+                  <nuxt-link
+                    class="show-all-upcoming-events__btn"
+                    :to="{
+                      name: 'news-and-events-events'
+                    }"
+                  >
+                    Show All ({{ pastEvents.total }}) Past Events
+                  </nuxt-link>
                 </div>
               </template>
             </div>
@@ -128,13 +139,13 @@ import MarkedMixin from '@/mixins/marked'
 
 import createClient from '@/plugins/contentful.js';
 
-import { Computed, Data, Methods, fetchData, fetchNews, PageEntry, NewsAndEventsComponent, NewsCollection } from './model';
+import { Computed, Data, Methods, fetchData, fetchNews, PageEntry, NewsAndEventsComponent, NewsCollection, EventsCollection } from './model';
 
 const client = createClient()
 const MAX_PAST_EVENTS = 8
 
 export default Vue.extend<Data, Methods, Computed, never>({
-  name: 'EventPage',
+  name: 'NewsAndEventPage',
 
   mixins: [
     MarkedMixin
@@ -191,8 +202,8 @@ export default Vue.extend<Data, Methods, Computed, never>({
           type: 'past'
         }
       ],
-      upcomingEvents: [],
-      pastEvents: [],
+      upcomingEvents: {} as EventsCollection,
+      pastEvents: {} as EventsCollection,
       news: {} as NewsCollection,
       page: {} as PageEntry
     }

--- a/pages/news-and-events/index.vue
+++ b/pages/news-and-events/index.vue
@@ -85,7 +85,10 @@
                   <nuxt-link
                     class="show-all-upcoming-events__btn"
                     :to="{
-                      name: 'news-and-events-events'
+                      name: 'news-and-events-events',
+                      query: {
+                        tab: 'past'
+                      }
                     }"
                   >
                     Show All ({{ pastEvents.total }}) Past Events

--- a/pages/news-and-events/model.ts
+++ b/pages/news-and-events/model.ts
@@ -8,7 +8,7 @@ export const fetchData = async (client: ContentfulClientApi, query?: string, lim
   try {
     const todaysDate = new Date()
 
-    const upcomingEvents = await client.getEntries<Event>({
+    const upcomingEvents = await client.getEntries<EventsEntry>({
       content_type: process.env.ctf_event_id,
       order: 'fields.startDate',
       'fields.startDate[gte]': todaysDate.toISOString(),
@@ -16,7 +16,7 @@ export const fetchData = async (client: ContentfulClientApi, query?: string, lim
       limit
     })
 
-    const pastEvents = await client.getEntries<Event>({
+    const pastEvents = await client.getEntries<EventsEntry>({
       content_type: process.env.ctf_event_id,
       order: 'fields.startDate',
       'fields.startDate[lt]': todaysDate.toISOString(),
@@ -29,16 +29,16 @@ export const fetchData = async (client: ContentfulClientApi, query?: string, lim
     const page = await client.getEntry<PageData>(process.env.ctf_news_and_events_page_id ?? '')
 
     return {
-      upcomingEvents: upcomingEvents.items,
-      pastEvents: pastEvents.items,
+      upcomingEvents,
+      pastEvents,
       news,
       page
     }
   } catch (e) {
     console.error(e)
     return {
-      upcomingEvents: [],
-      pastEvents: [],
+      upcomingEvents: {} as unknown as EventsCollection,
+      pastEvents: {} as unknown as EventsCollection,
       news: {} as unknown as NewsCollection,
       page: {} as unknown as PageEntry
     }
@@ -63,7 +63,7 @@ export const fetchNews = async (client: ContentfulClientApi, query?: string, lim
 export type AsyncData = Pick<Data, "upcomingEvents" | "pastEvents" | "news" | "page">
 
 export interface PageData {
-  featuredEvent?: Entry<Event>;
+  featuredEvent?: EventsEntry;
   page_title?: string;
   heroCopy?: string;
   heroImage?: Asset;
@@ -86,6 +86,7 @@ export interface Event {
 }
 
 export type EventsEntry = Entry<Event>
+export type EventsCollection = EntryCollection<EventsEntry>
 
 export interface News {
   publishedDate?: string;
@@ -104,18 +105,18 @@ export interface Tab {
 }
 
 export interface Data {
-  title: string
-  breadcrumb: Breadcrumb[],
-  activeTab: string,
-  eventsTabs: Tab[],
-  upcomingEvents: EventsEntry[],
-  pastEvents: EventsEntry[],
-  news: NewsCollection,
-  page: PageEntry
+  title: string;
+  breadcrumb: Breadcrumb[];
+  activeTab: string;
+  eventsTabs: Tab[];
+  upcomingEvents: EventsCollection;
+  pastEvents: EventsCollection;
+  news: NewsCollection;
+  page: PageEntry;
 }
 
 export interface Computed {
-  featuredEvent: Entry<Event>
+  featuredEvent: EventsEntry
 }
 export interface Methods {
   getAllNews: (this: NewsAndEventsComponent) => void;

--- a/pages/news-and-events/model.ts
+++ b/pages/news-and-events/model.ts
@@ -1,5 +1,6 @@
 import { Asset, ContentfulClientApi, Entry, EntryCollection } from 'contentful';
 import { Route } from 'vue-router';
+import { sub } from 'date-fns'
 
 import { Breadcrumb } from '@/components/Breadcrumb/model.ts';
 
@@ -20,6 +21,7 @@ export const fetchData = async (client: ContentfulClientApi, query?: string, lim
       content_type: process.env.ctf_event_id,
       order: 'fields.startDate',
       'fields.startDate[lt]': todaysDate.toISOString(),
+      'fields.startDate[gte]': sub(todaysDate, { years: 2 }).toISOString(),
       query,
       limit
     })


### PR DESCRIPTION
# Description
The purpose of this PR is to address the following feedback:

News and events page
- Add "Show (X) past events" button
- This button should lead directly to the past events tab on the past events page

Events page
- Past events tab should have a "Show all" button to show all events after four

General
- Past events older than two years should not be shown

## Type of change
- [x] New feature (non-breaking change which adds functionality)

# How Has This Been Tested?

- Go to the [news and events page](http://localhost:3000/news-and-events)
- Click on the Past events tab
- Click on the "Show All (18) Past Events" button
- This should take you to the past tabs on the events page, showing four events
- Click on the "Show All (18) Past Events" button
- This should show all past events


# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added unit tests that prove my fix is effective or that my feature works
