### PR TITLE
Updated show facet menu property

### DIFF
--- a/components/FacetMenu/SparcInfoFacetMenu.vue
+++ b/components/FacetMenu/SparcInfoFacetMenu.vue
@@ -143,7 +143,7 @@ export default {
       hasDatasetsCategory: hasDatasetsCategory,
       hasModelSimulationCategory: hasModelSimulationCategory,
       defaultCheckedKeys: [],
-      showFacetMenu: process.env.show_facet_menu
+      showFacetMenu: (process.env.show_facet_menu == 'true') ? true : false,
     }
   },
 


### PR DESCRIPTION
# Description

Was wrongly assuming env var value would get cast to a boolean. This was resulting in the sparc info facet menu categories getting shown in prod

## Type of change

Delete those that don't apply.

- [X] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

Ran locally and changed my local env var

# Checklist:

- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my own code
- [X] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added unit tests that prove my fix is effective or that my feature works
