### PR TITLE
feat(Resources): Add detail page

### DIFF
--- a/components/NewsEventsPage/NewsEventsPage.vue
+++ b/components/NewsEventsPage/NewsEventsPage.vue
@@ -1,10 +1,10 @@
 <template>
   <div>
-    <breadcrumb :breadcrumb="breadcrumb" />
+    <breadcrumb :breadcrumb="breadcrumb" :title="heroTitle" />
     <page-hero>
-      <h1>{{ page.fields.title }}</h1>
+      <h1>{{ heroTitle }}</h1>
       <p>
-        {{ page.fields.summary }}
+        {{ heroSummary }}
       </p>
     </page-hero>
     <div class="page-wrap container">
@@ -20,8 +20,8 @@
               <share-network
                 network="facebook"
                 :url="pageUrl"
-                :title="page.fields.title"
-                :description="page.fields.summary"
+                :title="heroTitle"
+                :description="heroSummary"
               >
                 <svg-icon name="icon-share-facebook" height="28" width="28" />
                 <span class="visuallyhidden">Share on Facebook</span>
@@ -30,7 +30,7 @@
                 network="twitter"
                 class="ml-8"
                 :url="pageUrl"
-                :title="page.fields.title"
+                :title="heroTitle"
               >
                 <svg-icon name="icon-share-twitter" height="28" width="28" />
                 <span class="visuallyhidden">Share on Twitter</span>
@@ -39,7 +39,7 @@
                 network="linkedin"
                 class="ml-8"
                 :url="pageUrl"
-                :title="page.fields.title"
+                :title="heroTitle"
               >
                 <svg-icon name="icon-share-linked" height="28" width="28" />
                 <span class="visuallyhidden">Share on Linkedin</span>
@@ -96,6 +96,14 @@ export default {
       default: ''
     },
     type: {
+      type: String,
+      default: ''
+    },
+    heroTitle: {
+      type: String,
+      default: ''
+    },
+    heroSummary: {
       type: String,
       default: ''
     },

--- a/components/Resources/ResourcesSearchResults.vue
+++ b/components/Resources/ResourcesSearchResults.vue
@@ -9,9 +9,14 @@
         <img v-show="data.fields.logo" :src="getBannerImage(data)" />
       </div>
       <div class="resources-search-results__items--content">
-        <a :href="data.fields.url" target="blank">
+        <router-link
+          :to="{
+            name: 'resources-resourceId',
+            params: { resourceId: data.sys.id }
+          }"
+        >
           <h2>{{ data.fields.name }}</h2>
-        </a>
+        </router-link>
 
         <p v-if="data.fields.developedBySparc" class="resource-category">
           SPARC

--- a/pages/news-and-events/events/_id.vue
+++ b/pages/news-and-events/events/_id.vue
@@ -3,6 +3,8 @@
     :page="page"
     :content="page.fields.description"
     :breadcrumb="breadcrumb"
+    :hero-title="page.fields.title"
+    :hero-summary="page.fields.summary"
     type="event"
   >
     <img :src="newsImage" :alt="newsImageAlt" />

--- a/pages/news-and-events/news/_id.vue
+++ b/pages/news-and-events/news/_id.vue
@@ -3,6 +3,8 @@
     :page="page"
     :content="page.fields.copy"
     :breadcrumb="breadcrumb"
+    :hero-title="page.fields.title"
+    :hero-summary="page.fields.summary"
     type="news"
   >
     <template v-if="newsImage">

--- a/pages/resources/_resourceId.vue
+++ b/pages/resources/_resourceId.vue
@@ -1,6 +1,36 @@
 <template>
   <div class="resources">
-    <page-hero>
+    <news-events-page
+      :page="resource"
+      :content="resource.fields.longDescription"
+      :breadcrumb="breadcrumb"
+      :hero-title="resource.fields.name"
+      :hero-summary="resource.fields.description"
+      type="news"
+    >
+      <template v-if="resourceLogoUrl">
+        <img :src="resourceLogoUrl" :alt="resourceLogoAlt" />
+        <hr />
+      </template>
+
+      <div class="mb-8">
+        <h3>Tool / Resource Name</h3>
+        <p class="mb-0">
+          {{ resource.fields.name }}
+        </p>
+        <span v-if="resource.fields.developedBySparc" class="resource-category">
+          SPARC
+        </span>
+      </div>
+      <h3>URL</h3>
+      <p>
+        <a :href="resource.fields.url" target="_blank">
+          {{ resource.fields.url }}
+        </a>
+      </p>
+    </news-events-page>
+
+    <!-- <page-hero>
       <h2>{{ resource.fields.name }}</h2>
     </page-hero>
     <div class="page-wrap container">
@@ -23,14 +53,15 @@
           </el-col>
         </el-row>
       </div>
-    </div>
+    </div> -->
   </div>
 </template>
 
 <script>
 import { pathOr } from 'ramda'
-import PageHero from '@/components/PageHero/PageHero.vue'
-import BfButton from '@/components/shared/BfButton/BfButton.vue'
+
+import NewsEventsPage from '@/components/NewsEventsPage/NewsEventsPage'
+
 import createClient from '@/plugins/contentful.js'
 
 const client = createClient()
@@ -39,8 +70,7 @@ export default {
   name: 'Resources',
 
   components: {
-    BfButton,
-    PageHero
+    NewsEventsPage
   },
 
   asyncData(ctx) {
@@ -55,7 +85,21 @@ export default {
 
   data() {
     return {
-      resource: {}
+      resource: {},
+      breadcrumb: [
+        {
+          label: 'Home',
+          to: {
+            name: 'index'
+          }
+        },
+        {
+          label: 'Tools & Resources',
+          to: {
+            name: 'resources'
+          }
+        }
+      ]
     }
   },
 
@@ -65,7 +109,11 @@ export default {
      * @returns {String}
      */
     resourceLogoUrl: function() {
-      return pathOr('', ['fields', 'logo', 'fields', 'file', 'url'], this.resource)
+      return pathOr(
+        '',
+        ['fields', 'logo', 'fields', 'file', 'url'],
+        this.resource
+      )
     },
     /**
      * Compute the alt tag for the resource's logo
@@ -78,4 +126,19 @@ export default {
 }
 </script>
 
-<style lang="scss" scoped></style>
+<style lang="scss" scoped>
+@import '../../assets/_variables.scss';
+
+.resource-category {
+  background: $median;
+  border-radius: 15px;
+  color: #fff;
+  display: block;
+  font-size: 0.875rem;
+  top: 10px;
+  padding: 0 0.65rem;
+  right: 14px;
+  width: fit-content;
+  margin-bottom: 10px;
+}
+</style>


### PR DESCRIPTION
# Description

The purpose of this PR is to add a detail page for resources

## Type of change

- [x] New feature (non-breaking change which adds functionality)

# How Has This Been Tested?

- Go to the tools and resources page
- Click on a name of a resource to be taken to its detail page
- For a more complete page, visit [Blackfynn Data Management Platform](http://localhost:3000/resources/56y6lcUnJGdIUbo2btPzxk)
- Visit an [event page](http://localhost:3000/news-and-events/events/5i2AUXJ0JU57vDgaVpCqcz) to verify everything still works
- Visit a [news page](http://localhost:3000/news-and-events/news/1IAtotegXUlp6JziLsULtn) to verify everything still works

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added unit tests that prove my fix is effective or that my feature works
