### PR TITLE
Remove pagination from community spotlight

### DIFF
--- a/pages/news-and-events/community-spotlight/index.vue
+++ b/pages/news-and-events/community-spotlight/index.vue
@@ -13,32 +13,14 @@
       <h2>Success Stories</h2>
       <community-spotlight-listings :stories="shownStories" :bottomLink="true" linkLocation="news-and-events-community-spotlight-success-stories" linkText="View all Success Stories"/>
     </div>
-    <pagination
-      v-if="allStories.length > storiesPageSize"
-      :page-size="storiesPageSize"
-      :total-count="allStories.length"
-      @select-page="storiesPageChange"
-    />
     <div class="page-wrap container">
       <h2>Fireside Chats</h2>
       <community-spotlight-listings :stories="shownChats" :bottomLink="true" linkLocation="news-and-events-community-spotlight-fireside-chats" linkText="View all Fireside Chats"/>
     </div>
-    <pagination
-      v-if="allChats.length > chatsPageSize"
-      :page-size="chatsPageSize"
-      :total-count="allChats.length"
-      @select-page="chatsPageChange"
-    />
     <div class="page-wrap container">
       <h2>Community Announcements</h2>
       <community-announcement-listings :items="shownAnnouncements" :bottomLink="true" linkLocation="news-and-events-community-spotlight-community-announcements" linkText="View all Community Announcements"/>
     </div>
-    <pagination
-      v-if="allAnnouncements.length > announcementsPageSize"
-      :page-size="announcementsPageSize"
-      :total-count="allAnnouncements.length"
-      @select-page="announcementsPageChange"
-    />
   </div>
 </template>
 
@@ -79,43 +61,19 @@ export default {
   },
   computed: {
     shownStories: function() {
-      return this.allStories.slice(
-        (this.storiesPage - 1) * this.storiesPageSize,
-        this.storiesPage * this.storiesPageSize
-      )
+      return this.allStories.slice(0, this.storiesPageSize)
     },
     shownChats: function() {
-      return this.allChats.slice(
-        (this.chatsPage - 1) * this.chatsPageSize,
-        this.chatsPage * this.chatsPageSize
-      )
+      return this.allChats.slice(0, this.chatsPageSize)
     },
     shownAnnouncements: function() {
-      return this.allAnnouncements.slice(
-        (this.announcementsPage - 1) * this.announcementsPageSize,
-        this.announcementsPage * this.announcementsPageSize
-      )
-    },
-  },
-  methods: {
-    storiesPageChange: function(val) {
-      this.storiesPage = val
-    },
-    chatsPageChange: function(val) {
-      this.chatsPage = val
-    },
-    announcementsPageChange: function(val) {
-      this.announcementsPage = val
+      return this.allAnnouncements.slice(0, this.announcementsPageSize)
     }
   },
   data() {
     return {
-      allStories: [],
-      storiesPage: 1,
       storiesPageSize: 5,
-      chatsPage: 1,
       chatsPageSize: 5,
-      announcementsPage: 1,
       announcementsPageSize: 5,
       videoSrc: '',
       isLoadingSearch: false,


### PR DESCRIPTION
# Description

This is a quick fix for the fact that pagination should not be on the `community-spotlight` page.

Details are on this wrike ticket:
https://www.wrike.com/open.htm?id=678413958

A heroku instance of this change is available here:
https://sparc-succcess-stories.herokuapp.com/news-and-events/community-spotlight

## Type of change

Delete those that don't apply.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

# How Has This Been Tested?

Tested locally and available at:
https://sparc-succcess-stories.herokuapp.com/news-and-events/community-spotlight


# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have utilized components from the Design System Library where applicable
- [ ] I have added unit tests that prove my fix is effective or that my feature works
