### PR TITLE
Fix homepage news image link

### DIFF
--- a/components/HomepageNews/HomepageNews.vue
+++ b/components/HomepageNews/HomepageNews.vue
@@ -14,10 +14,7 @@
         <template slot="image">
           <nuxt-link
             v-if="item.fields.requiresADetailsPage"
-            :to="{
-              name: 'news-and-events-events-id',
-              params: { id: item.sys.id }
-            }"
+            :to="nuxtLink(item)"
             class="sparc-card__image"
             :style="`background-image: url(${getImageSrc(item)})`"
           >


### PR DESCRIPTION
# Description
The purpose of this PR is to Fix homepage news image link. Previously, this link wasn't using the `nuxtLink()` which computes the link based on the entry type.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

You will need to update your `CTF_CDA_ACCESS_TOKEN` environment variable if you haven't yet already. This can be found on Heroku.

- Go to the homepage
- Scroll down to the "Request for project proposals for the 2021 SPARC FAIR Codeathon" event
- Click on its image
- You should be taken to that event's detail page

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added unit tests that prove my fix is effective or that my feature works
