### PR TITLE
90% zoom fix

### DIFF
--- a/components/header/Header.vue
+++ b/components/header/Header.vue
@@ -51,7 +51,7 @@
               @clear="searchQuery = ''"
             />
             <div
-              v-if="mobilSearchOpen"
+              v-if="mobileSearchOpen"
               class="click-outside-mobile-search-catch"
               @click="mobileSearchOpen = false"
             />

--- a/pages/news-and-events/index.vue
+++ b/pages/news-and-events/index.vue
@@ -289,7 +289,7 @@ h3 {
   margin: 0 1rem 1rem;
   width: 100%;
   @media (min-width: 48em) {
-    width: calc(50% - 4.125em); // Account for the margins and the border
+    width: calc(50% - 4.25em); // Account for the margins and the border
   }
 }
 .show-all-upcoming-events {


### PR DESCRIPTION


# Description

 - typo in mobileSearchOpen
 - Fix for 90% zoom at Asher's request https://www.wrike.com/open.htm?id=678414135
 
 
![image](https://user-images.githubusercontent.com/37255664/129117733-4cee4159-c1a0-4560-a535-12a2045d2f35.png)
On https://sparc.science/news-and-events. If you are on a large external screen and at 90% zoom (which sometimes seems to be the default), the events cards will stack vertically as opposed to horizontally. 

I've adding a bigger buffer in the width calculation to keep this from happening until we get to 33% zoom/

While implementing this I noticed a typo in the mobile search.




## Type of change

Delete those that don't apply.

- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

Ran locally and confirmed the bug on sparc.science.

Zoom at 90% after this change:
![image](https://user-images.githubusercontent.com/37255664/129118009-95fee489-dce3-48aa-a7c0-6833bb355581.png)


# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added unit tests that prove my fix is effective or that my feature works
