### PR TITLE
Added Community Spotlight to News Facet Menu

### DIFF
--- a/components/FacetMenu/NewsAndEventsFacetMenu.vue
+++ b/components/FacetMenu/NewsAndEventsFacetMenu.vue
@@ -43,11 +43,18 @@ import FacetRadioButtonDateCategory from './FacetRadioButtonDateCategory.vue'
 const options = [
   {
     label: 'news',
-    id: 'news'
+    id: 'news',
+    sortOrder: '-fields.publishedDate'
   },
   {
     label: 'events',
-    id: 'event'
+    id: 'event',
+    sortOrder: '-fields.startDate'
+  },
+  {
+    label: 'community spotlight',
+    id: 'successStoryDisplay',
+    sortOrder: '-fields.storyTitle'
   }
 ]
 
@@ -99,6 +106,9 @@ export default {
           return []
         }
         facet.label = `${this.eventDateOption} ${this.eventMonth} ${this.eventYear}`
+      }
+      else if (this.newsAndEventsType === options[2].id) {
+        return []
       }
       facet.id = this.newsAndEventsType
       return [facet]
@@ -252,6 +262,11 @@ export default {
     },
     getSelectedType() {
       return this.newsAndEventsType
+    },
+    getSortOrder() {
+      return options.find(option => {
+        return option.id === this.newsAndEventsType
+      }).sortOrder
     },
     deselectAllFacets() {
       this.$router.replace(

--- a/components/SearchResults/NewsAndEventsSearchResults.vue
+++ b/components/SearchResults/NewsAndEventsSearchResults.vue
@@ -4,11 +4,16 @@
       v-if="this.$route.query.newsAndEventsType === 'event'"
       :table-data="tableData"
     />
+    <community-spotlight-listings 
+      v-else-if="this.$route.query.newsAndEventsType === 'successStoryDisplay'" 
+      :stories="tableData" 
+    />
     <news-search-results v-else :table-data="tableData" />
   </div>
 </template>
 
 <script>
+import CommunitySpotlightListings from '../CommunitySpotlight/CommunitySpotlightListings.vue'
 import NewsSearchResults from './NewsSearchResults.vue'
 import EventSearchResults from './EventSearchResults.vue'
 
@@ -16,6 +21,7 @@ export default {
   name: 'NewsAndEventsSearchResults',
 
   components: {
+    CommunitySpotlightListings,
     NewsSearchResults,
     EventSearchResults
   },

--- a/pages/data/index.vue
+++ b/pages/data/index.vue
@@ -543,7 +543,7 @@ export default {
         newsPublishedGreaterThanOrEqualToDate = this.$refs.newsAndEventsFacetMenu?.getPublishedGreaterThanOrEqualToDate();
         eventStartLessThanDate = this.$refs.newsAndEventsFacetMenu?.getEventsLessThanDate();
         eventStartGreaterThanOrEqualToDate = this.$refs.newsAndEventsFacetMenu?.getEventsGreaterThanOrEqualToDate();
-        sortOrder = contentType === process.env.ctf_news_id ? '-fields.publishedDate' : '-fields.startDate';
+        sortOrder = this.$refs.newsAndEventsFacetMenu?.getSortOrder();
       }
       if (this.$route.query.type === process.env.ctf_resource_id) {
         resourceTypes = this.$route.query.resourceTypes;


### PR DESCRIPTION
# Description

Added the community spotlight option to the news and events facet menu as shown in the wireframes:
https://app.abstract.com/share/ca9ac8ee-68b2-4422-b0d7-55a61c0bb403?collectionId=aac5183e-7ed8-469a-9d73-7e39036ce2ef&collectionLayerId=2ec2f953-7a67-4690-8417-994b7d9b7e3d&present=true&preview=false&sha=deb221da2686562e2063344b84eaa2807aba5346

I realized that I forgot to add this option when first implementing this facet menu

## Type of change

Delete those that don't apply.

- [X] New feature (non-breaking change which adds functionality)

# How Has This Been Tested?

Verified locally that the one published listing is shown

# Checklist:

- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my own code
- [X] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added unit tests that prove my fix is effective or that my feature works
