### PR TITLE
Switch videos to using the '/download' api endpoint

### DIFF
--- a/components/ImagesGallery/ImagesGallery.vue
+++ b/components/ImagesGallery/ImagesGallery.vue
@@ -327,7 +327,8 @@ export default {
         this.thumbnails.push({
           id: this.datasetId,
           img: this.defaultVideoImg,
-          file_path: this.datasetVideos[i].file_path
+          file_path: this.datasetVideos[i].file_path,
+          presigned_url: this.datasetVideos[i].presigned_url
         })
       }
     },
@@ -411,7 +412,8 @@ export default {
           query = {
             dataset_version: this.datasetVersion,
             dataset_id: this.datasetId,
-            file_path: imageInfo.file_path
+            file_path: imageInfo.file_path,
+            presigned_url: imageInfo.presigned_url
           }
           break
         default:

--- a/pages/datasets/_datasetId.vue
+++ b/pages/datasets/_datasetId.vue
@@ -388,6 +388,16 @@ const getImagesData = async (datasetId, datasetDetails, $axios) => {
     // ImageGallery.vue to start making scicrunch calls
     let videoData = Videos[datasetId]
     if (videoData) {
+      let cors = ''
+      // let cors = 'https://cors-anywhere.herokuapp.com/'
+      let presigned_url = await $axios.$get(
+        process.env.portal_api +
+          '/download?' +
+          new URLSearchParams({
+            key: videoData.file_path
+          })
+      )
+      videoData.presigned_url = cors + presigned_url
       videoData = [videoData]
     }
 

--- a/pages/datasets/videoviewer/_id.vue
+++ b/pages/datasets/videoviewer/_id.vue
@@ -36,7 +36,7 @@
         <client-only placeholder="Loading video ...">
           <div class="video-container">
             <video ref="vid" class="video" controls crossorigin playsinline>
-              <source :src="video_src" type="video/mp4" size="1080" />
+              <source :src="videoSrc" type="video/mp4" size="1080" />
             </video>
           </div>
         </client-only>
@@ -96,8 +96,8 @@ export default {
       return this.$route.query.dataset_version
     },
 
-    video_src: function() {
-      return `${process.env.portal_api}/s3-resource/${this.$route.query.file_path}`
+    videoSrc: function() {
+      return this.$route.query.presigned_url
     }
   },
   mounted() {


### PR DESCRIPTION
# Description

Videos moved to the '/download' endpoint to allow downloading of videos bigger than 20MB

***Note* This requires sparc.science to be whitelisted on s3**

See:
[Presigned URL is to resources that are not cross origin #41](https://github.com/nih-sparc/sparc-api/issues/41)


## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] Breaking change

# How Has This Been Tested?

Run locally using cors-anywhere

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added unit tests that prove my fix is effective or that my feature works
