### PR TITLE
added env variable for algolia index

### DIFF
--- a/nuxt.config.js
+++ b/nuxt.config.js
@@ -71,6 +71,7 @@ export default {
     CTF_API_HOST: process.env.CTF_API_HOST,
     ALGOLIA_API_KEY: process.env.ALGOLIA_API_KEY,
     ALGOLIA_APP_ID: process.env.ALGOLIA_APP_ID,
+    ALGOLIA_INDEX: process.env.ALGOLIA_INDEX || 'k-core_dev_published_time_desc',
     BL_SERVER_URL: 'https://sparc.biolucida.net/api/v1/',
     BL_SHARE_LINK_PREFIX: 'https://sparc.biolucida.net/image?c=',
     NL_LINK_PREFIX: 'https://sparc.biolucida.net:8081',

--- a/pages/data/index.vue
+++ b/pages/data/index.vue
@@ -218,7 +218,7 @@ import ToolsAndResourcesFacetMenu from '~/components/FacetMenu/ToolsAndResources
 const client = createClient()
 const algoliaClient = createAlgoliaClient()
 const algoliaPennseiveIndex = algoliaClient.initIndex('PENNSIEVE_DISCOVER');
-const algoliaIndex = algoliaClient.initIndex('k-core_dev_published_time_desc')
+const algoliaIndex = algoliaClient.initIndex(process.env.ALGOLIA_INDEX)
 
 export default {
   name: 'DataPage',


### PR DESCRIPTION
# Description
Updated code to use an env var for deciding what index in algolia to pull from now that we have a prod algolia index


## Type of change

Delete those that don't apply.

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

# How Has This Been Tested?

Tested locally and added the env var in Heroku so once changes are merged then staging automatic re-deploy should be fine
