### PR TITLE
Segmentation viewer path correction

### DIFF
--- a/components/ImagesGallery/ImagesGallery.vue
+++ b/components/ImagesGallery/ImagesGallery.vue
@@ -233,7 +233,7 @@ export default {
             ...Array.from(scicrunchData['mbf-segmentation'], segmentation => {
               const id = segmentation.id
               const file_path = segmentation.dataset.path
-              const link = `${baseRoute}datasets/segmentationviewer?dataset_id=${datasetId}&dataset_version=${datasetVersion}&file_path=${file_path}`
+              const link = `${baseRoute}datasets/segmentationviewer?dataset_id=${datasetId}&dataset_version=${datasetVersion}&file_path=files/${file_path}`
 
               this.getSegmentationThumbnail(items, {
                 id,


### PR DESCRIPTION
# Description

The path to the segmentation file is not the full path on AWS this fix corrects that.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

Tested manually with dataset 43.

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added unit tests that prove my fix is effective or that my feature works
