### PR TITLE
call redirect for external url

### DIFF
--- a/pages/signup/index.vue
+++ b/pages/signup/index.vue
@@ -1,7 +1,8 @@
 <script>
-  export default {
-    middleware({ redirect }) {
-      return redirect('https:/mailchi.mp/199fe3626d97/signup')
-    }
+export default {
+  asyncData(context) {
+    context.redirect("https:/mailchi.mp/199fe3626d97/signup");
+    return {};
   }
+};
 </script>


### PR DESCRIPTION
# Description

Another attempt to redirect to an external link. Apparently vue router only lets you redirect to relative routes so you have to use window.location.href. However, there is no where to access window prior to the page being mounted and shown to the user. This is attempting to redirect in async data before page gets loaded. It works locally, but so did my other attempts at redirecting so we shall see...

## Type of change

- [X] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

Locally