### PR TITLE
fix total nr resources

### DIFF
--- a/pages/resources/index.vue
+++ b/pages/resources/index.vue
@@ -166,11 +166,7 @@ export default Vue.extend<Data, Methods, Computed, never>({
      * @returns {Number}
      */
     currentResourceCount: function() {
-      return this.resourceData.limit > this.resourceData.total
-        ? this.resourceData.total
-        : this.resourceData.skip !== 0
-        ? this.resourceData.total - this.resourceData.limit
-        : this.resourceData.limit
+      return this.resourceData.total
     },
 
     /**
@@ -274,6 +270,7 @@ export default Vue.extend<Data, Methods, Computed, never>({
      */
     setActiveTab: function(tab) {
       this.activeTab = tab
+      this.resourceData.skip = 0
       this.$router.push({
         name: 'resources',
         query: {


### PR DESCRIPTION
# Description

1) Always show total number of resources indicator
2) Reset pagination when switching tabs


## Type of change

Delete those that don't apply.

- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

Deployed locally
1) Go to resources page and selected multiple pages. Verfiy that indicator always shows total nr results
2) Switch tabs from various pages and verify that first page of results is shown.


# Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added unit tests that prove my fix is effective or that my feature works
