### PR TITLE
Comment out flatmap viewer in gallery until fCCB approval

### DIFF
--- a/pages/datasets/_datasetId.vue
+++ b/pages/datasets/_datasetId.vue
@@ -366,22 +366,20 @@ const getThumbnailData = async (datasetDoi, datasetId, datasetVersion) => {
         version: datasetVersion
       }
 
-      // **NOTE: Below code is commented out as flatmap CCB is still in the process of approving this feature**
-
       // Check for flatmap neuron data
-      // if (scicrunchData.organs) {
-      //   let flatmapData = [{}]
-      //   for (let i in scicrunchData.organs) {
-      //     if (flatmapData.length <= i) {
-      //       flatmapData.push({})
-      //     }
-      //     flatmapData[i].taxo = Uberons.species['rat']
-      //     flatmapData[i].uberonid = scicrunchData.organs[i].curie
-      //     flatmapData[i].id = datasetId
-      //     flatmapData[i].version = datasetVersion
-      //   }
-      //   scicrunchData['flatmaps'] = flatmapData
-      // }
+      if (scicrunchData.organs) {
+        let flatmapData = [{}]
+        for (let i in scicrunchData.organs) {
+          if (flatmapData.length <= i) {
+            flatmapData.push({})
+          }
+          flatmapData[i].taxo = Uberons.species['rat']
+          flatmapData[i].uberonid = scicrunchData.organs[i].curie
+          flatmapData[i].id = datasetId
+          flatmapData[i].version = datasetVersion
+        }
+        scicrunchData['flatmaps'] = flatmapData
+      }
     }
   } catch (e) {
     return {

--- a/pages/datasets/flatmapviewer/_id.vue
+++ b/pages/datasets/flatmapviewer/_id.vue
@@ -118,10 +118,11 @@ export default {
     flatmapReady: function(component) {
       let id = this.checkForIlxtr(this.uberonid)
       component.mapImp.zoomTo(id)
-      component.checkAndCreatePopups({
-        resource: [id],
-        eventType: 'click'
-      })
+      // **NOTE: This is commented out until fCCB approves the popups
+      // component.checkAndCreatePopups({
+      //   resource: [id],
+      //   eventType: 'click'
+      // })
     },
     checkForIlxtr: function(id) {
       if (id.includes('neuron-type-keast') && !id.includes('ilxtr')) {


### PR DESCRIPTION
# Description

Flatmap CCB is still in the process of approving the use of pubmed papers on the flatmap. So we need to remove this until that happens. 

(Sorry it must have slipped through)

https://staging.sparc.science/datasets/flatmapviewer?dataset_version=1&dataset_id=106&taxo=NCBITaxon%3A10114&uberonid=neuron-type-keast-10
![image](https://user-images.githubusercontent.com/37255664/131060572-762aa418-447c-47f6-8f1f-bdc26cbcd5ca.png)



## Type of change

Delete those that don't apply.

- [x] Bug fix (non-breaking change which fixes an issue)


# How Has This Been Tested?

Ran locally. No changes besides image-gallery not showing and flatmap results.


# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added unit tests that prove my fix is effective or that my feature works
