### PR TITLE
Accessed Algolia Pennseive index

### DIFF
--- a/components/header/Header.vue
+++ b/components/header/Header.vue
@@ -114,7 +114,7 @@
               </div>
             </div>
           </div>
-          <div class="nav-main-container__search" v-if="shouldShowSearch">
+          <div v-if="shouldShowSearch" class="nav-main-container__search">
             <el-input
               v-model="searchQuery"
               type="text"

--- a/components/header/Header.vue
+++ b/components/header/Header.vue
@@ -114,7 +114,7 @@
               </div>
             </div>
           </div>
-          <div class="nav-main-container__search">
+          <div class="nav-main-container__search" v-if="shouldShowSearch">
             <el-input
               v-model="searchQuery"
               type="text"

--- a/nuxt.config.js
+++ b/nuxt.config.js
@@ -67,6 +67,8 @@ export default {
     CTF_SPACE_ID: process.env.CTF_SPACE_ID,
     CTF_CDA_ACCESS_TOKEN: process.env.CTF_CDA_ACCESS_TOKEN,
     CTF_API_HOST: process.env.CTF_API_HOST,
+    ALGOLIA_API_KEY: process.env.ALGOLIA_API_KEY,
+    ALGOLIA_APP_ID: process.env.ALGOLIA_APP_ID,
     BL_SERVER_URL: 'https://sparc.biolucida.net/api/v1/',
     BL_SHARE_LINK_PREFIX: 'https://sparc.biolucida.net/image?c=',
     ROOT_URL: process.env.ROOT_URL || 'http://localhost:3000',

--- a/nuxt.config.js
+++ b/nuxt.config.js
@@ -106,11 +106,11 @@ export default {
   /*
    ** Global CSS
    */
-    css: ['element-ui/lib/theme-chalk/index.css'],
+  css: ['element-ui/lib/theme-chalk/index.css'],
   /*
    ** Plugins to load before mounting the App
    */
-    plugins: ['@/plugins/bootstrap', '@/plugins/contentful'],
+  plugins: ['@/plugins/bootstrap', '@/plugins/contentful'],
   /*
    ** Nuxt.js dev-modules
    */

--- a/package.json
+++ b/package.json
@@ -24,6 +24,7 @@
     "@nuxtjs/axios": "^5.8.0",
     "@nuxtjs/google-analytics": "^2.2.3",
     "@nuxtjs/robots": "^2.4.2",
+    "algoliasearch": "^4.9.3",
     "babel-eslint": "^10.0.3",
     "contentful": "^7.10.0",
     "cookie-universal-nuxt": "^2.1.1",

--- a/pages/data/index.vue
+++ b/pages/data/index.vue
@@ -8,16 +8,18 @@
         </h3>
         <ul class="search-tabs">
           <li v-for="type in searchTypes" :key="type.label">
-            <nuxt-link class="search-tabs__button"
-                      :class="{ active: type.type === $route.query.type }"
-                      :to="{
-                          name: 'data',
-                          query: {
-                          type: type.type,
-                          q: $route.query.q
-                        }
-                      }">
-                  {{ type.label }}
+            <nuxt-link
+              class="search-tabs__button"
+              :class="{ active: type.type === $route.query.type }"
+              :to="{
+                name: 'data',
+                query: {
+                  type: type.type,
+                  q: $route.query.q
+                }
+              }"
+            >
+              {{ type.label }}
             </nuxt-link>
           </li>
         </ul>
@@ -26,10 +28,12 @@
         <h5>
           Search within category
         </h5>
-        <search-form v-model="searchQuery"
-                    :q="q"
-                    @search="submitSearch"
-                    @clear="clearSearch" />
+        <search-form
+          v-model="searchQuery"
+          :q="q"
+          @search="submitSearch"
+          @clear="clearSearch"
+        />
       </div>
     </div>
     <div class="page-wrap container">
