### PR TITLE
Replace uberon and taxon with organ and species

### DIFF
--- a/components/DatasetDetails/SimilarDatasetsInfoBox.vue
+++ b/components/DatasetDetails/SimilarDatasetsInfoBox.vue
@@ -62,6 +62,7 @@ import { propOr} from 'ramda'
 
 import { getAlgoliaFacets, facetPropPathMapping } from '../../pages/data/utils'
 import createAlgoliaClient from '@/plugins/algolia.js'
+import FormatString from '@/mixins/format-string'
 
 const algoliaClient = createAlgoliaClient()
 const algoliaIndex = algoliaClient.initIndex(process.env.ALGOLIA_INDEX)
@@ -69,6 +70,8 @@ const EXPERIMENTAL_APPROACH_LABEL = facetPropPathMapping['item.modalities.keywor
 
 export default {
   name: 'SimilarDatasetsInfoBox',
+
+  mixins: [ FormatString ],
 
   data() {
     return {
@@ -116,9 +119,6 @@ export default {
       })
   },
   methods: {
-    capitalize(text) {
-      return text.charAt(0).toUpperCase() + text.slice(1);
-    },
     getFacetId(datasetFacet) {
       const key = datasetFacet.facetPropPath;
       const label = datasetFacet.label;

--- a/components/FacetMenu/FacetCategory.vue
+++ b/components/FacetMenu/FacetCategory.vue
@@ -45,6 +45,7 @@
 <script>
 import { propOr, pathOr, pluck } from 'ramda'
 import FacetLabel from './FacetLabel.vue'
+import FormatString from '@/mixins/format-string'
 
 const tooltipDelay = 800
 
@@ -52,6 +53,8 @@ export default {
   name: 'FacetCategory',
 
   components: { FacetLabel },
+
+  mixins: [ FormatString ],
 
   props: {
     facet: {
@@ -164,9 +167,6 @@ export default {
       } else {
         this.showAll = true
       }
-    },
-    capitalize(text) {
-      return text.charAt(0).toUpperCase() + text.slice(1);
     },
     onCheckChange: function() {
       this.setShowAll()

--- a/components/ImagesGallery/ImagesGallery.vue
+++ b/components/ImagesGallery/ImagesGallery.vue
@@ -24,6 +24,7 @@
 import biolucida from '@/services/biolucida'
 import discover from '@/services/discover'
 
+import FormatString from '@/mixins/format-string'
 import MarkedMixin from '@/mixins/marked'
 
 import { baseName, extractSection } from '@/utils/common'
@@ -35,7 +36,7 @@ export default {
       ? () => import('@abi-software/gallery').then(gallery => gallery)
       : null
   },
-  mixins: [MarkedMixin],
+  mixins: [FormatString, MarkedMixin],
   props: {
     datasetScicrunch: {
       type: Object,
@@ -211,10 +212,13 @@ export default {
         if ('flatmaps' in scicrunchData) {
           items.push(
             ...Array.from(scicrunchData.flatmaps, f => {
+              let title = f.uberonid
+              if (f.organ)
+                title = this.capitalize(f.organ)
               const linkUrl = `${baseRoute}datasets/flatmapviewer?dataset_version=${datasetVersion}&dataset_id=${datasetId}&taxo=${f.taxo}&uberonid=${f.uberonid}`
               const item = {
                 id: f.uberonid,
-                title: f.uberonid,
+                title: title,
                 type: 'Flatmap',
                 thumbnail: null,
                 link: linkUrl

--- a/mixins/format-string/index.js
+++ b/mixins/format-string/index.js
@@ -6,7 +6,6 @@ export default {
      * @param {String} text
      */
     capitalize: function(text) {
-      console.log(text)
       if (text && (typeof text === 'string' || text instanceof String))
         return text.charAt(0).toUpperCase() + text.slice(1)
       return text

--- a/mixins/format-string/index.js
+++ b/mixins/format-string/index.js
@@ -2,7 +2,7 @@
 export default {
   methods: {
     /**
-     * Return the string with the first letter capitalize
+     * Return the string with the first letter capitalized
      * @param {String} text
      */
     capitalize: function(text) {

--- a/mixins/format-string/index.js
+++ b/mixins/format-string/index.js
@@ -1,0 +1,15 @@
+
+export default {
+  methods: {
+    /**
+     * Return the string with the first letter capitalize
+     * @param {String} text
+     */
+    capitalize: function(text) {
+      console.log(text)
+      if (text && (typeof text === 'string' || text instanceof String))
+        return text.charAt(0).toUpperCase() + text.slice(1)
+      return text
+    }
+  }
+}

--- a/pages/datasets/_datasetId.vue
+++ b/pages/datasets/_datasetId.vue
@@ -293,6 +293,7 @@ const getThumbnailData = async (datasetDoi, datasetId, datasetVersion) => {
           }
           flatmapData[i].taxo = Uberons.species['rat']
           flatmapData[i].uberonid = scicrunchData.organs[i].curie
+          flatmapData[i].organ = scicrunchData.organs[i].name
           flatmapData[i].id = datasetId
           flatmapData[i].version = datasetVersion
         }

--- a/pages/datasets/flatmapviewer/_id.vue
+++ b/pages/datasets/flatmapviewer/_id.vue
@@ -32,13 +32,25 @@
             Flatmap
           </div>
         </div>
-        <div class="file-detail">
+        <div class="file-detail" v-if="species">
+          <strong class="file-detail__column">Speices</strong>
+          <div class="file-detail__column">
+            {{ capitalize(species) }}
+          </div>
+        </div>
+        <div class="file-detail" v-else>
           <strong class="file-detail__column">taxo</strong>
           <div class="file-detail__column">
             {{ taxo }}
           </div>
         </div>
-        <div class="file-detail">
+        <div class="file-detail" v-if="organ_name">
+          <strong class="file-detail__column">Organ</strong>
+          <div class="file-detail__column">
+            {{ capitalize(organ_name) }}
+          </div>
+        </div>
+        <div class="file-detail" v-else>
           <strong class="file-detail__column">uberon</strong>
           <div class="file-detail__column">
             {{ uberonid }}
@@ -63,6 +75,10 @@
 
 <script>
 import DetailTabs from '@/components/DetailTabs/DetailTabs.vue'
+import idMaps from '@/static/js/uberon-map.js'
+import scicrunch from '@/services/scicrunch'
+import FormatString from '@/mixins/format-string'
+
 export default {
   name: 'FlatmapViewerPage',
   components: {
@@ -70,6 +86,24 @@ export default {
     FlatmapVuer: process.client
       ? () => import('@abi-software/flatmapvuer').then(m => m.FlatmapVuer)
       : null
+  },
+
+  mixins: [ FormatString ],
+
+  async asyncData({ route }) {
+    //Get the organ name from uberon id
+    const uberonid = route.query.uberonid
+    try {
+      const  organ_name = await scicrunch.getOrganFromUberonId(uberonid)
+      return {
+        organ_name
+      }
+    } catch (e) {
+      // Error caught return empty data.
+    }
+    return {
+      organ_name: undefined,
+    }
   },
   data: () => {
     return {
@@ -91,6 +125,17 @@ export default {
      */
     taxo: function() {
       return this.$route.query.taxo
+    },
+    /**
+     * Get the species name using the static mapping
+     * @returns String
+     */
+    species: function() {
+      for (const [key, value] of Object.entries(idMaps.species)) {
+        if (value === this.$route.query.taxo)
+          return key
+      }
+      return undefined;
     },
     /**
      * Get the uberon id from the query parameter.

--- a/services/scicrunch.js
+++ b/services/scicrunch.js
@@ -6,6 +6,8 @@ const apiClient = axios.create({
   timeout: 10000
 })
 
+let uberonOrganPairs = undefined;
+
 const search = query => {
   return apiClient.get('search/' + query)
 }
@@ -44,11 +46,48 @@ const getCollectionInfo = async id => {
   return apiClient.get('collections/' + id)
 }
 
+/**
+ * Get the uberon organ pairs array.
+ * 
+ * @returns {String} Array containing organ, uberon id pair
+ */
+const getUberonOrganPairs = async () =>{
+  if (uberonOrganPairs)
+    return uberonOrganPairs
+  else {
+    return apiClient.get('get-organ-curies/')
+      .then(res => {
+        uberonOrganPairs = res.data['uberon']['array']
+        return uberonOrganPairs
+      })
+  }
+}
+
+/**
+ * Get the organ name from the uberon id using a 
+ * organ - uberon id map from SciCrunch
+ * @param {id} The uberon id
+ * @returns {String} the organ name
+ */
+const getOrganFromUberonId = async id => {
+  return getUberonOrganPairs()
+    .then(pairs => {
+      if (pairs) {
+        for (let i = 0; i < pairs.length; i++) {
+          if (pairs[i]['id'] === id) {
+            return pairs[i]['name']
+          }
+        }
+      }
+    })
+}
+
 export default {
   getDatasetInfoFromObjectIdentifier,
   getDatasetInfoFromDOI,
   getDatasetInfoFromPennsieveIdentifier,
   search,
   getImageInfo,
-  getCollectionInfo
+  getCollectionInfo,
+  getOrganFromUberonId
 }


### PR DESCRIPTION
# Description

This pull request address the issue specified here - https://www.wrike.com/open.htm?id=745347248/
Uberon and taxon are now displayed as organ and species. The uberon id on the image gallery is now displayed as organ name.
I have added a mixin and services to support the required feature.

## Type of change

Delete those that don't apply.

- [x] New feature (non-breaking change which adds functionality)

# How Has This Been Tested?

This has been tested manually.
This can also be tested in the following page - https://mapcore-demo.org/current/sparc-app/datasets/169?type=dataset&datasetDetailsTab=images
The uberon id should now be organ name on the image gallery.
Click on the flatmap image to go to the Flatmap viewer -> the uberon id and taxon should now be organ and species respecitvely.

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have utilized components from the Design System Library where applicable
- [x] I have added unit tests that prove my fix is effective or that my feature works
