### PR TITLE
check by default

### DIFF
--- a/components/header/Header.vue
+++ b/components/header/Header.vue
@@ -402,7 +402,8 @@ export default {
           name: 'data',
           query: {
             type,
-            q: term
+            q: term,
+            developedBySparc: true
           }
         }
       }


### PR DESCRIPTION
# Description

Need to take into account checking sparc resource by default when navigating from search bar now that Jesse's changes got merged in

## Type of change

- [X] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

Locally
