### PR TITLE
Notify user when share link button on News and Events page is pressed.

### DIFF
--- a/components/NewsEventsPage/NewsEventsPage.vue
+++ b/components/NewsEventsPage/NewsEventsPage.vue
@@ -45,7 +45,7 @@
                 <span class="visuallyhidden">Share on Linkedin</span>
               </share-network>
               <button
-                v-clipboard:copy="pageUrl"
+                @click="copyLink"
                 class="ml-8 btn-copy-permalink"
               >
                 <svg-icon name="icon-permalink" height="28" width="28" />
@@ -68,7 +68,7 @@
 
 <script>
 import { pathEq } from 'ramda'
-
+import { successMessage, failMessage } from '@/utils/notification-messages'
 import MarkedMixin from '@/mixins/marked'
 import FormatDate from '@/mixins/format-date'
 import Breadcrumb from '@/components/Breadcrumb/Breadcrumb'
@@ -83,6 +83,17 @@ export default {
   },
 
   mixins: [FormatDate, MarkedMixin],
+
+  methods: {
+    copyLink: function() {
+      this.$copyText(`${process.env.ROOT_URL}${this.$route.fullPath}`).then(
+        () => {
+          this.$message(successMessage('Share link copied to clipboard.'))
+      }, () => {
+          this.$message(failMessage('Failed to copy share link.'))
+      });
+    },
+  },
 
   props: {
     page: {
@@ -122,14 +133,6 @@ export default {
      */
     htmlContent() {
       return this.content || ''
-    },
-
-    /**
-     * Compute the full URL of the page
-     * @returns {String}
-     */
-    pageUrl: function() {
-      return `${process.env.ROOT_URL}${this.$route.fullPath}`
     },
 
     /**


### PR DESCRIPTION
# Description

Display message after clicking on "Share link" icon on the News and Events page. This is the same pop up used on the dataset page after clicking on the "Copy citation".

Ticket can be found [here](https://www.wrike.com/open.htm?id=681288214).

## Type of change

Delete those that don't apply.

- [x] New feature (non-breaking change which adds functionality)


# How Has This Been Tested?
Manually tested and can be tested [here](https://alan-wu-sparc-app.herokuapp.com/news-and-events/events/460HOij0sXC0MDUzJ0c899).


# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas

