### PR TITLE
Modified "Databases" to "Data and Models" in SPARC Resource contentType

### DIFF
--- a/components/FacetMenu/ToolsAndResourcesFacetMenu.vue
+++ b/components/FacetMenu/ToolsAndResourcesFacetMenu.vue
@@ -42,10 +42,10 @@ const typesCategory = {
     },
     {
       label: 'Data and Models',
-      id: 'Databases',
+      id: 'Data and Models',
       children: [],
       facetPropPath: 'type',
-      key: 'Databases'
+      key: 'Data and Models'
     },
     {
       label: 'Information Services',

--- a/pages/resources/model.ts
+++ b/pages/resources/model.ts
@@ -38,7 +38,7 @@ export interface Methods {
 export type ResourcesComponent = Data & Computed & Methods & { $route: Route, $router: VueRouter }
 
 
-type ResourceType = 'Devices' | 'Information Services' | 'Databases' | 'Software' | 'Biologicals' | 'sparcPartners'
+type ResourceType = 'Devices' | 'Information Services' | 'Data and Models' | 'Software' | 'Biologicals' | 'sparcPartners'
 
 interface TabType {
   label: string,


### PR DESCRIPTION
# Description

closes https://www.wrike.com/open.htm?id=773974064

**IMPORTANT**: All changed ``SPARC Resource``s will need to be published for this to work in production. They must be published in Contentful once this is merged to production. The affected ones are all the Resource that previously had "Databases" among their ``resourceType``s

This PR merges the changes in the frontend code to use the changes made in Contentful.

The changes is in Contentful:
* All ``resourceType``s were migrated to include "Data and Models" instead of Databases.
```javascript
module.exports = function (migration) {
  migration.transformEntries({
    contentType: 'sparcPartners',
    from: ['resourceType'],
    to: ['resourceType'],
    transformEntryForLocale: async (from, locale) => {
      if (from.resourceType) {
        const before = from.resourceType[locale]
        if (before.includes('Databases')) {
          const index = before.indexOf('Databases')
          after = [...before.slice(0, index), 'Data and Models', ...before.slice(index + 1)]
          return { resourceType: after }
        }
      }
    }
  })
}
```
* Validation of this field changed to disallow "Databases" and allow "Data and Models".
* Explanatory helper text that indicated the equivalence has been removed.


## Type of change

Delete those that don't apply.

- [x] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)

# How Has This Been Tested?

Manual test


# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added unit tests that prove my fix is effective or that my feature works
