### PR TITLE
feat(Resources): Add Databases and Information Services category

### DIFF
--- a/pages/resources/index.vue
+++ b/pages/resources/index.vue
@@ -100,8 +100,12 @@ const tabTypes = [
     type: 'Device' as const
   },
   {
-    label: 'Digital Repositories',
-    type: 'Digital Repositories' as const
+    label: 'Databases',
+    type: 'Databases' as const
+  },
+  {
+    label: 'Information Services',
+    type: 'Information Services' as const
   },
   {
     label: 'Software',

--- a/pages/resources/model.ts
+++ b/pages/resources/model.ts
@@ -38,7 +38,7 @@ export interface Methods {
 export type ResourcesComponent = Data & Computed & Methods & { $route: Route, $router: VueRouter }
 
 
-type ResourceType = 'Device' | 'Digital Repositories' | 'Software' | 'Biologicals' | 'sparcPartners'
+type ResourceType = 'Device' | 'Information Services' | 'Databases' | 'Software' | 'Biologicals' | 'sparcPartners'
 
 interface TabType {
   label: string,


### PR DESCRIPTION
# Description

The purpose of this PR is to add Databases and Information Services category for Resources.

## Type of change

- [x] New feature (non-breaking change which adds functionality)

# How Has This Been Tested?

- Go to the [Database](http://localhost:3000/resources?type=Databases) tab on the Resources page
- You should see the resources tagged Database
- Go to the [Information Services](http://localhost:3000/resources?type=Information%20Services) tab on the Resources page
- You should see the resources tagged Information Services

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added unit tests that prove my fix is effective or that my feature works
