### PR TITLE
Correction for getting segmentation metadata.

### DIFF
--- a/services/discover.js
+++ b/services/discover.js
@@ -43,7 +43,7 @@ const fetchEmbeddedThumbnail = async (id, version, path) => {
 const getSegmentationInfo = async (id, version, path) => {
   const config = {
     params: {
-      dataset_path: `${id}/${version}/files/${path}`
+      dataset_path: `${id}/${version}/${path}`
     }
   }
   return apiClient.get('/segmentation_info', config)


### PR DESCRIPTION
# Description

The parameter to getSegmentationInfo now includes the `files` part of the path.  This PR removes `files` from the formulation of the dataset_path value.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

Manually test with dataset 43.

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have utilized components from the Design System Library where applicable
- [ ] I have added unit tests that prove my fix is effective or that my feature works
