### PR TITLE
Make event images links

### DIFF
--- a/components/EventCard/EventCard.vue
+++ b/components/EventCard/EventCard.vue
@@ -1,7 +1,24 @@
 <template>
   <div class="upcoming-event">
     <div class="upcoming-event__image">
-      <img :src="eventImage(event)" :alt="eventAlt(event)" />
+      <nuxt-link
+        v-if="event.fields.requiresADetailsPage"
+        :to="{
+          name: 'news-and-events-events-id',
+          params: { id: event.sys.id }
+        }"
+      >
+        <img :src="eventImage(event)" :alt="eventAlt(event)" />
+      </nuxt-link>
+      <template v-else>
+        <a v-if="event.fields.url" :href="event.fields.url" target="_blank">
+          <img :src="eventImage(event)" :alt="eventAlt(event)" />
+        </a>
+        <div v-else>
+          <img :src="eventImage(event)" :alt="eventAlt(event)" />
+        </div>
+      </template>
+
       <span>{{ event.fields.eventType }}</span>
     </div>
     <h3>

--- a/components/FeaturedEvent/FeaturedEvent.vue
+++ b/components/FeaturedEvent/FeaturedEvent.vue
@@ -1,5 +1,37 @@
 <template>
-  <sparc-card :image="imageSrc" :image-alt="imageAlt">
+  <sparc-card>
+    <template slot="image">
+      <nuxt-link
+        v-if="event.fields.requiresADetailsPage"
+        :to="{
+          name: 'news-and-events-events-id',
+          params: { id: event.sys.id }
+        }"
+        class="sparc-card__image"
+        :style="`background-image: url(${imageSrc})`"
+      >
+        <img class="visuallyhidden" :src="imageSrc" :alt="imageAlt" />
+      </nuxt-link>
+      <template v-else>
+        <a
+          v-if="event.fields.url"
+          :href="event.fields.url"
+          target="_blank"
+          class="sparc-card__image"
+          :style="`background-image: url(${imageSrc})`"
+        >
+          <img class="visuallyhidden" :src="imageSrc" :alt="imageAlt" />
+        </a>
+        <div
+          v-else
+          class="sparc-card__image"
+          :style="`background-image: url(${imageSrc})`"
+        >
+          <img class="visuallyhidden" :src="imageSrc" :alt="imageAlt" />
+        </div>
+      </template>
+    </template>
+
     <div>
       <h3>
         <nuxt-link

--- a/components/HomepageNews/HomepageNews.vue
+++ b/components/HomepageNews/HomepageNews.vue
@@ -9,10 +9,51 @@
       <sparc-card
         v-for="(item, idx) in upcomingNews"
         :key="item.sys.id"
-        :image="getImageSrc(item)"
-        :image-alt="getImageAlt(item)"
         :image-align="idx % 2 ? 'right' : ''"
       >
+        <template slot="image">
+          <nuxt-link
+            v-if="item.fields.requiresADetailsPage"
+            :to="{
+              name: 'news-and-events-events-id',
+              params: { id: item.sys.id }
+            }"
+            class="sparc-card__image"
+            :style="`background-image: url(${getImageSrc(item)})`"
+          >
+            <img
+              class="visuallyhidden"
+              :src="getImageSrc(item)"
+              :alt="getImageAlt(item)"
+            />
+          </nuxt-link>
+          <template v-else>
+            <a
+              v-if="item.fields.url"
+              :href="item.fields.url"
+              target="_blank"
+              class="sparc-card__image"
+              :style="`background-image: url(${getImageSrc(item)})`"
+            >
+              <img
+                class="visuallyhidden"
+                :src="getImageSrc(item)"
+                :alt="getImageAlt(item)"
+              />
+            </a>
+            <div
+              v-else
+              class="sparc-card__image"
+              :style="`background-image: url(${getImageSrc(item)})`"
+            >
+              <img
+                class="visuallyhidden"
+                :src="getImageSrc(item)"
+                :alt="getImageAlt(item)"
+              />
+            </div>
+          </template>
+        </template>
         <div>
           <h3>
             <nuxt-link

--- a/components/SparcCard/SparcCard.vue
+++ b/components/SparcCard/SparcCard.vue
@@ -3,9 +3,14 @@
     class="sparc-card"
     :class="{ 'sparc-card--image-right': imageAlign === 'right' }"
   >
-    <div class="sparc-card__image" :style="`background-image: url(${image})`">
+    <div
+      v-if="!$slots.image"
+      class="sparc-card__image"
+      :style="`background-image: url(${image})`"
+    >
       <img class="visuallyhidden" :src="image" :alt="imageAlt" />
     </div>
+    <slot name="image" class="sparc-card__image" />
 
     <div class="sparc-card__content-wrap">
       <div class="sparc-card__content-wrap__content">

--- a/pages/news-and-events/news/_id.vue
+++ b/pages/news-and-events/news/_id.vue
@@ -98,7 +98,9 @@ export default {
      * @returns {String}
      */
     publishedDate: function() {
-      return this.formatDate(this.page.fields.publishedDate)
+      return this.page.fields.publishedDate
+        ? this.formatDate(this.page.fields.publishedDate)
+        : ''
     }
   }
 }


### PR DESCRIPTION
# Description

The purpose of this PR is to make event images links.

## Type of change

- [x] New feature (non-breaking change which adds functionality)

# How Has This Been Tested?

- Go to the homepage and scroll down to the News and Upcoming Events section
- The images should link to the same link as the title of the item (internal or external, depending on the entry)
- Go to the News and Events page
- The featured event's image should link to the same link as the title of the item
- The two upcoming and two past event's image should link to the same link as the title of the item
- Click on "Show all events" to go to the events landing page
- The images should link to the same link as the title of the item (internal or external, depending on the entry)

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas

