### PR TITLE
Update to version 0.2.1 of @abi-software/gallery

### DIFF
--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
   },
   "dependencies": {
     "@abi-software/flatmapvuer": "0.2.1",
-    "@abi-software/gallery": "^0.1.6",
+    "@abi-software/gallery": "^0.2.0",
     "@abi-software/mapintegratedvuer": "0.2.2",
     "@abi-software/plotvuer": "^0.3.0",
     "@abi-software/scaffoldvuer": "0.1.48",

--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
   },
   "dependencies": {
     "@abi-software/flatmapvuer": "0.2.1",
-    "@abi-software/gallery": "^0.2.0",
+    "@abi-software/gallery": "^0.2.1",
     "@abi-software/mapintegratedvuer": "0.2.2",
     "@abi-software/plotvuer": "^0.3.0",
     "@abi-software/scaffoldvuer": "0.1.48",

--- a/pages/datasets/biolucidaviewer/_id.vue
+++ b/pages/datasets/biolucidaviewer/_id.vue
@@ -9,7 +9,10 @@
       >
         <el-row :gutter="16">
           <el-col :offset="22" :span="4" class="details">
-            <button class="ml-8 btn-copy-permalink-solid" @click="copyLink">
+            <button
+              class="ml-8 btn-copy-permalink-solid hidden"
+              @click="copyLink"
+            >
               <svg-icon name="icon-permalink" height="28" width="28" />
               <span class="visuallyhidden">Copy permalink</span>
             </button>
@@ -174,6 +177,10 @@ export default {
 </script>
 
 <style scoped lang="scss">
+.hidden {
+  visibility: hidden;
+}
+
 .page {
   display: flex;
   margin-top: 7rem;

--- a/yarn.lock
+++ b/yarn.lock
@@ -38,12 +38,11 @@
     lodash "^4.17.21"
     vue "^2.6.10"
 
-"@abi-software/gallery@^0.1.6":
-  version "0.1.6"
-  resolved "https://registry.yarnpkg.com/@abi-software/gallery/-/gallery-0.1.6.tgz#b7a67eb269e3d245a0cccd19f81a8df69a4f47bb"
-  integrity sha512-fWI0BGI5XFPveEaIi7WgOyNOXivp4tGx9XY102Y29lXeZ7oxy4rT1obgCs4RDla/R2I6wMyP34ErzvEVjqQH0A==
+"@abi-software/gallery@^0.2.0":
+  version "0.2.0"
+  resolved "https://registry.yarnpkg.com/@abi-software/gallery/-/gallery-0.2.0.tgz#6c3a80826008531719cee37dd8fcef5f2e592276"
+  integrity sha512-rEc8Uxh89cVudQFAgq4JybkEHc9Lbs8j0CDoxya2PaIQ3LJ7o8lC89DDiDWiZ/HbOadq1G/4HTLW3ynBhi3AsA==
   dependencies:
-    "@abi-software/svg-sprite" "^0.1.11"
     "@babel/code-frame" "^7.12.11"
     core-js "^3.8.3"
     element-ui "^2.15.0"
@@ -163,7 +162,16 @@
     element-ui "^2.14.1"
     vue "^2.6.11"
 
-"@abi-software/svg-sprite@^0.1.11", "@abi-software/svg-sprite@^0.1.12":
+"@abi-software/svg-sprite@^0.1.11":
+  version "0.1.13"
+  resolved "https://registry.yarnpkg.com/@abi-software/svg-sprite/-/svg-sprite-0.1.13.tgz#ab2f76b70f8a6f9d01535dab383662986762eb54"
+  integrity sha512-JwzxRSz+aVAoRZ0EXalW0sZEN2I6kDg2yrhNEPD+mwTjnPX2beztc81Y8leDIdY8YaBR8SDdS1HdYUIOpjo5wQ==
+  dependencies:
+    core-js "^3.6.5"
+    svg-inline-loader "^0.8.2"
+    vue "^2.6.11"
+
+"@abi-software/svg-sprite@^0.1.12":
   version "0.1.12"
   resolved "https://registry.yarnpkg.com/@abi-software/svg-sprite/-/svg-sprite-0.1.12.tgz#ad902d356b6304014ac239ffdd5c0c44d4704fda"
   integrity sha512-aLS45qN+3OnPcSl5zNRHXChTmom1QgphYPOWGyWPra+Cdn8bv0+e5KnkarEV6vBcPf5I3u+gSUGHEGCex9vvnQ==
@@ -283,19 +291,19 @@
   dependencies:
     "@babel/highlight" "^7.10.4"
 
-"@babel/code-frame@^7.12.11", "@babel/code-frame@^7.12.13":
-  version "7.12.13"
-  resolved "https://registry.yarnpkg.com/@babel/code-frame/-/code-frame-7.12.13.tgz#dcfc826beef65e75c50e21d3837d7d95798dd658"
-  integrity sha512-HV1Cm0Q3ZrpCR93tkWOYiuYIgLxZXZFVG2VgK+MBWjUqZTundupbfx2aXarXuw5Ko5aMcjtJgbSs4vUGBS5v6g==
-  dependencies:
-    "@babel/highlight" "^7.12.13"
-
-"@babel/code-frame@^7.14.5":
+"@babel/code-frame@^7.12.11", "@babel/code-frame@^7.14.5":
   version "7.14.5"
   resolved "https://registry.yarnpkg.com/@babel/code-frame/-/code-frame-7.14.5.tgz#23b08d740e83f49c5e59945fbf1b43e80bbf4edb"
   integrity sha512-9pzDqyc6OLDaqe+zbACgFkb6fKMNG6CObKpnYXChRsvYGyEdc7CA2BaqeOM+vOtCS5ndmJicPJhKAwYRI6UfFw==
   dependencies:
     "@babel/highlight" "^7.14.5"
+
+"@babel/code-frame@^7.12.13":
+  version "7.12.13"
+  resolved "https://registry.yarnpkg.com/@babel/code-frame/-/code-frame-7.12.13.tgz#dcfc826beef65e75c50e21d3837d7d95798dd658"
+  integrity sha512-HV1Cm0Q3ZrpCR93tkWOYiuYIgLxZXZFVG2VgK+MBWjUqZTundupbfx2aXarXuw5Ko5aMcjtJgbSs4vUGBS5v6g==
+  dependencies:
+    "@babel/highlight" "^7.12.13"
 
 "@babel/compat-data@^7.12.13", "@babel/compat-data@^7.13.0", "@babel/compat-data@^7.13.8":
   version "7.13.8"
@@ -616,12 +624,12 @@
   dependencies:
     "@babel/types" "^7.14.5"
 
-"@babel/helper-validator-identifier@^7.12.11":
-  version "7.12.11"
-  resolved "https://registry.yarnpkg.com/@babel/helper-validator-identifier/-/helper-validator-identifier-7.12.11.tgz#c9a1f021917dcb5ccf0d4e453e399022981fc9ed"
-  integrity sha512-np/lG3uARFybkoHokJUmf1QfEvRVCPbmQeUQpKow5cQ3xWrV9i3rUHodKDJPQfTVX61qKi+UdYk8kik84n7XOw==
+"@babel/helper-validator-identifier@^7.12.11", "@babel/helper-validator-identifier@^7.14.5":
+  version "7.14.9"
+  resolved "https://registry.yarnpkg.com/@babel/helper-validator-identifier/-/helper-validator-identifier-7.14.9.tgz#6654d171b2024f6d8ee151bf2509699919131d48"
+  integrity sha512-pQYxPY0UP6IHISRitNe8bsijHex4TWZXi2HwKVsjPiltzlhse2znVcm9Ace510VT1kxIHjGJCZZQBX2gJDbo0g==
 
-"@babel/helper-validator-identifier@^7.14.5", "@babel/helper-validator-identifier@^7.14.8":
+"@babel/helper-validator-identifier@^7.14.8":
   version "7.14.8"
   resolved "https://registry.yarnpkg.com/@babel/helper-validator-identifier/-/helper-validator-identifier-7.14.8.tgz#32be33a756f29e278a0d644fa08a2c9e0f88a34c"
   integrity sha512-ZGy6/XQjllhYQrNw/3zfWRwZCTVSiBLZ9DHVZxn9n2gip/7ab8mv2TWlKPIBk26RwedCBoWdjLmn+t9na2Gcow==
@@ -659,21 +667,12 @@
     "@babel/traverse" "^7.13.0"
     "@babel/types" "^7.13.0"
 
-"@babel/highlight@^7.10.4", "@babel/highlight@^7.14.5":
+"@babel/highlight@^7.10.4", "@babel/highlight@^7.12.13", "@babel/highlight@^7.14.5":
   version "7.14.5"
   resolved "https://registry.yarnpkg.com/@babel/highlight/-/highlight-7.14.5.tgz#6861a52f03966405001f6aa534a01a24d99e8cd9"
   integrity sha512-qf9u2WFWVV0MppaL877j2dBtQIDgmidgjGk5VIMw3OadXvYaXn66U1BFlH2t4+t3i+8PhedppRv+i40ABzd+gg==
   dependencies:
     "@babel/helper-validator-identifier" "^7.14.5"
-    chalk "^2.0.0"
-    js-tokens "^4.0.0"
-
-"@babel/highlight@^7.12.13":
-  version "7.13.10"
-  resolved "https://registry.yarnpkg.com/@babel/highlight/-/highlight-7.13.10.tgz#a8b2a66148f5b27d666b15d81774347a731d52d1"
-  integrity sha512-5aPpe5XQPzflQrFwL1/QoeHkP2MsA4JCntcXHRhEsdsfPVkvPi2w7Qix4iV7t5S/oC9OodGrggd8aco1g3SZFg==
-  dependencies:
-    "@babel/helper-validator-identifier" "^7.12.11"
     chalk "^2.0.0"
     js-tokens "^4.0.0"
 
@@ -4452,10 +4451,15 @@ core-js@^2.4.0, core-js@^2.5.7, core-js@^2.6.5:
   resolved "https://registry.yarnpkg.com/core-js/-/core-js-2.6.12.tgz#d9333dfa7b065e347cc5682219d6f690859cc2ec"
   integrity sha512-Kb2wC0fvsWfQrgk8HU5lW6U/Lcs8+9aaYcy4ZFc6DDlo4nZ7n70dEgE5rtR0oG6ufKDUnrwfWL1mXR5ljDatrQ==
 
-core-js@^3.3.2, core-js@^3.6.5, core-js@^3.7.0, core-js@^3.8.1, core-js@^3.8.3:
+core-js@^3.3.2, core-js@^3.7.0, core-js@^3.8.1:
   version "3.9.1"
   resolved "https://registry.yarnpkg.com/core-js/-/core-js-3.9.1.tgz#cec8de593db8eb2a85ffb0dbdeb312cb6e5460ae"
   integrity sha512-gSjRvzkxQc1zjM/5paAmL4idJBFzuJoo+jDjF1tStYFMV2ERfD02HhahhCGXUyHxQRG4yFKVSdO6g62eoRMcDg==
+
+core-js@^3.6.5, core-js@^3.8.3:
+  version "3.16.4"
+  resolved "https://registry.yarnpkg.com/core-js/-/core-js-3.16.4.tgz#0fb1029a554fc2688c0963d7c900e188188a78e0"
+  integrity sha512-Tq4GVE6XCjE+hcyW6hPy0ofN3hwtLudz5ZRdrlCnsnD/xkm/PWQRudzYHiKgZKUcefV6Q57fhDHjZHJP5dpfSg==
 
 core-util-is@1.0.2, core-util-is@~1.0.0:
   version "1.0.2"
@@ -5352,7 +5356,7 @@ element-size@^1.1.1:
   resolved "https://registry.yarnpkg.com/element-size/-/element-size-1.1.1.tgz#64e5f159d97121631845bcbaecaf279c39b5e34e"
   integrity sha1-ZOXxWdlxIWMYRby67K8nnDm1404=
 
-element-ui@^2.13.0, element-ui@^2.15.0, element-ui@^2.4.11:
+element-ui@^2.13.0, element-ui@^2.4.11:
   version "2.15.1"
   resolved "https://registry.yarnpkg.com/element-ui/-/element-ui-2.15.1.tgz#ada00aa6e32c02774a2e77563dd84668f813cdff"
   integrity sha512-TqlScAKGH97XndSScUDeEHIzL1x7yg7DvQdKPEOUdiDcyIz3y3FJJBlpHYaJT96FOn1xpIcUZb+I2FJeU9EcrQ==
@@ -5364,7 +5368,7 @@ element-ui@^2.13.0, element-ui@^2.15.0, element-ui@^2.4.11:
     resize-observer-polyfill "^1.5.0"
     throttle-debounce "^1.0.1"
 
-element-ui@^2.14.1:
+element-ui@^2.14.1, element-ui@^2.15.0:
   version "2.15.5"
   resolved "https://registry.yarnpkg.com/element-ui/-/element-ui-2.15.5.tgz#dfb376dc5cd60adab21c991bd4fac3e67e5300f4"
   integrity sha512-B/YCdz2aRY2WnFXzbTRTHPKZHBD/2KV6u88EBnkaARC/Lyxnap+7vpvrcW5UNTyVwjItS5Fj1eQyRy6236lbXg==
@@ -14185,10 +14189,15 @@ vue-template-es2015-compiler@^1.9.0:
   resolved "https://registry.yarnpkg.com/vue-template-es2015-compiler/-/vue-template-es2015-compiler-1.9.1.tgz#1ee3bc9a16ecbf5118be334bb15f9c46f82f5825"
   integrity sha512-4gDntzrifFnCEvyoO8PqyJDmguXgVPxKiIxrBKjIowvL9l+N66196+72XVYR8BBf1Uv1Fgt3bGevJ+sEmxfZzw==
 
-vue@^2.6.10, vue@^2.6.11, vue@^2.6.12:
+vue@^2.6.10, vue@^2.6.12:
   version "2.6.12"
   resolved "https://registry.yarnpkg.com/vue/-/vue-2.6.12.tgz#f5ebd4fa6bd2869403e29a896aed4904456c9123"
   integrity sha512-uhmLFETqPPNyuLLbsKz6ioJ4q7AZHzD8ZVFNATNyICSZouqP2Sz0rotWQC8UNBF6VGSCs5abnKJoStA6JbCbfg==
+
+vue@^2.6.11:
+  version "2.6.14"
+  resolved "https://registry.yarnpkg.com/vue/-/vue-2.6.14.tgz#e51aa5250250d569a3fbad3a8a5a687d6036e235"
+  integrity sha512-x2284lgYvjOMj3Za7kqzRcUSxBboHqtgRE2zlos1qWaOye5yUmHn42LB1250NJBLRwEcdrB0JRwyPTEPhfQjiQ==
 
 vuex@^3.5.1, vuex@^3.6.2:
   version "3.6.2"

--- a/yarn.lock
+++ b/yarn.lock
@@ -38,10 +38,10 @@
     lodash "^4.17.21"
     vue "^2.6.10"
 
-"@abi-software/gallery@^0.2.0":
-  version "0.2.0"
-  resolved "https://registry.yarnpkg.com/@abi-software/gallery/-/gallery-0.2.0.tgz#6c3a80826008531719cee37dd8fcef5f2e592276"
-  integrity sha512-rEc8Uxh89cVudQFAgq4JybkEHc9Lbs8j0CDoxya2PaIQ3LJ7o8lC89DDiDWiZ/HbOadq1G/4HTLW3ynBhi3AsA==
+"@abi-software/gallery@^0.2.1":
+  version "0.2.1"
+  resolved "https://registry.yarnpkg.com/@abi-software/gallery/-/gallery-0.2.1.tgz#8ee0fea38dff02c96cea9f85c009168aef9ada53"
+  integrity sha512-mt8LmUaXNATQk+bZLQOIMvTyzGr2VVwT62QSjDx/9XEc+0hpjPhGOGXaJaXpm7lnRgwhVo/mzF5OCL3wu1vNCQ==
   dependencies:
     "@babel/code-frame" "^7.12.11"
     core-js "^3.8.3"


### PR DESCRIPTION


# Description

Upgrade to version 0.2.0 of @abi-software/gallery.  This version only loads the visible cards onto the DOM.  This also hides the permalink button on Biolucida viewer, which is not working.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

Tested with dataset 137 which contains 10000+ image files.

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
