### PR TITLE
A few requested changes from gazelle

### DIFF
--- a/pages/news-and-events/community-spotlight/success-stories/_id.vue
+++ b/pages/news-and-events/community-spotlight/success-stories/_id.vue
@@ -239,12 +239,6 @@ export default {
           to: {
             name: 'news-and-events-community-spotlight'
           }
-        },
-        {
-          label: 'Success Stories',
-          to: {
-            name: 'news-and-events-community-spotlight-success-stories'
-          }
         }
       ]
     }

--- a/pages/news-and-events/community-spotlight/success-stories/_id.vue
+++ b/pages/news-and-events/community-spotlight/success-stories/_id.vue
@@ -45,7 +45,7 @@
                 Published Date
               </div>
               <div class="story-field">
-                {{ entry.publishDate }}
+                {{ formatDate(entry.publishDate) }}
               </div>
               <br />
             </template>
@@ -133,10 +133,10 @@
       <nuxt-link
         class="community-link mt-16"
         :to="{
-          name: 'news-and-events-community-spotlight-success-stories'
+          name: 'news-and-events-community-spotlight'
         }"
       >
-        View All Success Stories &gt;
+        View All Community Spotlights &gt;
       </nuxt-link>
     </div>
   </div>
@@ -151,6 +151,7 @@ import PageHero from '@/components/PageHero/PageHero.vue'
 import DatasetCard from '@/components/DatasetCard/DatasetCard.vue'
 import createClient from '@/plugins/contentful.js'
 import youtubeEmbeddedSource from '@/mixins/youtube-embedded-src'
+import FormatDate from '@/mixins/format-date'
 
 // options for rendering contentful rich text. Modified from:
 // https://www.contentful.com/blog/2021/04/14/rendering-linked-assets-entries-in-contentful/
@@ -194,6 +195,7 @@ export default {
     Breadcrumb,
     PageHero
   },
+  mixins: [FormatDate],
   async asyncData({ route }) {
     try {
       const results = await client.getEntries({

--- a/pages/news-and-events/index.vue
+++ b/pages/news-and-events/index.vue
@@ -100,7 +100,7 @@
         </el-row>
 
         <h2>Community Spotlight</h2>
-        <community-spotlight-listings :stories="stories.items" :in-news="true" />
+        <community-spotlight-listings :stories="shownStories" :in-news="true" />
 
         <h2>Stay Connected</h2>
         <div class="subpage">
@@ -226,6 +226,13 @@ export default Vue.extend<Data, Methods, Computed, never>({
      */
     featuredEvent: function() {
       return this.page.fields.featuredEvent || {}
+    },
+    /**
+     * Filter to only show two stories
+     * @returns {Array}
+     */
+    shownStories: function() {
+      return this.stories.items.slice(0,2)
     }
   },
 

--- a/pages/news-and-events/model.ts
+++ b/pages/news-and-events/model.ts
@@ -134,7 +134,8 @@ export interface Data {
 }
 
 export interface Computed {
-  featuredEvent: EventsEntry
+  featuredEvent: EventsEntry,
+  shownStories: StoryCollection
 }
 export interface Methods {
   getAllNews: (this: NewsAndEventsComponent) => void;


### PR DESCRIPTION
# Description

Gazelle pointed out a few points that don't match the design and had a few design changes since the wireframes were created.

They are:

 - Only two success stories to be shown in news-and-events
 - Publication date was unformatted
 - Breadcrumbs for story detail to be changed to > news-and-events > community-spotlight > story-id
 - Story end now links out to community-spotlight, not success-stories
 
Changes of this branch can be viewed at:
https://sparc-succcess-stories.herokuapp.com/news-and-events/
 
Discussion can be viewed on wrike at:
https://www.wrike.com/open.htm?id=660279044


## Type of change

Delete those that don't apply.

- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

Run locally and on a heroku clone


# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added unit tests that prove my fix is effective or that my feature works
