### PR TITLE
faceted-browse-v785th-update-and-show-facet-menu

### DIFF
--- a/assets/components/_el-tooltip.scss
+++ b/assets/components/_el-tooltip.scss
@@ -3,7 +3,7 @@
 .el-tooltip__popper{
     background: rgb(243, 236, 246) !important;
     border: 1px solid rgb(131, 0, 191) !important;
-    color: rgb(48, 49, 51);
+    color: rgb(48, 49, 51) !important;
     font-size: 12px;
     font-weight: normal;
     line-height: 18px;
@@ -87,5 +87,9 @@
 
 .el-tooltip__popper[x-placement^=bottom-end] .popper__arrow{
     right: 6px!important;
+}
+
+.el-tooltip__popper.capitalize{
+    text-transform: capitalize;
 }
 

--- a/components/FacetMenu/DatasetFacetMenu.vue
+++ b/components/FacetMenu/DatasetFacetMenu.vue
@@ -1,0 +1,89 @@
+<template>
+  <div class="white-background">
+    <h2 class="title">
+      Refine results
+    </h2>
+    <hr />
+		<tags-container :selectedFacets="selectedFacets" @deselect-facet="deselectFacet" @deselect-all-facets="deselectAllFacets"/>
+    <hr />
+    <facet-menu ref="menu" :facets="facets" :defaultCheckedFacetIds="defaultCheckedFacetIds" :visibleFacets="visibleFacets" @selected-facets-changed="selectedFacetsChanged"/>
+  </div>
+</template>
+
+<script>
+import FacetMenu from '@/components/FacetMenu/FacetMenu.vue'
+import TagsContainer from '@/components/FacetMenu/TagsContainer.vue'
+export default {
+  name: 'DatasetFacetMenu',
+
+  components: { FacetMenu, TagsContainer },
+
+  props: {
+    facets: {
+      type: Array,
+      default: () => []
+    },
+    visibleFacets: {
+      type: Object,
+      default: () => {}
+    },
+    defaultCheckedFacetIds: {
+      type: Array,
+      default: () => []
+    }
+  },
+
+  data() {
+    return {
+      selectedFacets: [],
+    }
+  },
+
+	mounted() {
+		// Work around el-tree component not firing onFacetChecked event when setting default checked keys.
+		// When user navigates between tabs, we need to force selectedFacets to update so that the tags get shown
+		if (this.$refs.menu.facets.length > 0) {
+			this.$refs.menu.onFacetChecked()
+		}
+	},
+
+  methods: {
+    selectedFacetsChanged: function(newSelectedFacets) {
+			this.selectedFacets = newSelectedFacets
+      this.$emit('selected-facets-changed', newSelectedFacets)
+  	},
+		deselectAllFacets() {
+      this.$refs.menu.deselectAllFacets()
+    },
+    deselectFacet(id) {
+      this.$refs.menu.deselectFacet(id)
+    }
+	}
+}
+</script>
+
+<style lang="scss" scoped>
+@import '../../assets/_variables.scss';
+	.white-background {
+		background-color: white;
+	}
+
+	h2 {
+		font-size: 1.25rem;
+		font-weight: 500;
+		line-height: 1.2;
+	}
+
+	.title {
+		margin-bottom: 0;
+		padding: 0.5rem 1rem;
+	}
+
+	hr {
+		border: none;
+		border-bottom: 1px solid #dbdfe6;
+		margin: 0;
+	}
+  
+</style>
+

--- a/components/FacetMenu/FacetMenu.vue
+++ b/components/FacetMenu/FacetMenu.vue
@@ -1,38 +1,18 @@
 <template>
-  <div class="facets">
-    <h2 class="title">
-      Refine results
-    </h2>
-    <hr />
-    <div class="tags-section">
-      <span class="flex">
-        Filters applied:
-        <el-link @click="deselectAllFacets">Reset all</el-link>
-      </span>
-      <hr />
-      <el-card shadow="never" class="facet-card">
-        <span v-if="selectedFacets.length == 0" class="no-facets">No filters applied</span>
-        <el-tag
-          v-for="facet in selectedFacets"
-          :key="facet.id"
-          disable-transitions
-          closable
-          @close="deselectFacet(facet.id)"
-        >
-          {{ facet.label }}
-        </el-tag>
-      </el-card>
-    </div>
-    <hr />
+  <div class="facet-menu">
     <el-tree
       ref="tree"
       :data="facets"
       node-key="id"
       indent="0"
       show-checkbox
+      default-expand-all
       :expand-on-click-node="false"
+      :default-checked-keys="defaultCheckedFacetIds"
+      :filter-node-method="hideFacets"
       :render-content="renderTreeNode"
       @check="onFacetChecked"
+      :key="facets.length"
     />
   </div>
 </template>
@@ -44,8 +24,18 @@ export default {
   components: {},
 
   props: {
-    // The facets to be displayed in the menu
+    // All facets contained in the menu
     facets: {
+      type: Array,
+      default: () => []
+    },
+    // Setting visibleFacets hides all other facets
+    visibleFacets: {
+      type: Object,
+      default: () => {}
+    },
+    // Facets to be checked by default when loading the facet menu
+    defaultCheckedFacetIds: {
       type: Array,
       default: () => []
     }
@@ -54,7 +44,23 @@ export default {
   data() {
     return {
       // The facets that are selected by the user
-      selectedFacets: []
+      selectedFacets: [],
+    }
+  },
+
+  watch: {
+    "visibleFacets": function(facets) {
+      this.$refs.tree.filter(facets)
+    },
+    'facets': function(facets){
+      if (facets.length){
+        this.$nextTick(() => {
+          /* Work around el-tree component not firing onFacetChecked event when setting default checked keys. When user refreshes page, 
+           * we need to force selectedFacets to update so that the tags get shown and that the selectedFacets changed event gets fired 
+           * and notifies the parent that the selected facets have changed so that they can then fetch results */
+          this.onFacetChecked()
+        })
+      } 
     }
   },
 
@@ -63,23 +69,33 @@ export default {
       var customClasses = 'custom-tree-node'
       return this.isTopLevelNode(node) ? (
         <span class={customClasses}>
-          <span class="label">{node.label}</span>
+          <span class="label uppercase">{node.label}</span>
           <el-link on-click={() => this.deselectAllChildrenFacets(data)}>
             Reset
           </el-link>
         </span>
       ) : (
         <span class={customClasses}>
-          <span class="label">{node.label}</span>
+          <el-tooltip content={node.label} popper-class="capitalize" transition="none" open-delay="700" placement="top-start">
+            <span class="label capitalize">{node.label}</span>
+          </el-tooltip>
         </span>
       )
     },
+    hideFacets(value, data, node) {
+      const facetChildren = value[data.facetPropPath]
+      if (facetChildren == undefined) {
+        return false
+      }
+      return facetChildren[data.label] != undefined
+    },
+    
     // If the facet is a top level facet then it is one of the categories and cannot be selected,
     // We can only hide the checkbox so it still shows up as selected when all its children are checked
     isTopLevelNode(node) {
       return node.level <= 1
     },
-    onFacetChecked(clickedNode, treeStatus) {
+    onFacetChecked() {
       this.selectedFacets = this.$refs.tree
         .getCheckedNodes()
         .filter(checkedNode => {
@@ -116,27 +132,7 @@ export default {
 
 <style lang="scss">
 @import '../../assets/_variables.scss';
-
-.facets {
-  background: white;
-
-  h2 {
-    font-size: 1.25rem;
-    font-weight: 500;
-    line-height: 1.2;
-  }
-
-  .title {
-    margin-bottom: 0;
-    padding: 0.5rem 1rem;
-  }
-
-  hr {
-    border: none;
-    border-bottom: 1px solid #dbdfe6;
-    margin: 0;
-  }
-
+.facet-menu {
   .el-tree-node {
     border-bottom: 1px solid #dbdfe6;
   }
@@ -146,7 +142,6 @@ export default {
   }
 
   .el-tree > .el-tree-node > .el-tree-node__content {
-    text-transform: uppercase;
     label.el-checkbox {
       display: none;
     }
@@ -183,41 +178,32 @@ export default {
     border-color: $median !important;
   }
 
+  .el-tree-node__expand-icon.is-leaf {
+    display: none;
+  }
+
   .custom-tree-node {
+    text-overflow: ellipsis;
+    overflow: hidden;
+
     .el-link {
       margin-left: 1rem;
     }
-    .label {
+    .label{
       color: black;
       font-size: 1rem;
       font-weight: 500;
       line-height: 0;
       margin: 0;
     }
+    .capitalize {
+      text-transform: capitalize;
+    }
+    .uppercase {
+      text-transform: uppercase;
+    }
   }
 
-  .tags-section {
-    margin: 0.75rem;
-    hr {
-      padding-bottom: 0.75rem;
-      margin-bottom: 0.5rem;
-    }
-    .flex {
-      display: flex;
-      .el-link {
-        margin-left: auto;
-      }
-    }
-    .facet-card {
-      .el-card__body {
-        padding: 10px;
-      }
-      .no-facets {
-        font-style: italic;
-        opacity: 0.5;
-      }
-    }
-  }
   .el-link .el-link--inner {
     text-decoration: underline;
     text-transform: none;

--- a/components/FacetMenu/SparcInfoFacetMenu.vue
+++ b/components/FacetMenu/SparcInfoFacetMenu.vue
@@ -1,0 +1,112 @@
+<template>
+  <div class="white-background">
+    <h2 class="title">
+      Refine results
+    </h2>
+    <hr />
+		<tags-container :selectedFacets="selectedFacets" @deselect-facet="deselectFacet" @deselect-all-facets="deselectAllFacets"/>
+    <hr />
+		<hr />
+		<div class="types-section">
+			<div class="types-title">
+      	Type
+    	</div>
+			<el-radio-group v-model="selectedType">
+				<el-radio :label="0">Projects</el-radio>
+				<el-radio :label="1">About</el-radio>
+				<el-radio :label="2">Help</el-radio>
+			</el-radio-group>
+		</div>
+		<hr />
+    <facet-menu ref="menu" :facets="facets" :defaultCheckedFacetIds="defaultCheckedFacetIds" :visibleFacets="visibleFacets" @selected-facets-changed="selectedFacetsChanged"/>
+  </div>
+</template>
+
+<script>
+import FacetMenu from '@/components/FacetMenu/FacetMenu.vue'
+import TagsContainer from '@/components/FacetMenu/TagsContainer.vue'
+export default {
+  name: 'SparcInfoFacetMenu',
+
+  components: { FacetMenu, TagsContainer },
+
+  props: {
+    facets: {
+      type: Array,
+      default: () => []
+    },
+    visibleFacets: {
+      type: Object,
+      default: () => {}
+    },
+    defaultCheckedFacetIds: {
+      type: Array,
+      default: () => []
+    }
+  },
+
+  data() {
+    return {
+      selectedFacets: [],
+			selectedType: 0
+    }
+  },
+
+  methods: {
+    selectedFacetsChanged: function(newSelectedFacets) {
+			this.selectedFacets = newSelectedFacets
+      this.$emit('selected-facets-changed', newSelectedFacets)
+  	},
+		deselectAllFacets() {
+      this.$refs.menu.deselectAllFacets()
+    },
+    deselectFacet(id) {
+      this.$refs.menu.deselectFacet(id)
+    }
+	}
+}
+</script>
+
+<style lang="scss">
+@import '../../assets/_variables.scss';
+.white-background {
+	background-color: white;
+}
+
+h2 {
+	font-size: 1.25rem;
+	font-weight: 500;
+	line-height: 1.2;
+}
+
+.title {
+	margin-bottom: 0;
+	padding: 0.5rem 1rem;
+}
+
+hr {
+	border: none;
+	border-bottom: 1px solid #dbdfe6;
+	margin: 0;
+}
+
+.types-section {
+	margin: 0.75rem;
+	font-weight: 500;
+
+	.el-radio {
+		display: block;
+		margin: .75rem .75rem .75rem 1rem;
+
+		.el-radio__label {
+			color: black;
+			font-size: 1rem;
+			line-height: 0;
+		}
+	}
+
+	.types-title {
+		text-transform: uppercase;
+	}
+}
+</style>

--- a/components/FacetMenu/TagsContainer.vue
+++ b/components/FacetMenu/TagsContainer.vue
@@ -1,0 +1,93 @@
+<template>
+	<div class="tags-container">
+		<span class="flex">
+			Filters applied:
+			<el-link @click="deselectAllFacets">Reset all</el-link>
+		</span>
+		<hr />
+		<el-card shadow="never" class="facet-card">
+			<span v-if="selectedFacets.length == 0" class="no-facets">No filters applied</span>
+			<el-tag
+				v-for="facet in selectedFacets"
+				:key="facet.id"
+        class="capitalize"
+				disable-transitions
+				closable
+				@close="deselectFacet(facet.id)"
+			>
+				{{ facet.label }}
+			</el-tag>
+		</el-card>
+	</div>
+</template>
+
+<script>
+export default {
+  name: 'TagsContainer',
+
+  props: {
+    // All facets contained in the menu
+    selectedFacets: {
+      type: Array,
+      default: () => []
+    },
+  },
+  
+  methods: {
+		deselectAllFacets() {
+      this.$emit('deselect-all-facets')
+    },
+    deselectFacet(id) {
+			this.$emit('deselect-facet', id)
+    }
+	}
+}
+</script>
+
+<style lang="scss">
+@import '../../assets/_variables.scss';
+  .tags-container {
+    margin: 0.75rem;
+    hr {
+      padding-bottom: 0.75rem;
+      margin-bottom: 0.5rem;
+			border: none;
+			border-bottom: 1px solid #dbdfe6;
+    }
+    .flex {
+      display: flex;
+      .el-link {
+        margin-left: auto;
+      }
+    }
+    .facet-card {
+      .el-card__body {
+        padding: 10px;
+        max-height: 10rem;
+        overflow-y: auto;
+      }
+      .no-facets {
+        font-style: italic;
+        opacity: 0.5;
+      }
+      .capitalize {
+        text-transform: capitalize;
+      }
+    }
+		.el-link .el-link--inner {
+			text-decoration: underline;
+			text-transform: none;
+			color: $median;
+			a:hover {
+				text-decoration: none;
+			}
+		}
+		//el-link adds a component with a border in order to underline the text.
+		//The underline is too low so we cannot use it, and must instead hide it
+		.el-link.el-link--default:after {
+			border: none;
+		}
+  }
+  
+</style>
+

--- a/components/SearchResults/DatasetSearchResults.vue
+++ b/components/SearchResults/DatasetSearchResults.vue
@@ -10,22 +10,25 @@
         <nuxt-link
           :to="{
             name: 'datasets-datasetId',
-            params: { datasetId: scope.row.id },
+            params: { datasetId: scope.row.object_id },
             query: {
               type: $route.query.type
             }
           }"
           class="img-dataset"
         >
+        <div v-if="scope.row.pennsieve">
           <img
-            :src="scope.row.banner"
-            :alt="`Banner for ${scope.row.name}`"
+            v-if="scope.row.pennsieve.banner"
+            :src="scope.row.pennsieve.banner.uri"
+            :alt="`Banner for ${scope.row.item.name}`"
             height="128"
             width="128"
           />
-          <sparc-pill v-if="scope.row.embargo">
+          <sparc-pill v-show='scope.row.item.published.status == "embargo"'>
             Embargoed
           </sparc-pill>
+        </div>
         </nuxt-link>
       </template>
     </el-table-column>
@@ -38,24 +41,21 @@
         <nuxt-link
           :to="{
             name: 'datasets-datasetId',
-            params: { datasetId: scope.row.id },
+            params: { datasetId: scope.row.object_id },
             query: {
               type: $route.query.type
             }
           }"
         >
-          {{ scope.row.name }}
+          {{ scope.row.item.name }}
         </nuxt-link>
         <div class="mt-8 mb-8">
-          {{ scope.row.description }}
+          {{ scope.row.item.description }}
         </div>
         <table class="property-table">
           <tr
             v-for="(property, index) in PROPERTY_DATA"
-            v-show="
-              property.propPath === 'createdAt' ||
-                getPropertyValue(tableMetadata.get(scope.row.doi), property)
-            "
+            v-show="getPropertyValue(scope.row, property)"
             :key="index"
           >
             <td class="property-name-column">
@@ -63,12 +63,7 @@
             </td>
             <td>
               {{
-                property.propPath === 'createdAt'
-                  ? formatDate(scope.row.createdAt) +
-                    ' (Last updated ' +
-                    formatDate(scope.row.updatedAt) +
-                    ')'
-                  : getPropertyValue(tableMetadata.get(scope.row.doi), property)
+                getPropertyValue(scope.row, property)
               }}
             </td>
           </tr>
@@ -98,10 +93,6 @@ export default {
       type: Array,
       default: () => []
     },
-    tableMetadata: {
-      type: Map,
-      default: () => new Map()
-    }
   },
 
   data() {
@@ -126,11 +117,11 @@ export default {
         },
         {
           displayName: 'Publication Date',
-          propPath: 'createdAt'
+          propPath: 'dates'
         },
         {
           displayName: 'Includes',
-          propPath: 'publication'
+          propPath: 'item.published.boolean'
         }
       ]
     }
@@ -160,7 +151,8 @@ export default {
             : undefined
         }
         case 'Includes': {
-          return _.get(item, property.propPath) ? undefined : 'Publications'
+          const published = _.get(item, property.propPath)
+          return (published == undefined || published == 'false') ? undefined : 'Publications'
         }
         case 'Samples': {
           const sampleCount = _.get(item, property.propPath + '.samples.count')
@@ -180,6 +172,15 @@ export default {
                 .join(', ')
                 .replaceAll(' technique', '')
             : undefined
+        }
+        case 'Publication Date': {
+          const dates = _.get(item, property.propPath)
+          const createdAt = dates.created.timestamp.split(",")[0]
+          const updatedAt = dates.updated[0].timestamp.split(",")[0]
+          return this.formatDate(createdAt) +
+                    ' (Last updated ' +
+                    this.formatDate(updatedAt) +
+                    ')'
         }
         default: {
           return _.get(item, property.propPath)

--- a/components/SearchResults/DatasetSearchResults.vue
+++ b/components/SearchResults/DatasetSearchResults.vue
@@ -117,7 +117,7 @@ export default {
         },
         {
           displayName: 'Publication Date',
-          propPath: 'dates'
+          propPath: 'pennsieve'
         },
         {
           displayName: 'Includes',
@@ -174,9 +174,9 @@ export default {
             : undefined
         }
         case 'Publication Date': {
-          const dates = _.get(item, property.propPath)
-          const createdAt = dates.created.timestamp.split(",")[0]
-          const updatedAt = dates.updated[0].timestamp.split(",")[0]
+          const pennsieve = _.get(item, property.propPath)
+          const createdAt = pennsieve.createdAt.timestamp.split(",")[0]
+          const updatedAt = pennsieve.updatedAt.timestamp.split(",")[0]
           return this.formatDate(createdAt) +
                     ' (Last updated ' +
                     this.formatDate(updatedAt) +

--- a/pages/data/index.vue
+++ b/pages/data/index.vue
@@ -201,7 +201,7 @@ import SparcInfoFacetMenu from '~/components/FacetMenu/SparcInfoFacetMenu.vue'
 
 const client = createClient()
 const algoliaClient = createAlgoliaClient()
-const algoliaIndex = algoliaClient.initIndex('k-core_dev')
+const algoliaIndex = algoliaClient.initIndex('k-core_dev_published_time_desc')
 
 export default {
   name: 'DataPage',
@@ -420,12 +420,12 @@ export default {
       const query = this.$route.query.q
       var filters = this.constructFilters(this.selectedFacets);
       const searchType = pathOr('', ['query', 'type'], this.$route)
-      const itemTypeFilter =
-        searchType === 'simulation' ? "item.types.name:Simulation" : "NOT item.types.name:Simulation"
+      const organizationNameFilter =
+        searchType === 'simulation' ? "IT'IS Foundation" : "SPARC Consortium"
 
       filters = filters == undefined ? 
-      `${itemTypeFilter}` : 
-      filters + ` AND ${itemTypeFilter}`
+      `pennsieve.organization.name:"${organizationNameFilter}"` : 
+      filters + ` AND pennsieve.organization.name:"${organizationNameFilter}"`
 
       /* First we need to find only those facets that are relevant to the search query.
        * If we attempt to do this in the same search as below than the response facets

--- a/pages/data/utils.ts
+++ b/pages/data/utils.ts
@@ -151,3 +151,14 @@ export const extractExtension = (
   }
   return ''
 }
+
+// Mapping between display categories and their Algolia index property path
+// Used for populating the Dataset Search Results facet menu dynamically
+export const facetPropPathMapping = {
+  'anatomy.organ.name' : 'Anatomical Structure',
+  'organisms.primary.species.name' : 'Species',
+  'item.techniques.keyword' : 'Techniques',
+  'attributes.subject.sex.value' : 'Sex',
+  'attributes.subject.ageCategory.value' : 'Age Categories',
+  'item.published.status' : 'Publication Status'
+}


### PR DESCRIPTION
# Description

Implemented faceted browse for datasets tab. Dataset search results can now be narrowed down based off facet selections. Selections are persisted between tab changes and results are displayed in publication date order:

![image](https://user-images.githubusercontent.com/5529126/130356963-632d8c23-66b1-4709-80c3-b399741462fb.png)

Wireframes can be found here:
https://app.abstract.com/share/ca9ac8ee-68b2-4422-b0d7-55a61c0bb403?collectionId=aac5183e-7ed8-469a-9d73-7e39036ce2ef&collectionLayerId=77147cf9-0a22-4770-af6f-cdd93e0cb131&present=true&preview=false&sha=deb221da2686562e2063344b84eaa2807aba5346&showComments=false

In regards to the show all checkbox functionality, that has been diregarded as an anti-pattern and the deselect button has been added in its place

## Type of change

Delete those that don't apply.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

# How Has This Been Tested?

Pulled down changes and:

-entered a search query and verified that only relevant facets were shown
-selected facets to narrow down results further
-used the deselect/deselect all buttons on the menu
-deleted tags from the tags container of the menu
-refreshed the page and navigated between tabs

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added unit tests that prove my fix is effective or that my feature works
