### PR TITLE
Fix incorrect sparc api used by generating permalink in the maps page.

### DIFF
--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
   "dependencies": {
     "@abi-software/flatmapvuer": "0.2.4-beta-1",
     "@abi-software/gallery": "^0.2.1",
-    "@abi-software/mapintegratedvuer": "0.2.5",
+    "@abi-software/mapintegratedvuer": "0.2.5-fixes-1",
     "@abi-software/plotvuer": "^0.3.0",
     "@abi-software/scaffoldvuer": "0.1.51",
     "@miyaoka/nuxt-twitter-widgets-module": "^0.0.1",

--- a/pages/maps/index.vue
+++ b/pages/maps/index.vue
@@ -44,7 +44,7 @@ export default {
     if (this.uuid != this.$route.query.id) {
       this.uuid = this.$route.query.id
       if (this.uuid) {
-        let url = this.api + `map/getstate`
+        let url = this.options.sparcApi + `map/getstate`
         await fetch(url, {
           method: 'POST',
           headers: {
@@ -97,7 +97,7 @@ export default {
   },
   methods: {
     updateUUID: function() {
-      let url = this.api + `map/getshareid`
+      let url = this.options.sparcApi + `map/getshareid`
       let state = this.$refs.map.getState()
       fetch(url, {
         method: 'POST',

--- a/yarn.lock
+++ b/yarn.lock
@@ -48,24 +48,24 @@
     element-ui "^2.15.0"
     vue "^2.6.11"
 
-"@abi-software/map-side-bar@^1.1.8":
-  version "1.1.8"
-  resolved "https://registry.yarnpkg.com/@abi-software/map-side-bar/-/map-side-bar-1.1.8.tgz#b599dfc3b0e8c68ba9667ac40329678a8b0185f9"
-  integrity sha512-hBNF41IobE5OTPtYRDz/iCq90xQAK29cAPM84hdHyvRS3YlnOeJID9oDJtLkaB4RvLK6VGeUiOQKD+Tn+ZzNXA==
+"@abi-software/map-side-bar@^1.1.12":
+  version "1.1.12"
+  resolved "https://registry.yarnpkg.com/@abi-software/map-side-bar/-/map-side-bar-1.1.12.tgz#b52d8d17cbc81a806dfa5b1591d5087990010b23"
+  integrity sha512-nNwvjyiLMPI7+Vm6t+QVjjYJhfQLOU2nvYfGndNZyvfTfTaZKkO/ZV2rtXzEv+RoikKJwRJczgAdaH6N6qzjHQ==
   dependencies:
     "@abi-software/svg-sprite" "^0.1.14"
     algoliasearch "^4.10.5"
     element-ui "^2.13.0"
     vue "^2.6.10"
 
-"@abi-software/mapintegratedvuer@0.2.5":
-  version "0.2.5"
-  resolved "https://registry.yarnpkg.com/@abi-software/mapintegratedvuer/-/mapintegratedvuer-0.2.5.tgz#8c54f2191db07010bce8973615c29ce7d1862fa8"
-  integrity sha512-Dw5UeZBpHcy1m//fRkYSj4CdqxiuFDuusZ5WCClkiZnHn+oWWc2cTKP4lhICTkF3BWCtkR3QvofSbSKoze28Lg==
+"@abi-software/mapintegratedvuer@0.2.5-fixes-1":
+  version "0.2.5-fixes-1"
+  resolved "https://registry.yarnpkg.com/@abi-software/mapintegratedvuer/-/mapintegratedvuer-0.2.5-fixes-1.tgz#77133fafe5a84d26d523698180d6e7564cb666a2"
+  integrity sha512-8hbne4zSUC3oD/BnsEj6g1XU4aj70ozS/UgtlStKHBkW9FT38zG6AKMzdMM6Kp2orbf1pmIbu4cOs4Tyio2J3A==
   dependencies:
     "@abi-software/flatmap-viewer" "2.1.0-beta.14"
     "@abi-software/flatmapvuer" "^0.2.4-beta-1"
-    "@abi-software/map-side-bar" "^1.1.8"
+    "@abi-software/map-side-bar" "^1.1.12"
     "@abi-software/plotvuer" "^0.2.41"
     "@abi-software/scaffoldvuer" "^0.1.51"
     "@abi-software/simulationvuer" "^0.4.6"


### PR DESCRIPTION
# Description

This is a fix for a bug causing the permalinks to stop working on the map page.
This also changes the endpoint used by the sidebar, the endpoint used now uses DOI instead of dataset ID to lookup for information.

## Type of change

Delete those that don't apply.

- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

I have ran some tests and it seems to work fine with the fix.
The fix can be tested using this link here - https://mapcore-demo.org/current/sparc-app/maps/?id=ad42b477

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have utilized components from the Design System Library where applicable
- [x] I have added unit tests that prove my fix is effective or that my feature works
