### PR TITLE
Faceted browse UI v785th search results UI

### DIFF
--- a/components/SearchResults/DatasetSearchResults.vue
+++ b/components/SearchResults/DatasetSearchResults.vue
@@ -3,6 +3,7 @@
     :data="tableData"
     :show-header="false"
     empty-text="No Results"
+    @sort-change="onSortChange"
   >
     <el-table-column prop="banner" label="Image" width="160">
       <template slot-scope="scope">
@@ -29,8 +30,9 @@
       </template>
     </el-table-column>
     <el-table-column
-    sortable="custom"
       min-width="400"
+      sortable="custom"
+      :sort-orders="sortOrders"
     >
       <template slot-scope="scope">
         <nuxt-link
@@ -68,6 +70,7 @@
 import SparcPill from '@/components/SparcPill/SparcPill.vue'
 import FormatDate from '@/mixins/format-date'
 import StorageMetrics from '@/mixins/bf-storage-metrics'
+import { onSortChange } from '@/pages/data/utils'
 import { pathOr } from 'ramda'
 
 export default {
@@ -105,6 +108,12 @@ export default {
     areSimulationResults: function() {
       const searchType = pathOr('', ['query', 'type'], this.$route)
       return searchType === 'simulation'
+    }
+  },
+
+  methods: {
+    onSortChange: function(payload) {
+      onSortChange(this, payload)
     }
   }
 }

--- a/components/SearchResults/DatasetSearchResults.vue
+++ b/components/SearchResults/DatasetSearchResults.vue
@@ -50,14 +50,21 @@
           {{ scope.row.description }}
         </div>
         <table class="property-table">
-          <tr v-for="(property, index) in PROPERTY_DATA" :key=index>
+          <tr v-for="(property, index) in PROPERTY_DATA" :key="index">
             <td class="property-name-column">
-              {{property.displayName}}
+              {{ property.displayName }}
             </td>
             <td>
-              {{`${property.propName === "createdAt" ? 
-                  formatDate(scope.row[`${property.propName}`]) + " (Last updated " + formatDate(scope.row.updatedAt) + ")" :  
-                  scope.row[`${property.propName}`]}`}}
+              {{
+                `${
+                  property.propName === 'createdAt'
+                    ? formatDate(scope.row[`${property.propName}`]) +
+                      ' (Last updated ' +
+                      formatDate(scope.row.updatedAt) +
+                      ')'
+                    : scope.row[`${property.propName}`]
+                }`
+              }}
             </td>
           </tr>
         </table>
