### PR TITLE
navigation now always selects sparc resource by default

### DIFF
--- a/components/FacetMenu/ToolsAndResourcesFacetMenu.vue
+++ b/components/FacetMenu/ToolsAndResourcesFacetMenu.vue
@@ -17,7 +17,7 @@
     />
     <dropdown-multiselect
       :category="developedBySparcCategory"
-      :default-checked-ids="defaultCheckedIds"
+      :default-checked-ids="selectedDevelopedBySparcIds"
       @selection-change="onDevelopedBySparcChanged"
       ref="developedBySparcCategory"
     />
@@ -81,7 +81,6 @@ export default {
       selectedResourceTypeIds: [],
       selectedDevelopedBySparcIds: [],
       visibleCategories: visibleCategories,
-      defaultCheckedIds: [],
     }
   },
 
@@ -114,11 +113,7 @@ export default {
     if (this.$route.query.resourceTypes) {
       this.selectedResourceTypeIds = this.$route.query.resourceTypes.split(',')
     }
-    if (this.$route.query.developedBySparc) {
-      this.defaultCheckedIds = this.defaultCheckedIds.concat([
-        this.developedBySparcCategory.data[0].id
-      ])
-    }
+    this.selectedDevelopedBySparcIds = ['developedBySparc']
   },
 
   methods: {

--- a/pages/data/index.vue
+++ b/pages/data/index.vue
@@ -77,7 +77,6 @@
               >
                 <tools-and-resources-facet-menu
                   @tool-and-resources-selections-changed="onPaginationPageChange(1)"
-                  @hook:mounted="facetMenuMounted"
                 />
               </el-col>
               <el-col

--- a/pages/resources/index.vue
+++ b/pages/resources/index.vue
@@ -11,7 +11,7 @@
       <div class="mt-32">
         <p class="tab2" v-html="fields.description" />
         <div class="button-container">
-          <NuxtLink :to="'/data?type=sparcPartners&developedBySparc=true&skip=0'">
+          <NuxtLink :to="'/data?type=sparcPartners'">
             <el-button>Browse Tools &amp; Resources</el-button>
           </NuxtLink>
         </div>


### PR DESCRIPTION
# Description

Made changes to always select developed by sparc facet by default when navigating to tools & resources tab. This change will be deployed as a hotfix upon sign off of correct behavior in staging

## Type of change

- [X] New feature (non-breaking change which adds functionality)

# How Has This Been Tested?

Locally
