### PR TITLE
Fix issue with dataset filters and pagination

### DIFF
--- a/components/SparcPill/SparcPill.vue
+++ b/components/SparcPill/SparcPill.vue
@@ -21,6 +21,5 @@ export default {
   overflow: hidden;
   padding: 0 0.65rem;
   text-overflow: ellipsis;
-  // width: fit-content;
 }
 </style>

--- a/components/SparcPill/SparcPill.vue
+++ b/components/SparcPill/SparcPill.vue
@@ -21,6 +21,6 @@ export default {
   overflow: hidden;
   padding: 0 0.65rem;
   text-overflow: ellipsis;
-  width: fit-content;
+  // width: fit-content;
 }
 </style>

--- a/pages/data/index.vue
+++ b/pages/data/index.vue
@@ -280,10 +280,7 @@ export default {
     blackfynnApiUrl: function() {
       const searchType = pathOr('', ['query', 'type'], this.$route)
 
-      const embargoed = shouldGetEmbargoed(
-        searchType,
-        this.$route.query.datasetFilters
-      )
+      const embargoed = shouldGetEmbargoed(searchType, this.datasetFilters)
 
       let url = `${process.env.discover_api_host}/search/${
         searchType === 'simulation' ? 'dataset' : searchType
@@ -430,15 +427,6 @@ export default {
         }
       },
       immediate: true
-    },
-
-    '$route.query.datasetFilters': function() {
-      /**
-       * Clear table data so the new table that is rendered can
-       * properly render data and account for any missing data
-       */
-      this.searchData = clone(searchData)
-      this.fetchResults()
     }
   },
 
@@ -466,10 +454,13 @@ export default {
       }
 
       this.searchData = { ...this.searchData, ...queryParams }
-      console.log('mounted', this.$route.query.datasetFilters)
-      this.datasetFilters = Array.isArray(this.$route.query.datasetFilters)
-        ? this.$route.query.datasetFilters
-        : [this.$route.query.datasetFilters]
+
+      if (this.$route.query.datasetFilters) {
+        this.datasetFilters = Array.isArray(this.$route.query.datasetFilters)
+          ? this.$route.query.datasetFilters
+          : [this.$route.query.datasetFilters]
+      }
+
       this.fetchResults()
     }
     if (window.innerWidth <= 768) this.titleColumnWidth = 150
@@ -824,8 +815,21 @@ export default {
      */
     setDatasetFilter() {
       this.$router.replace({
-        query: { ...this.$route.query, datasetFilters: this.datasetFilters }
+        query: {
+          type: 'dataset',
+          q: this.$route.query.q,
+          datasetFilters: this.datasetFilters,
+          skip: 0,
+          limit: 10
+        }
       })
+
+      /**
+       * Clear table data so the new table that is rendered can
+       * properly render data and account for any missing data
+       */
+      this.searchData = clone(searchData)
+      this.fetchResults()
     }
   }
 }


### PR DESCRIPTION
# Description
The purpose of this PR is to an issue with find data search with dataset filters (embargo) where pagination always showed first page results. In addition, it fixes an issue with the "Embargoed" pill on Safari.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

- Go to the [dataset search page](http://localhost:3000/data?type=dataset)
- Go to page 2, and you should see page 2 results
- Check the "Embargo" status on the left
- You should be taken back to page 1
- Uncheck "Public"
- You should only see Embargoed datasets
- The "Embargoed" pill over a dataset's image should not be truncated on Safari
- Check "Public"
- You should see all datasets
- Click on page 4
- You should see page 4
- Refresh the browser
- You should see page 4 results for all datasets

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added unit tests that prove my fix is effective or that my feature works
