### PR TITLE
Award number links to the project's page

### DIFF
--- a/components/DatasetDetails/DatasetAboutInfo.vue
+++ b/components/DatasetDetails/DatasetAboutInfo.vue
@@ -21,7 +21,7 @@
       </span>
     </div>
     <hr />
-    <div class="mb-16"><span class="label4">Award: </span>{{awardSparcNumber}}</div>
+    <div class="mb-16"><span class="label4">Award: </span><nuxt-link :to="associatedProjectLink">{{awardSparcNumber}}</nuxt-link></div>
     <hr />
     <div class="mb-16"><span class="label4">Associated project: </span>
       <nuxt-link


### PR DESCRIPTION
# Description

The NIH award number now becomes a link to the funding project's page.


## Type of change

New feature (non-breaking change which adds functionality)

# How Has This Been Tested?

Manual