@@ -84,20 +91,19 @@ export default {
     tableData: {
       type: Array,
       default: () => []
-    },
+    }
   },
 
   data() {
     return {
-      sortOrders: ['ascending', 'descending']
+      sortOrders: ['ascending', 'descending'],
+      PROPERTY_DATA: [
+        {
+          displayName: 'Publication Date',
+          propName: 'createdAt'
+        }
+      ]
     }
-  },
-
-  created() {
-    this.PROPERTY_DATA = [{
-        displayName: 'Publication Date',
-        propName: "createdAt",
-      }]
   },
 
   computed: {
@@ -138,18 +144,18 @@ export default {
 }
 .property-table {
   td {
-    padding: .25rem 0 0 0;
+    padding: 0.25rem 0 0 0;
     border: none;
   }
   border: none;
   padding: 0;
 }
- // The outermost bottom border of the table. Element UI adds psuedo elements to create the bottom table border that we must hide to remove
-table:not([class^=el-table__])::before {
+// The outermost bottom border of the table. Element UI adds psuedo elements to create the bottom table border that we must hide to remove
+table:not([class^='el-table__'])::before {
   display: none;
 }
 .property-name-column {
   width: 160px;
-  font-weight: 500;
+  font-weight: bold;
 }
 </style>

--- a/components/SearchResults/DatasetSearchResults.vue
+++ b/components/SearchResults/DatasetSearchResults.vue
@@ -29,7 +29,7 @@
       </template>
     </el-table-column>
     <el-table-column
-      sortable="custom"
+    sortable="custom"
       min-width="400"
     >
       <template slot-scope="scope">
@@ -47,6 +47,18 @@
         <div class="mt-8 mb-8">
           {{ scope.row.description }}
         </div>
+        <table class="property-table">
+          <tr v-for="(property, index) in PROPERTY_DATA" :key=index>
+            <td class="property-name-column">
+              {{property.displayName}}
+            </td>
+            <td>
+              {{`${property.propName === "createdAt" ? 
+                  formatDate(scope.row[`${property.propName}`]) + " (Last updated " + formatDate(scope.row.updatedAt) + ")" :  
+                  scope.row[`${property.propName}`]}`}}
+            </td>
+          </tr>
+        </table>
       </template>
     </el-table-column>
   </el-table>
@@ -78,6 +90,13 @@ export default {
     }
   },
 
+  created() {
+    this.PROPERTY_DATA = [{
+        displayName: 'Publication Date',
+        propName: "createdAt",
+      }]
+  },
+
   computed: {
     /**
      * Compute if the search results are for simulations
@@ -107,5 +126,21 @@ export default {
   img {
     display: block;
   }
+}
+.property-table {
+  td {
+    padding: .25rem 0 0 0;
+    border: none;
+  }
+  border: none;
+  padding: 0;
+}
+ // The outermost bottom border of the table. Element UI adds psuedo elements to create the bottom table border that we must hide to remove
+table:not([class^=el-table__])::before {
+  display: none;
+}
+.property-name-column {
+  width: 160px;
+  font-weight: 500;
 }
 </style>

--- a/components/SearchResults/DatasetSearchResults.vue
+++ b/components/SearchResults/DatasetSearchResults.vue
@@ -1,31 +1,9 @@
 <template>
   <el-table
     :data="tableData"
+    :show-header="false"
     empty-text="No Results"
-    @sort-change="onSortChange"
   >
-    <el-table-column
-      :fixed="true"
-      sortable="custom"
-      prop="name"
-      label="Title"
-      :sort-orders="sortOrders"
-      :width="titleColumnWidth"
-    >
-      <template slot-scope="scope">
-        <nuxt-link
-          :to="{
-            name: 'datasets-datasetId',
-            params: { datasetId: scope.row.id },
-            query: {
-              type: $route.query.type
-            }
-          }"
-        >
-          {{ scope.row.name }}
-        </nuxt-link>
-      </template>
-    </el-table-column>
     <el-table-column prop="banner" label="Image" width="160">
       <template slot-scope="scope">
         <nuxt-link
@@ -51,31 +29,24 @@
       </template>
     </el-table-column>
     <el-table-column
-      prop="description"
-      label="Description"
-      :width="areSimulationResults ? 550 : 400"
-    />
-    <el-table-column
-      prop="createdAt"
-      label="Last Published"
-      width="200"
       sortable="custom"
-      :sort-orders="sortOrders"
+      min-width="400"
     >
       <template slot-scope="scope">
-        {{ formatDate(scope.row.createdAt) }}
-      </template>
-    </el-table-column>
-    <el-table-column
-      v-if="!areSimulationResults"
-      prop="size"
-      label="Size"
-      width="150"
-      sortable="custom"
-      :sort-orders="sortOrders"
-    >
-      <template slot-scope="scope">
-        {{ formatMetric(scope.row.size) }}
+        <nuxt-link
+          :to="{
+            name: 'datasets-datasetId',
+            params: { datasetId: scope.row.id },
+            query: {
+              type: $route.query.type
+            }
+          }"
+        >
+          {{ scope.row.name }}
+        </nuxt-link>
+        <div class="mt-8 mb-8">
+          {{ scope.row.description }}
+        </div>
       </template>
     </el-table-column>
   </el-table>
@@ -85,7 +56,6 @@
 import SparcPill from '@/components/SparcPill/SparcPill.vue'
 import FormatDate from '@/mixins/format-date'
 import StorageMetrics from '@/mixins/bf-storage-metrics'
-import { onSortChange } from '@/pages/data/utils'
 import { pathOr } from 'ramda'
 
 export default {
@@ -100,10 +70,6 @@ export default {
       type: Array,
       default: () => []
     },
-    titleColumnWidth: {
-      type: Number,
-      default: () => 300
-    }
   },
 
   data() {
@@ -120,12 +86,6 @@ export default {
     areSimulationResults: function() {
       const searchType = pathOr('', ['query', 'type'], this.$route)
       return searchType === 'simulation'
-    }
-  },
-
-  methods: {
-    onSortChange: function(payload) {
-      onSortChange(this, payload)
     }
   }
 }

--- a/pages/data/index.vue
+++ b/pages/data/index.vue
@@ -782,9 +782,9 @@ export default {
         .then(() => {
           this.fetchResults()
         })
-    },  
+    },
 
-/**
+    /**
      * Adjust the Title column width when
      * on smaller screens or mobile
      * @param {Number} width

--- a/pages/data/index.vue
+++ b/pages/data/index.vue
@@ -105,6 +105,7 @@
                   :is="searchResultsComponent"
                   :table-data="tableData"
                   :title-column-width="titleColumnWidth"
+                  @sort-change="handleSortChange"
                 />
               </div>
             </el-col>

--- a/pages/data/index.vue
+++ b/pages/data/index.vue
@@ -105,7 +105,6 @@
                   :is="searchResultsComponent"
                   :table-data="tableData"
                   :title-column-width="titleColumnWidth"
-                  @sort-change="handleSortChange"
                 />
               </div>
             </el-col>
@@ -782,9 +781,9 @@ export default {
         .then(() => {
           this.fetchResults()
         })
-    },
+    },  
 
-    /**
+/**
      * Adjust the Title column width when
      * on smaller screens or mobile
      * @param {Number} width
@@ -904,10 +903,8 @@ export default {
 }
 .page-wrap {
   padding-bottom: 1em;
-  padding-top: 1em;
   @media (min-width: 48em) {
     padding-bottom: 3em;
-    padding-top: 3em;
   }
 }
 .table-wrap {


### PR DESCRIPTION
# Description

Updated the dataset search results table view to match the wireframes for faceted browse, found here: https://app.abstract.com/share/ca9ac8ee-68b2-4422-b0d7-55a61c0bb403?collectionId=aac5183e-7ed8-469a-9d73-7e39036ce2ef&sha=deb221da2686562e2063344b84eaa2807aba5346

I tried to use an element ui table for displaying the list of properties but element ui makes it impossible to customize it how we wanted so I used an HTML table instead. 

I still have not updated the endpoint to point at algolia. That will be part of my next changeset. 

I created a constant array that maps what properties we want to display along with what the actual name of the property on the object is. I wasn't sure of a better way to do this. Feel free to suggest alternatives.

I left the sorting logic for the results table in, in case we want to keep sorting. However, it is still not accessible by the user bc the table header is now hidden 

## Type of change

- [ x] New feature (non-breaking change which adds functionality)

# How Has This Been Tested?

I ran the changes locally: Pull down the changes, 'run a yarn run dev', and then navigate to the Datasets tab


# Checklist:

- [x ] My code follows the style guidelines of this project
- [x ] I have performed a self-review of my own code
- [ x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added unit tests that prove my fix is effective or that my feature works
