### PR TITLE
Add support for Contentful "requires details page"

### DIFF
--- a/components/Resources/ResourcesSearchResults.vue
+++ b/components/Resources/ResourcesSearchResults.vue
@@ -10,6 +10,7 @@
       </div>
       <div class="resources-search-results__items--content">
         <router-link
+          v-if="data.fields.requiresDetailsPage"
           :to="{
             name: 'resources-resourceId',
             params: { resourceId: data.sys.id }
@@ -17,7 +18,9 @@
         >
           <h2>{{ data.fields.name }}</h2>
         </router-link>
-
+        <a v-else :href="data.fields.url" target="blank">
+          <h2>{{ data.fields.name }}</h2>
+        </a>
         <p v-if="data.fields.developedBySparc" class="resource-category">
           SPARC
         </p>


### PR DESCRIPTION
# Description

The purpose of this PR is to add support for the "requires details page" from Contentful.

## Type of change

- [x] New feature (non-breaking change which adds functionality)

# How Has This Been Tested?

- Go to the [tools and resources page](http://localhost:3000/resources?type=sparcPartners)
- Clicking on all but "Blackfynn Data Management Platform" names should take you to their external site
- Clicking on "Blackfynn Data Management Platform" should take you to its details page

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added unit tests that prove my fix is effective or that my feature works