@@ -153,7 +157,6 @@ import {
   find,
   filter,
   head,
-  map,
   mergeLeft,
   pathOr,
   propEq,
@@ -224,7 +227,7 @@ const getEmbargoedFilter = (searchType, datasetFilters) => {
   const filters = Array.isArray(datasetFilters)
     ? datasetFilters
     : [datasetFilters]
-  if (searchType !== 'dataset'){
+  if (searchType !== 'dataset') {
     return
   }
   if (filters.includes('Embargoed') && !filters.includes('Public')) {
@@ -233,7 +236,7 @@ const getEmbargoedFilter = (searchType, datasetFilters) => {
   if (!filters.includes('Embargoed') && filters.includes('Public')) {
     return 'embargo:false'
   }
-  return '';
+  return ''
 }
 
 import createClient from '@/plugins/contentful.js'
@@ -319,10 +322,6 @@ export default {
      * @returns {String}
      */
     searchHeading: function() {
-      const start = this.searchData.skip + 1
-      const pageRange = this.searchData.limit * this.curSearchPage
-      const end =
-        pageRange < this.searchData.total ? pageRange : this.searchData.total
       const query = pathOr('', ['query', 'q'], this.$route)
 
       const searchTypeLabel = compose(
@@ -512,27 +511,36 @@ export default {
       this.isLoadingSearch = true
 
       const searchType = pathOr('', ['query', 'type'], this.$route)
-      const embargoedFilter = getEmbargoedFilter(searchType, this.datasetFilters);
+      const embargoedFilter = getEmbargoedFilter(
+        searchType,
+        this.datasetFilters
+      )
       const query = this.$route.query.q
-      const organizationNameFilter = searchType === 'simulation'
-          ? "IT'IS Foundation"
-          : "SPARC Consortium";
+      const organizationNameFilter =
+        searchType === 'simulation' ? "IT'IS Foundation" : 'SPARC Consortium'
 
-      const filters = `${embargoedFilter === undefined || embargoedFilter.length === 0 ? '' : embargoedFilter + " AND "}organizationName:"${organizationNameFilter}"`
+      const filters = `${
+        embargoedFilter === undefined || embargoedFilter.length === 0
+          ? ''
+          : embargoedFilter + ' AND '
+      }organizationName:"${organizationNameFilter}"`
 
-      algoliaSearchIndex.search(query, {
-        hitsPerPage: this.searchData.limit,
-        page: this.curSearchPage - 1,
-        filters: filters,
-      }).then(response => {
+      algoliaSearchIndex
+        .search(query, {
+          hitsPerPage: this.searchData.limit,
+          page: this.curSearchPage - 1,
+          filters: filters
+        })
+        .then(response => {
           const searchData = {
             items: response.hits,
             total: response.nbHits
           }
           this.searchData = mergeLeft(searchData, this.searchData)
-        }).finally(() => {
+        })
+        .finally(() => {
           this.isLoadingSearch = false
-        });
+        })
     },
 
     /**
@@ -823,19 +831,19 @@ export default {
 }
 .search-tabs__container {
   margin-top: 2rem;
-  padding-top: .5rem;
+  padding-top: 0.5rem;
   background-color: white;
-  border: .1rem solid $purple-gray;
+  border: 0.1rem solid $purple-gray;
   h3 {
-    padding-left: .75rem;
+    padding-left: 0.75rem;
     font-weight: 600;
     font-size: 1.5rem;
   }
 }
 .search-bar__container {
   margin-top: 1em;
-  padding: .75rem;
-  border: .1rem solid $purple-gray;
+  padding: 0.75rem;
+  border: 0.1rem solid $purple-gray;
   background: white;
   h5 {
     line-height: 1rem;
@@ -849,7 +857,7 @@ export default {
   overflow: auto;
   margin: 0 0 0 0;
   padding: 0 0;
-  outline: .1rem solid $median;
+  outline: 0.1rem solid $median;
   li {
     width: 100%;
     text-align: center;
@@ -868,14 +876,16 @@ export default {
   padding: 0;
   text-decoration: none;
   text-transform: uppercase;
-  border-right: .1rem solid $median;
+  border-right: 0.1rem solid $median;
   line-height: 3.5rem;
   @media (min-width: 48em) {
     font-size: 1.25rem;
     font-weight: 600;
     text-transform: none;
   }
-  &:hover, &:focus, &.active {
+  &:hover,
+  &:focus,
+  &.active {
     color: white;
     background-color: $median;
     font-weight: 500;

--- a/plugins/algolia.js
+++ b/plugins/algolia.js
@@ -1,0 +1,7 @@
+import algoliasearch from 'algoliasearch';
+
+// export `createAlgoliaClient` to use it in page components
+export default function createAlgoliaClient() {
+  const client = algoliasearch(process.env.ALGOLIA_APP_ID, process.env.ALGOLIA_API_KEY);
+  return client
+}

--- a/plugins/algolia.js
+++ b/plugins/algolia.js
@@ -1,7 +1,10 @@
-import algoliasearch from 'algoliasearch';
+import algoliasearch from 'algoliasearch'
 
 // export `createAlgoliaClient` to use it in page components
 export default function createAlgoliaClient() {
-  const client = algoliasearch(process.env.ALGOLIA_APP_ID, process.env.ALGOLIA_API_KEY);
+  const client = algoliasearch(
+    process.env.ALGOLIA_APP_ID,
+    process.env.ALGOLIA_API_KEY
+  )
   return client
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -136,6 +136,110 @@
     svg-inline-loader "^0.8.2"
     vue "^2.6.11"
 
+"@algolia/cache-browser-local-storage@4.9.3":
+  version "4.9.3"
+  resolved "https://registry.yarnpkg.com/@algolia/cache-browser-local-storage/-/cache-browser-local-storage-4.9.3.tgz#44e6306a548a76c410b5f64a8a0a1b65f63183c9"
+  integrity sha512-t9yKMfPNxxEUk/PPbZtXj0GCttDk1pk0wV2eA5udIOgf+Wqb/77yH75zz1u8EmCBGPe+FWXjSVT/wS1tlQz7SA==
+  dependencies:
+    "@algolia/cache-common" "4.9.3"
+
+"@algolia/cache-common@4.9.3":
+  version "4.9.3"
+  resolved "https://registry.yarnpkg.com/@algolia/cache-common/-/cache-common-4.9.3.tgz#0b3ca07c9af108433b4d3423a03511c3d053fed5"
+  integrity sha512-4dvzz28ESs7lRHmpBIjlmRloD9oGeD90E2C0QWNQYuAYosSdXGwW7vw4vdGRdPoL32t6u6S+47Bk6Dhcbw2ftA==
+
+"@algolia/cache-in-memory@4.9.3":
+  version "4.9.3"
+  resolved "https://registry.yarnpkg.com/@algolia/cache-in-memory/-/cache-in-memory-4.9.3.tgz#0bae2ad1de6537ca28efaf5280051265903bfca5"
+  integrity sha512-e1eRpP/Ht9qmLw5Sp674N6Y0c59K0L2LBI71EBOlq1j+kVc+JxVO03he5g+nQ7JOwLijyJPrkbm3RvXb5CX0sA==
+  dependencies:
+    "@algolia/cache-common" "4.9.3"
+
+"@algolia/client-account@4.9.3":
+  version "4.9.3"
+  resolved "https://registry.yarnpkg.com/@algolia/client-account/-/client-account-4.9.3.tgz#af9bf3612d05e87aa36372da50a2f0a9265de201"
+  integrity sha512-mSF0jiAo/tWKf/Z7mqhz6ETltrl+L+Zt2xuM3W5y1UOZvj47fn2ZcMRce8MQ+dd54t9iA8qIa+0XGlCSQf9lxA==
+  dependencies:
+    "@algolia/client-common" "4.9.3"
+    "@algolia/client-search" "4.9.3"
+    "@algolia/transporter" "4.9.3"
+
+"@algolia/client-analytics@4.9.3":
+  version "4.9.3"
+  resolved "https://registry.yarnpkg.com/@algolia/client-analytics/-/client-analytics-4.9.3.tgz#cddb4a97d796291d91bd15735de008b2d80a0b1b"
+  integrity sha512-Z3EjegxsdTMRmOLoDBnCZJjdL3ZM4J/G7TMe2PIArdCJFWM4iDnO7/MvYasqpK0PPOCHRh0wS4yKG9rZOz6Vsw==
+  dependencies:
+    "@algolia/client-common" "4.9.3"
+    "@algolia/client-search" "4.9.3"
+    "@algolia/requester-common" "4.9.3"
+    "@algolia/transporter" "4.9.3"
+
+"@algolia/client-common@4.9.3":
+  version "4.9.3"
+  resolved "https://registry.yarnpkg.com/@algolia/client-common/-/client-common-4.9.3.tgz#167a6863b55ffe7788ab9ac98b1b6fd0078f79df"
+  integrity sha512-6GAfuNqMrBN3094H0DzvQyxJoKUkyQpEr5OiFhH8I3lihI1rTtjEUrNDTsVp6e9VsR2OCRpnL9EEDv2HcGe8cw==
+  dependencies:
+    "@algolia/requester-common" "4.9.3"
+    "@algolia/transporter" "4.9.3"
+
+"@algolia/client-recommendation@4.9.3":
+  version "4.9.3"
+  resolved "https://registry.yarnpkg.com/@algolia/client-recommendation/-/client-recommendation-4.9.3.tgz#e2031237b2904c9d9b946fc846c87a21ad67bc5a"
+  integrity sha512-r+MNluwnUTr1tgHWQ5BPRw0A0YJZp9sXjSVxPCY3a+N6BgLaX4E02+FA8VrqVs8uR7mMQSLaJHoeCKnmNPrk9w==
+  dependencies:
+    "@algolia/client-common" "4.9.3"
+    "@algolia/requester-common" "4.9.3"
+    "@algolia/transporter" "4.9.3"
+
+"@algolia/client-search@4.9.3":
+  version "4.9.3"
+  resolved "https://registry.yarnpkg.com/@algolia/client-search/-/client-search-4.9.3.tgz#6259645ad5a7e7388727343806bcf2d0cf3e343a"
+  integrity sha512-8C6woYf6bY4Fh9H9nKY5IDDeBPwQ3nZn9QMQdgUj9ffDU8UzPqSivtLER1A+I81p1j9h+aBADRifwzIYtSXOkA==
+  dependencies:
+    "@algolia/client-common" "4.9.3"
+    "@algolia/requester-common" "4.9.3"
+    "@algolia/transporter" "4.9.3"
+
+"@algolia/logger-common@4.9.3":
+  version "4.9.3"
+  resolved "https://registry.yarnpkg.com/@algolia/logger-common/-/logger-common-4.9.3.tgz#d9b976524313b11f11c6ec546e2ed451c7964a11"
+  integrity sha512-8hGQ5HQvjx2kr7GWOmpON1tcRX2+VHqVg4p+qJqCBsPFlXbAshUyRJkxuen20eem2EAA5Cmmo1fPy/jlqdMMHA==
+
+"@algolia/logger-console@4.9.3":
+  version "4.9.3"
+  resolved "https://registry.yarnpkg.com/@algolia/logger-console/-/logger-console-4.9.3.tgz#f690bf8d5262a82425da26b42a519d7ec6c3784a"
+  integrity sha512-7FGulrAjS/oCVRShKJw5qFuyHOZk/44jolEtNtXvO/tZRR8hPPiow16Vrd3ByRSIhghkC5zj6at4nQhoPK+KqA==
+  dependencies:
+    "@algolia/logger-common" "4.9.3"
+
+"@algolia/requester-browser-xhr@4.9.3":
+  version "4.9.3"
+  resolved "https://registry.yarnpkg.com/@algolia/requester-browser-xhr/-/requester-browser-xhr-4.9.3.tgz#1c0fd594e253b41786b3408ade9f63862fe0c577"
+  integrity sha512-hP4YgxcY1kol0d+joXpO4BJuXjgF+vy3eBPk8WCXvZucv8hl5Vqb4BLccDMck+sTqP4Tqglwh/KwVTQrpmi/wA==
+  dependencies:
+    "@algolia/requester-common" "4.9.3"
+
+"@algolia/requester-common@4.9.3":
+  version "4.9.3"
+  resolved "https://registry.yarnpkg.com/@algolia/requester-common/-/requester-common-4.9.3.tgz#58fb72ca3f4f7714d75287ff568000ee6c2afac6"
+  integrity sha512-AgUw1iA/JkanZC+dhkSLyeiVgBhaaM3bI20f3cokuuDdz4X6F+hzi0vEpUZrEuNfnMLbUg8gxq3Vcg1/L9+9MA==
+
+"@algolia/requester-node-http@4.9.3":
+  version "4.9.3"
+  resolved "https://registry.yarnpkg.com/@algolia/requester-node-http/-/requester-node-http-4.9.3.tgz#a2bf0e7048fe3b81c6b6b170f8f68a5789dadafe"
+  integrity sha512-+nz7rRnI9qNcdZjHpyAyvcDLAO9mGobqsAi0aicxMka/szU1HVUX6+pvSOiiOsD8ST3R13rJuufgHfWdDUysQg==
+  dependencies:
+    "@algolia/requester-common" "4.9.3"
+
+"@algolia/transporter@4.9.3":
+  version "4.9.3"
+  resolved "https://registry.yarnpkg.com/@algolia/transporter/-/transporter-4.9.3.tgz#5a0933d4e59acdf88712156b2ab6f1b46c0a7f88"
+  integrity sha512-oJ68VSSpmUyB9EByqoyx25wgcrO9fgXtjH+pOtKoKmCW+RfxHW5agltJoQ808N8uq/AvP5ugMkRLGL3xf4WdzQ==
+  dependencies:
+    "@algolia/cache-common" "4.9.3"
+    "@algolia/logger-common" "4.9.3"
+    "@algolia/requester-common" "4.9.3"
+
 "@babel/code-frame@^7.0.0", "@babel/code-frame@^7.10.4":
   version "7.10.4"
   resolved "https://registry.yarnpkg.com/@babel/code-frame/-/code-frame-7.10.4.tgz#168da1a36e90da68ae8d49c0f1b48c7c6249213a"
@@ -3522,6 +3626,26 @@ ajv@^6.1.0, ajv@^6.10.0, ajv@^6.10.2, ajv@^6.12.3, ajv@^6.12.4:
     fast-json-stable-stringify "^2.0.0"
     json-schema-traverse "^0.4.1"
     uri-js "^4.2.2"
+
+algoliasearch@^4.9.3:
+  version "4.9.3"
+  resolved "https://registry.yarnpkg.com/algoliasearch/-/algoliasearch-4.9.3.tgz#b22ef0ae0450304cdf5264369a29cefa71ea2b30"
+  integrity sha512-VLl9pYXhVB397xTW369sy13qw3m1hHzCfj9zSdeDDYVwTxHiiok/QvhPKAMIzjqyUoY07O8j+941UxYZjugsMQ==
+  dependencies:
+    "@algolia/cache-browser-local-storage" "4.9.3"
+    "@algolia/cache-common" "4.9.3"
+    "@algolia/cache-in-memory" "4.9.3"
+    "@algolia/client-account" "4.9.3"
+    "@algolia/client-analytics" "4.9.3"
+    "@algolia/client-common" "4.9.3"
+    "@algolia/client-recommendation" "4.9.3"
+    "@algolia/client-search" "4.9.3"
+    "@algolia/logger-common" "4.9.3"
+    "@algolia/logger-console" "4.9.3"
+    "@algolia/requester-browser-xhr" "4.9.3"
+    "@algolia/requester-common" "4.9.3"
+    "@algolia/requester-node-http" "4.9.3"
+    "@algolia/transporter" "4.9.3"
 
 almost-equal@^1.1.0:
   version "1.1.0"


### PR DESCRIPTION
# Description

Populated the datasets and simulations data from the algolia index, while maintaining filtering for embargoed and public datasets. Also hid second search bar. TODO: Reimplement sorting for the data based off date or title, add additional facets and properties metadata, and update the tabs to reflect the wireframes.

## Type of change

Delete those that don't apply.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

# How Has This Been Tested?

I ran the changes locally and verified functionality. Datasets and Simulations tabs should work the same as before as should the emargoed and public filters. Additionally, the second search bar should now be hidden

# Checklist:

- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my own code
- [X] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added unit tests that prove my fix is effective or that my feature works
