### PR TITLE
Mail to user from issue reporting form

### DIFF
--- a/components/ContactUsForms/BugForm/BugForm.vue
+++ b/components/ContactUsForms/BugForm/BugForm.vue
@@ -243,7 +243,8 @@ export default {
             <br>${this.form.shouldFollowUp ? 'Yes' : 'No'}
             <br><br>Email
             <br>${this.form.email}
-          `
+          `,
+          userEmail: this.form.shouldFollowUp ? this.form.email : null
         })
         .then(() => {
           if (this.form.shouldSubscribe) {


### PR DESCRIPTION
# Description

Attempts to close https://www.wrike.com/open.htm?id=656177298

An email should be sent to the user also when he requires to follow up in the second form (issue reporting)

Here the front end code is modified so the form's payload includes a field with the user's email.

#### Important: Goes together with https://github.com/nih-sparc/sparc-api/pull/69

## Type of change

- Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

Manual testing


# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have utilized components from the Design System Library where applicable
- [ ] I have added unit tests that prove my fix is effective or that my feature works
