### PR TITLE
Better support for permalinks of the map page

### DIFF
--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
   "dependencies": {
     "@abi-software/flatmapvuer": "0.2.3-fixes-3",
     "@abi-software/gallery": "^0.2.1",
-    "@abi-software/mapintegratedvuer": "0.2.3",
+    "@abi-software/mapintegratedvuer": "0.2.3-fixes-1",
     "@abi-software/plotvuer": "^0.3.0",
     "@abi-software/scaffoldvuer": "0.1.49",
     "@miyaoka/nuxt-twitter-widgets-module": "^0.0.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -72,10 +72,10 @@
     element-ui "^2.13.0"
     vue "^2.6.10"
 
-"@abi-software/mapintegratedvuer@0.2.3":
-  version "0.2.3"
-  resolved "https://registry.yarnpkg.com/@abi-software/mapintegratedvuer/-/mapintegratedvuer-0.2.3.tgz#32baf8827645ae79c362d9572529b7595d4defe6"
-  integrity sha512-HM0UdyC9A1j8Dbp7w0W66gBHz2b5DwDrgLCPhxUux3WddM7ftmKTyVN58wW+nw4JU0NkEbTDC4t4/SkA3Wmj4A==
+"@abi-software/mapintegratedvuer@0.2.3-fixes-1":
+  version "0.2.3-fixes-1"
+  resolved "https://registry.yarnpkg.com/@abi-software/mapintegratedvuer/-/mapintegratedvuer-0.2.3-fixes-1.tgz#30ca76026cc78274ca1fbb52a5bb7a293c6092da"
+  integrity sha512-qdsCwDxpIXC+q55ZxnRFkg4JC+agohTscIvXMA/EPBDFKg4FHPGWRxgOTdOM7XzDy7MsvsSMdG05COzsqTaKHw==
   dependencies:
     "@abi-software/flatmap-viewer" "^2.1.0-beta.14"
     "@abi-software/flatmapvuer" "^0.2.3-fixes-1"


### PR DESCRIPTION
# Description

This is to fix a bug which was discovered after Team Red has raised a question about the validity of older permalinks on the newer interface.

Details:
Split screen button not active with older permalinks. 

## Type of change

Delete those that don't apply.

- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

Please test it on this [link](https://mapcore-demo.org/current/sparc-app/maps/?id=112fc346), it was used for testing when permalink was first implemented and introduced to the SPARC app.

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas

