### PR TITLE
Contributors list always visible

### DIFF
--- a/pages/datasets/_datasetId.vue
+++ b/pages/datasets/_datasetId.vue
@@ -30,24 +30,13 @@
           </div>
         </div>
         <div class="dataset-owners">
-          <template v-if="!isContributorListVisible">
-            <contributor-item :contributor="firstContributor" />
-            <button
-              class="contributors-button"
-              href="#"
-              @click.prevent="isContributorListVisible = true"
-            >
-              <span class="button-text">...</span>
-            </button>
-          </template>
-
           <div
-            v-for="(contributor, idx) in datasetContributorsList"
+            v-for="(contributor, idx) in datasetContributors"
             :key="contributor.id"
             class="contributor-item-wrap"
           >
             <contributor-item :contributor="contributor" />
-            <template v-if="idx < datasetContributorsList.length - 1">
+            <template v-if="idx < datasetContributors.length - 1">
               ,
             </template>
           </div>
@@ -474,7 +463,6 @@ export default {
       activeTab: this.$route.query.tab ? this.$route.query.tab : 'description',
       datasetRecords: [],
       discover_host: process.env.discover_api_host,
-      isContributorListVisible: true,
       isDownloadModalVisible: false,
       tabs: [],
       breadcrumb: [
@@ -614,16 +602,6 @@ export default {
      */
     datasetContributors: function() {
       return propOr([], 'contributors', this.datasetInfo)
-    },
-    /**
-     * Compute contributors list based
-     * on expanded list being show
-     * @returns {Array}
-     */
-    datasetContributorsList: function() {
-      return this.isContributorListVisible
-        ? this.datasetContributors
-        : [last(this.datasetContributors)]
     },
 
     /**
@@ -812,15 +790,6 @@ export default {
     datasetInfo: {
       handler: function() {
         this.getMarkdown()
-      },
-      immediate: true
-    },
-
-    datasetContributors: {
-      handler: function(val) {
-        if (val.length > 15) {
-          this.isContributorListVisible = false
-        }
       },
       immediate: true
     },


### PR DESCRIPTION
# Description

Responding to https://www.wrike.com/workspace.htm?acc=3203588#/task-view?id=467396116&pid=416152743&cid=415614298 now contributors list always shows in its full length. Before, if the list had more than 15 contributors, only the first and last were shown, together with button to show all of them.


## Type of change

- [x] New feature (non-breaking change which adds functionality)

# How Has This Been Tested?

Manually tested


# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added unit tests that prove my fix is effective or that my feature works
