### PR TITLE
Set max_old_space_size in Procfile.

### DIFF
--- a/Procfile
+++ b/Procfile
@@ -1,1 +1,1 @@
-web: nuxt start
+web: NODE_OPTIONS=--max_old_space_size=460 nuxt start


### PR DESCRIPTION
# Description

Set max_old_space_size when running nuxt start for heroku.

## Type of change

Delete those that don't apply.

- [ ] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

Deployed and tested here - https://alan-wu-sparc-app.herokuapp.com/datasets/imageviewer?dataset_id=20&dataset_version=3&file_path=source%2FDSC_0039.jpg&mimetype=image%2Fjpeg
The image previously crashing the site is working and the built was working as well.

