### PR TITLE
faceted-browse-v785th-add-tools-and-resources-and-news-and-events-tabs

### DIFF
--- a/components/SearchResults/EventSearchResults.vue
+++ b/components/SearchResults/EventSearchResults.vue
@@ -1,30 +1,22 @@
 <template>
-  <el-table :data="tableData" empty-text="No Results">
-    <el-table-column
-      :fixed="true"
-      prop="fields.title"
-      label="Title"
-      width="300"
-    >
-      <template slot-scope="scope">
-        <nuxt-link
-          :to="{
-            name: 'events-eventId',
-            params: { eventId: scope.row.sys.id }
-          }"
-        >
-          {{ scope.row.fields.title }}
-        </nuxt-link>
-      </template>
-    </el-table-column>
-    <el-table-column prop="fields.eventType" label="Event Type" />
-    <el-table-column prop="fields.location" label="Location" />
-  </el-table>
+  <div class="events">
+    <event-card
+      v-for="event in tableData"
+      :key="event.sys.id"
+      :event="event"
+    />
+  </div>
 </template>
 
 <script>
+import EventCard from '../EventCard/EventCard.vue'
+
 export default {
   name: 'EventSearchResults',
+
+  components: {
+    EventCard,
+  },
 
   props: {
     tableData: {
@@ -36,7 +28,18 @@ export default {
 </script>
 
 <style lang="scss" scoped>
-.el-table {
-  width: 100%;
+.events {
+  display: flex;
+  flex-wrap: wrap;
+  margin: 0 -1em;
+}
+.upcoming-event {
+  margin: 0 1em 2em;
+  @media (min-width: 48em) {
+    width: calc(50% - 4.125em); // Account for the margins and the border
+  }
+  @media (min-width: 64em) {
+    width: calc(25% - 4.125em); // Account for the margins and the border
+  }
 }
 </style>

--- a/components/SearchResults/NewsSearchResults.vue
+++ b/components/SearchResults/NewsSearchResults.vue
@@ -1,0 +1,37 @@
+<template>
+  <el-table :show-header="false" :data="tableData" empty-text="No Results">
+		<el-table-column>
+      <template slot-scope="scope">
+        <news-list-item
+          :key="scope.row.sys.id"
+          :item="scope.row"
+        />
+      </template>
+		</el-table-column>
+  </el-table>
+</template>
+
+<script>
+import NewsListItem from '@/components/NewsListItem/NewsListItem.vue'
+
+export default {
+  name: 'NewsSearchResults',
+
+	components: {
+    NewsListItem
+  },
+
+  props: {
+    tableData: {
+      type: Array,
+      default: () => []
+    }
+  }
+}
+</script>
+
+<style lang="scss" scoped>
+.el-table {
+  width: 100%;
+}
+</style>

--- a/pages/data/index.vue
+++ b/pages/data/index.vue
@@ -177,8 +177,8 @@ const EventSearchResults = () =>
   import('@/components/SearchResults/EventSearchResults.vue')
 const DatasetSearchResults = () =>
   import('@/components/SearchResults/DatasetSearchResults.vue')
-const OrganSearchResults = () =>
-  import('@/components/SearchResults/OrganSearchResults.vue')
+const NewsSearchResults = () =>
+  import('@/components/SearchResults/NewsSearchResults.vue')
 const ResourcesSearchResults = () =>
   import('@/components/Resources/ResourcesSearchResults.vue')
 
@@ -187,8 +187,8 @@ const searchResultsComponents = {
   sparcAward: ProjectSearchResults,
   sparcPartners: ResourcesSearchResults,
   event: EventSearchResults,
-  organ: OrganSearchResults,
-  simulation: DatasetSearchResults
+  simulation: DatasetSearchResults,
+  news: NewsSearchResults,
 }
 
 const searchTypes = [
@@ -199,14 +199,24 @@ const searchTypes = [
     dataSource: 'algolia'
   },
   {
-    label: 'Organs',
-    type: process.env.ctf_organ_id,
-    filterId: process.env.ctf_filters_organ_id,
+    label: 'Simulations',
+    type: 'simulation',
+    filterId: process.env.ctf_filters_simulation_id,
+    dataSource: 'algolia'
+  },
+  {
+    label: 'Resources',
+    type: process.env.ctf_resource_id,
     dataSource: 'contentful'
   },
   {
-    label: 'Tools & Resources',
-    type: process.env.ctf_resource_id,
+    label: 'Events',
+    type: process.env.ctf_event_id,
+    dataSource: 'contentful'
+  },
+  {
+    label: 'News',
+    type: process.env.ctf_news_id,
     dataSource: 'contentful'
   },
   {
@@ -215,12 +225,6 @@ const searchTypes = [
     filterId: process.env.ctf_filters_project_id,
     dataSource: 'contentful'
   },
-  {
-    label: 'Simulations',
-    type: 'simulation',
-    filterId: process.env.ctf_filters_simulation_id,
-    dataSource: 'algolia'
-  }
 ]
 
 const searchData = {

--- a/pages/data/index.vue
+++ b/pages/data/index.vue
@@ -179,10 +179,13 @@ const DatasetSearchResults = () =>
   import('@/components/SearchResults/DatasetSearchResults.vue')
 const OrganSearchResults = () =>
   import('@/components/SearchResults/OrganSearchResults.vue')
+const ResourcesSearchResults = () =>
+  import('@/components/Resources/ResourcesSearchResults.vue')
 
 const searchResultsComponents = {
   dataset: DatasetSearchResults,
   sparcAward: ProjectSearchResults,
+  sparcPartners: ResourcesSearchResults,
   event: EventSearchResults,
   organ: OrganSearchResults,
   simulation: DatasetSearchResults
@@ -199,6 +202,11 @@ const searchTypes = [
     label: 'Organs',
     type: process.env.ctf_organ_id,
     filterId: process.env.ctf_filters_organ_id,
+    dataSource: 'contentful'
+  },
+  {
+    label: 'Tools & Resources',
+    type: process.env.ctf_resource_id,
     dataSource: 'contentful'
   },
   {
@@ -889,6 +897,9 @@ export default {
   margin: 0 0 0 0;
   padding: 0 0;
   outline: 0.1rem solid $median;
+  @media (max-width: 40rem) {
+    display: block
+  }
   li {
     width: 100%;
     text-align: center;
@@ -907,12 +918,14 @@ export default {
   padding: 0;
   text-decoration: none;
   text-transform: uppercase;
-  border-right: 0.1rem solid $median;
   line-height: 3.5rem;
-  @media (min-width: 48em) {
+  @media (min-width: 54rem) {
     font-size: 1.25rem;
     font-weight: 600;
     text-transform: none;
+  }
+  @media (min-width: 40rem) {
+    border-right: 0.1rem solid $median;
   }
   &:hover,
   &:focus,


### PR DESCRIPTION
# Description

In the browse data page I added 3 new tabs 'News', 'Events', and 'Resources' tabs. This is for the time being as I work on faceted browse for the other tabs. Once faceted browse is implemented for the other tabs I will be able to condense the tabs to match the final wireframes, but since that is planned for next sprint I want to get these changes out for the time being so that a user still has the ability to search for news, events, and resources using the browse functionality.

My tab changes:
![image](https://user-images.githubusercontent.com/5529126/129449714-0140de97-71c2-4e17-bac4-06c4bc6f7c1b.png)

Final wireframe changes:
![image](https://user-images.githubusercontent.com/5529126/129449737-699ce561-6eff-422f-8d2f-6ef7529b2e5c.png)

## Type of change

Delete those that don't apply.

- [X] New feature (non-breaking change which adds functionality)

# How Has This Been Tested?

Navigate to the added tabs and verify content is there. Performed queries on the results as well as clicked on their hyperlinks to navigate to their details pages

# Checklist:

- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my own code
- [X] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added unit tests that prove my fix is effective or that my feature works
