### PR TITLE
o2s2parc replaced by o²S²PARC in Help search

### DIFF
--- a/pages/help/index.vue
+++ b/pages/help/index.vue
@@ -85,7 +85,7 @@ export default Vue.extend<Data, Methods, never, never>({
       this.searchTerms = terms;
       try {
         if (terms) {
-          let query = terms
+          let query = terms.toLowerCase()
           Object.entries(searchQueryReplacements).forEach(([term, replacement]) => query = query.replace(term, replacement))
           const { items } = await client
             .getEntries<HelpDocument>({


### PR DESCRIPTION
# Description

Attemps to close https://www.wrike.com/open.htm?id=661452723

In the Portal's Help page, it allows to see results with the term 'o²S²PARC' when looking for 'o2s2parc' or 'o2S2PARC'.



## Type of change

- [x] New feature (non-breaking change which adds functionality)

# How Has This Been Tested?

Manual
