### PR TITLE
Hotfix: 'resources' searched in header now takes user to 'data' page

### DIFF
--- a/components/header/Header.vue
+++ b/components/header/Header.vue
@@ -373,7 +373,8 @@ export default {
       const option = this.searchSelectOptions.find(
         o => o.value === this.searchSelect
       )
-      const searchKey = option.value === 'data' ? 'q' : 'search'
+      const searchKey =
+        option.value === 'data' || option.value === 'resources' ? 'q' : 'search'
       const type =
         option.value === 'data'
           ? 'dataset'
@@ -381,8 +382,11 @@ export default {
           ? 'sparcPartners'
           : undefined
 
+      // Search the 'data' page for resources
+      const route = option.value === 'resources' ? 'data' : option.value
+
       this.$router.push({
-        name: option.value,
+        name: route,
         query: {
           type,
           [searchKey]: term


### PR DESCRIPTION
# Description

Hotfix to take users to /data from the header search.

Previously users were taken to the 'Tools and Resources' page.

Wrike ticket defining this can be found here:
https://www.wrike.com/open.htm?id=869259065


## Type of change

Delete those that don't apply.

- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

Tested locally. 

Seeing as it is quite a small change I did not create an instance for testing. The lines changed here should hopefully be self explanatory


# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have utilized components from the Design System Library where applicable
- [ ] I have added unit tests that prove my fix is effective or that my feature works
