### PR TITLE
changed to use anonymous middleware redirect

### DIFF
--- a/middleware/mailchimp.js
+++ b/middleware/mailchimp.js
@@ -1,3 +1,0 @@
-export default ({ redirect }) => {
-  redirect('https:/mailchi.mp/199fe3626d97/signup')
-}

--- a/pages/signup/index.vue
+++ b/pages/signup/index.vue
@@ -1,5 +1,7 @@
 <script>
   export default {
-    middleware: ['mailchimp']
+    middleware({ redirect }) {
+      return redirect('https:/mailchi.mp/199fe3626d97/signup')
+    }
   }
 </script>


### PR DESCRIPTION
# Description

Named middleware was not executing redirect to an external url correctly In development environment eventhough it worked locally. I updated it to use an anonymous middleware instead.

## Type of change

- [X] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

Locally, not sure why the named middleware was not working
