### PR TITLE
Truncated URL in Tools&Resources detail page

### DIFF
--- a/pages/resources/_resourceId.vue
+++ b/pages/resources/_resourceId.vue
@@ -23,7 +23,7 @@
         </span>
       </div>
       <h3>URL</h3>
-      <p>
+      <p class="resource-url">
         <a :href="resource.fields.url" target="_blank">
           {{ resource.fields.url }}
         </a>
@@ -140,5 +140,10 @@ export default {
   right: 14px;
   width: fit-content;
   margin-bottom: 10px;
+}
+
+.resource-url {
+  overflow: hidden;
+  text-overflow: ellipsis;
 }
 </style>


### PR DESCRIPTION
# Description

closes https://www.wrike.com/open.htm?id=651174399


## Type of change


- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

Manual test

![Screenshot from 2022-01-06 17-33-56](https://user-images.githubusercontent.com/4764217/148416883-ed5636ce-dbda-46fa-9b02-a9be103b1cf8.png)

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
