### PR TITLE
Add associated publication in the "About" tab of a dataset

### DIFF
--- a/components/DatasetDetails/DatasetAboutInfo.vue
+++ b/components/DatasetDetails/DatasetAboutInfo.vue
@@ -20,14 +20,16 @@
       </p>
       <h3>NIH Award</h3>
       <p>{{ getSparcAwardNumber }}</p>
-      <h3>Associated Publication{{s}}</h3>
-      <p>
-        <external-pub-link 
-          v-for="(pub, i) in externalPublications"
-          :key="i"
-          :publication="externalPublications[i]"
-        />
-      </p>
+      <template v-if="externalPublications.length">
+        <h3>Associated Publication{{s}}</h3>
+        <p>
+          <external-pub-link 
+            v-for="(pub, i) in externalPublications"
+            :key="i"
+            :publication="externalPublications[i]"
+          />
+        </p>
+      </template>
       <h3>Tags</h3>
       <div v-if="datasetTags.length !== 0">
         <tag-list :tags="datasetTags" />

--- a/components/DatasetDetails/DatasetAboutInfo.vue
+++ b/components/DatasetDetails/DatasetAboutInfo.vue
@@ -20,6 +20,14 @@
       </p>
       <h3>NIH Award</h3>
       <p>{{ getSparcAwardNumber }}</p>
+      <h3>Associated Publication{{s}}</h3>
+      <p>
+        <external-pub-link 
+          v-for="(pub, i) in externalPublications"
+          :key="i"
+          :publication="externalPublications[i]"
+        />
+      </p>
       <h3>Tags</h3>
       <div v-if="datasetTags.length !== 0">
         <tag-list :tags="datasetTags" />
@@ -47,6 +55,7 @@
 import { compose, propOr, head } from 'ramda'
 
 import ExternalPublicationListItem from '@/components/ExternalPublicationListItem/ExternalPublicationListItem.vue'
+import ExternalPubLink from '@/components/ExternalPubLink/ExternalPubLink'
 import TagList from '@/components/TagList/TagList.vue'
 
 export default {
@@ -54,6 +63,7 @@ export default {
 
   components: {
     ExternalPublicationListItem,
+    ExternalPubLink,
     TagList
   },
   props: {
@@ -109,6 +119,9 @@ export default {
      */
     getRecordsUrl: function() {
       return `${process.env.discover_api_host}/search/records?datasetId=${this.$route.params.datasetId}`
+    },
+    s: function(){
+      return (this.externalPublications.length > 0) ? 's' : ''
     }
   },
 

--- a/components/ExternalPubLink/ExternalPubLink.vue
+++ b/components/ExternalPubLink/ExternalPubLink.vue
@@ -1,0 +1,61 @@
+<template>
+  <div class="external-publication-list-item">
+    <a
+      class="dataset-about-info__container--doi-link mb-16"
+      :href="linkFromDoi(publication.doi)"
+      target="_blank"
+    >
+      {{ title }}
+    </a>
+  </div>
+</template>
+
+<script>
+export default {
+  name: 'ExternalPublicationListItem',
+
+  props: {
+    publication: {
+      type: Object,
+      default: () => {
+        return {
+          doi: ''
+        }
+      }
+    }
+  },
+
+  data() {
+    return {
+      title: ''
+    }
+  },
+
+  mounted() {
+    this.getTitle()
+  },
+
+  methods: {
+    /**
+     * Get the DOI from doi.org
+     */
+    async getTitle() {
+      fetch(this.linkFromDoi(this.publication.doi), {
+        method: 'GET',
+        headers: { Accept: 'application/json'}
+      })
+        .then(response => response.json())
+        .then(json => {
+          this.title = json.title
+        })
+    },
+
+    linkFromDoi(doi){
+      return `https://doi.org/${doi}`
+    }
+  }
+}
+</script>
+
+<style lang="scss" scoped>
+</style>


### PR DESCRIPTION
# Description

**Add associated publication in the "About" tab of a dataset**
[Wrike ticket](https://www.wrike.com/open.htm?id=458765161)

![image](https://user-images.githubusercontent.com/37255664/115181862-ef476a80-a12c-11eb-875d-dae8ba9d11a8.png)



## Type of change

Delete those that don't apply.

- [x] New feature (non-breaking change which adds functionality)

# How Has This Been Tested?

Checked datasets with 0,1 and 2 external publications locally and on a heroku instance:

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added unit tests that prove my fix is effective or that my feature works
