### PR TITLE
added back query params into nuxt link

### DIFF
--- a/pages/resources/index.vue
+++ b/pages/resources/index.vue
@@ -11,7 +11,7 @@
       <div class="mt-32">
         <p class="tab2" v-html="fields.description" />
         <div class="button-container">
-          <NuxtLink :to="'/data?type=sparcPartners'">
+          <NuxtLink :to="'/data?type=sparcPartners&developedBySparc=true&skip=0'">
             <el-button>Browse Tools &amp; Resources</el-button>
           </NuxtLink>
         </div>


### PR DESCRIPTION
# Description

I thought we no longer needed the params defined in the nuxt link, but Asher found an issue when navigating back and forth between find data > tools and resources and the header tools and resources

## Type of change

- [X] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

Locally
