### PR TITLE
made change to external redirect for signup page and added download file button to segmentation viewer

### DIFF
--- a/pages/datasets/biolucidaviewer/_id.vue
+++ b/pages/datasets/biolucidaviewer/_id.vue
@@ -24,7 +24,7 @@
           :query-view="queryView"
         />
       </detail-tabs>
-      <div class="subpage">
+      <div class="subpage pt-0 pb-16">
         <div class="file-detail">
           <strong class="file-detail__column_1">Dataset</strong>
           <div class="file-detail__column_2">

--- a/pages/datasets/segmentationviewer/_id.vue
+++ b/pages/datasets/segmentationviewer/_id.vue
@@ -12,7 +12,7 @@
           :data="segmentationData"
         />
       </detail-tabs>
-      <div class="subpage">
+      <div class="subpage pt-0 pb-16">
         <div class="file-detail">
           <strong class="file-detail__column_1">Dataset</strong>
           <div class="file-detail__column_2">
@@ -88,6 +88,11 @@
             {{ segmentation_info.atlas.organ }}
           </div>
         </div>
+        <div class="pt-16">
+          <bf-button @click="requestDownloadFile(file)">
+            Download file
+          </bf-button>
+        </div>
       </div>
     </div>
   </div>
@@ -100,7 +105,9 @@ import general from '@/services/general'
 
 import SegmentationViewer from '@/components/SegmentationViewer/SegmentationViewer'
 import DetailTabs from '@/components/DetailTabs/DetailTabs.vue'
+import BfButton from '@/components/shared/BfButton/BfButton.vue'
 
+import RequestDownloadFile from '@/mixins/request-download-file'
 import MarkedMixin from '@/mixins/marked'
 
 import { extractSection } from '@/utils/common'
@@ -111,10 +118,11 @@ export default {
 
   components: {
     SegmentationViewer,
-    DetailTabs
+    DetailTabs,
+    BfButton
   },
 
-  mixins: [MarkedMixin],
+  mixins: [MarkedMixin, RequestDownloadFile],
 
   async asyncData({ route, $axios }) {
     const identifier = route.query.dataset_id

--- a/pages/signup/index.vue
+++ b/pages/signup/index.vue
@@ -1,8 +1,19 @@
+<template>
+  <client-only>
+    <div class="main-container">
+      Redirecting you to signup form...
+    </div>
+  </client-only>
+</template>
 <script>
 export default {
-  asyncData(context) {
-    context.redirect("https:/mailchi.mp/199fe3626d97/signup");
-    return {};
-  }
-};
+  mounted() {
+    // It appears the only way to handle vue router redirects to external sites is by setting window.location.href directly, but the window object is only present after
+    // the page has been mounted and is viewable. Thefore we display the redirecting text before redirecting. This issue has been filed many times with Vue:
+    // https://github.com/nuxt/nuxt.js/issues/770, https://github.com/vuejs/vue-router/issues/1280, https://github.com/nuxt/nuxt.js/issues/1082
+    if (process.client) {
+        window.location.href = "https:/mailchi.mp/199fe3626d97/signup";
+    }
+  },
+}
 </script>


### PR DESCRIPTION
# Description

It appears the only way to handle vue router redirects to external sites is by setting window.location.href directly, but the window object is only present after the page has been mounted and is viewable. Therefore we must display the redirecting text before redirecting

## Type of change

- [X] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

Locally
