### PR TITLE
Fix first published date using the wrong date

### DIFF
--- a/components/VersionHistory/VersionHistory.vue
+++ b/components/VersionHistory/VersionHistory.vue
@@ -3,8 +3,8 @@
     :visible="visible"
     :show-close="false"
     class="version-history-dialog"
-    width="772px"
-    height="360px"
+    width="48.25em"
+    height="22.5em"
     @close="closeDialog"
   >
     <bf-dialog-header slot="title" title="Version History" />
@@ -114,8 +114,8 @@ export default {
 <style lang="scss" scoped>
 .version-history-dialog {
   .version-history-container {
-    height: 320px;
-    width: calc(100% - 1px);
+    height: 20em;
+    width: 100%;
     font-size: 0.875rem;
     line-height: 1rem;
 

--- a/components/VersionHistory/VersionHistory.vue
+++ b/components/VersionHistory/VersionHistory.vue
@@ -4,20 +4,23 @@
     :show-close="false"
     class="version-history-dialog"
     width="772px"
-    height="600px"
+    height="360px"
     @close="closeDialog"
   >
     <bf-dialog-header slot="title" title="Version History" />
 
     <div class="version-history-container">
       <el-row class="table-header" type="flex" justify="center">
-        <el-col :span="6">
+        <el-col :span="4" :pull="1">
           Version
         </el-col>
-        <el-col :span="6">
-          Date Published
+        <el-col :span="4">
+          Revisions
         </el-col>
-        <el-col :span="10" :push="2">
+        <el-col :span="4">
+          Date 
+        </el-col>
+        <el-col :span="8" :push="2">
           DOI
         </el-col>
       </el-row>
@@ -28,7 +31,7 @@
         type="flex"
         justify="center"
       >
-        <el-col :span="6">
+        <el-col :span="4" :pull="1">
           <router-link
             :to="{
               name: 'version',
@@ -45,10 +48,13 @@
             Version {{ version.version }}
           </router-link>
         </el-col>
-        <el-col :span="6">
+        <el-col :span="4">
+          {{ version.revision ? version.revision : '-' }}
+        </el-col>
+        <el-col :span="4">
           {{ formatDate(version.createdAt) }}
         </el-col>
-        <el-col :span="10" :push="2">
+        <el-col :span="8" :push="2">
           {{ version.doi }}
         </el-col>
       </el-row>
@@ -91,7 +97,6 @@ export default {
       default: () => []
     }
   },
-
   methods: {
     /**
      * Closes the dialog
@@ -109,7 +114,8 @@ export default {
 <style lang="scss" scoped>
 .version-history-dialog {
   .version-history-container {
-    height: 290px;
+    height: 320px;
+    width: calc(100% - 1px);
     font-size: 0.875rem;
     line-height: 1rem;
 
@@ -138,8 +144,6 @@ export default {
   }
 
   ::v-deep .el-dialog {
-    width: 616px !important;
-    height: 350px;
     .el-dialog__header {
       background-color: #f1f1f3;
       padding-top: 1rem;

--- a/pages/datasets/_datasetId.vue
+++ b/pages/datasets/_datasetId.vue
@@ -658,7 +658,7 @@ export default {
      * @return {String}
      */
     originallyPublishedDate: function() {
-      const date = propOr('', 'createdAt', this.datasetInfo)
+      const date = propOr('', 'firstPublishedAt', this.datasetInfo)
       return this.formatDate(date)
     },
 


### PR DESCRIPTION
# Description

Wrike ticket for this sprint 14 ticket can be found here:
https://www.wrike.com/open.htm?id=579586850

Details of changes:

#### Revisions added to the version history pop up. 
View at: https://sparc-pub-date-fix.herokuapp.com/datasets/29?type=dataset
![image](https://user-images.githubusercontent.com/37255664/136119495-9a98b7b1-a484-48e1-83ce-8b3d8f185141.png)

#### Original publish date corrected
View at: https://sparc-pub-date-fix.herokuapp.com/datasets/32?type=dataset
![image](https://user-images.githubusercontent.com/37255664/136120027-504d2541-3874-40fa-9bcb-c28947254a73.png)


## Type of change

Delete those that don't apply.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

# How Has This Been Tested?

Tested locally and can be viewed at:
https://sparc-pub-date-fix.herokuapp.com/


# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added unit tests that prove my fix is effective or that my feature works
