### PR TITLE
default to sparc resources on resource page

### DIFF
--- a/pages/resources/index.vue
+++ b/pages/resources/index.vue
@@ -11,7 +11,7 @@
       <div class="mt-32">
         <p class="tab2" v-html="fields.description" />
         <div class="button-container">
-          <NuxtLink :to="'/data?type=sparcPartners'">
+          <NuxtLink :to="'/data?type=sparcPartners&developedBySparc=true&skip=0'">
             <el-button>Browse Tools &amp; Resources</el-button>
           </NuxtLink>
         </div>


### PR DESCRIPTION
# Description
When a user on the resource page clicks on more resources,
then the "SPARC resource" facet is checked by default.


## Type of change

Delete those that don't apply.

- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?
Locally run, 
Select the button --> verify that facet is checked.

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have utilized components from the Design System Library where applicable
