### PR TITLE
feat(Files): Copy File URL to clipboard

### DIFF
--- a/components/FilesTable/FilesTable.vue
+++ b/components/FilesTable/FilesTable.vue
@@ -146,6 +146,15 @@
                 >
                   Open Scaffold
                 </el-dropdown-item>
+                <el-dropdown-item
+                  v-if="scope.row.uri"
+                  :command="{
+                    type: 'copyS3Url',
+                    scope
+                  }"
+                >
+                  Copy URL to Clipboard
+                </el-dropdown-item>
               </el-dropdown-menu>
             </el-dropdown>
           </template>
@@ -173,6 +182,7 @@ import BfDownloadFile from '@/components/BfDownloadFile/BfDownloadFile'
 
 import FormatStorage from '@/mixins/bf-storage-metrics/index'
 import RequestDownloadFile from '@/mixins/request-download-file'
+import { successMessage, failMessage } from '@/utils/notification-messages'
 
 const contentTypes = {
   pdf: 'application/pdf',
@@ -485,6 +495,21 @@ export default {
       this.data.forEach(r => {
         this.$refs.table.toggleRowSelection(r, selectedPaths.includes(r.path))
       })
+    },
+
+    /**
+     * Copy file URL to clipboard
+     * @param {Object} scope
+     */
+    copyS3Url(scope) {
+      this.$copyText(scope.row.uri).then(
+        () => {
+          this.$message(successMessage(`File URL copied to clipboard.`))
+        },
+        () => {
+          this.$message(failMessage(`Cannot copy to clipboard.`))
+        }
+      )
     }
   }
 }


### PR DESCRIPTION
# Description

The purpose of this PR is to add the feature that allows the user to copy the file URL to their clipboard.

## Type of change

- [x] New feature (non-breaking change which adds functionality)

# How Has This Been Tested?

- Go to the [files tab of a dataset](http://localhost:3000/datasets/109?type=dataset)
- Open the menu for a file
- Click on "Copy URL to Clipboard"
- Toast should appear, and the S3 URL should be in your clipboard

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added unit tests that prove my fix is effective or that my feature works
