### PR TITLE
Fixed typo in devices id

### DIFF
--- a/components/FacetMenu/ToolsAndResourcesFacetMenu.vue
+++ b/components/FacetMenu/ToolsAndResourcesFacetMenu.vue
@@ -32,9 +32,9 @@ const typesCategory = {
   children: [
     {
       label: 'Devices',
-      id: 'Device',
+      id: 'Devices',
       children: [],
-      key: 'Device'
+      key: 'Devices'
     },
     {
       label: 'Data and Models',


### PR DESCRIPTION
# Description

Bug fix for tools and resources facet menu. Not displaying devices results bc I forgot the 's'

## Type of change

Delete those that don't apply.

- [X] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

Verified locally

# Checklist:

- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my own code
- [X] I have commented my code, particularly in hard-to-understand areas
- [] I have added unit tests that prove my fix is effective or that my feature works
