### PR TITLE
Scaffold routes hotfix:

### DIFF
--- a/pages/datasets/scaffoldviewer/_id.vue
+++ b/pages/datasets/scaffoldviewer/_id.vue
@@ -89,7 +89,7 @@ import FirstCol from '@/mixins/first-col/index'
 //  Note that modifying routes from Vue does not change the url, only the $route objecti in this component.
 const supportOldRoutes = function(query) {
   if (query.scaffold) {
-    // filename
+    // file_name
     const scaffold = query.scaffold
     let name =
       scaffold.substring(scaffold.lastIndexOf('/') + 1, scaffold.length) ||
@@ -97,13 +97,13 @@ const supportOldRoutes = function(query) {
     let nameWE = name.substring(0, name.lastIndexOf('.')) || name
     query.file_name = nameWE
 
-    // filepath
+    // file_path
     query.file_path = scaffold
 
-    // datasetId
+    // dataset_id
     query.dataset_id = scaffold.substring(0, scaffold.indexOf('/')) || ''
 
-    // version number
+    // version_number
     const postId =
       scaffold.substring(scaffold.indexOf('/') + 1, scaffold.length) || ''
     query.dataset_version = postId.substring(0, postId.indexOf('/')) || ''

--- a/pages/datasets/scaffoldviewer/_id.vue
+++ b/pages/datasets/scaffoldviewer/_id.vue
@@ -84,6 +84,35 @@ import { successMessage, failMessage } from '@/utils/notification-messages'
 
 import FirstCol from '@/mixins/first-col/index'
 
+// supportOldRoutes:
+//  Modifies the incoming $route.query to add the needed query parameters used in the new /scaffoldviewer route.
+//  Note that modifying routes from Vue does not change the url, only the $route objecti in this component.
+const supportOldRoutes = function(query) {
+  if (query.scaffold) {
+    // filename
+    const scaffold = query.scaffold
+    let name =
+      scaffold.substring(scaffold.lastIndexOf('/') + 1, scaffold.length) ||
+      scaffold
+    let nameWE = name.substring(0, name.lastIndexOf('.')) || name
+    query.file_name = nameWE
+
+    // filepath
+    query.file_path = scaffold
+
+    // datasetId
+    query.dataset_id = scaffold.substring(0, scaffold.indexOf('/')) || ''
+
+    // version number
+    const postId =
+      scaffold.substring(scaffold.indexOf('/') + 1, scaffold.length) || ''
+    query.dataset_version = postId.substring(0, postId.indexOf('/')) || ''
+    return query
+  } else {
+    return query
+  }
+}
+
 export default {
   name: 'ScaffoldViewerPage',
 
@@ -97,6 +126,7 @@ export default {
   mixins: [FirstCol],
 
   async asyncData({ route, $axios }) {
+    route.query = supportOldRoutes(route.query)
     const fileUrl = `${process.env.discover_api_host}/datasets/${route.query.dataset_id}/versions/${route.query.dataset_version}/files?path=${route.query.file_path}`
     const file = await $axios.$get(fileUrl)
 
@@ -216,6 +246,9 @@ export default {
     if (lastChar != '/') {
       this.api = this.api + '/'
     }
+  },
+  mounted: function() {
+    supportOldRoutes(this.$route.query)
   },
   methods: {
     copyLink: function() {


### PR DESCRIPTION
 - Scaffold page now supports both the new and old routes
 - old route was being used from the /dataset page before this change.
   This commit does not change that
 - Route parameters are added on mounted

# Description

This fixes the issue where scaffolds were not opening from file browser

This issue happend because the scaffold page's input has been changed from using `@route.query.scaffold` to
`@route.query.dataset_id` , `@route.query.dataset_id`  , and `@route.querey.file_path`

Can see this in this screenshot:
![image](https://user-images.githubusercontent.com/37255664/161466009-39be2271-f294-4954-a6b2-5ad77427627b.png)

The page would still work from the 'filesTable' if these new route queries had been added to the 'filesTables' output, but they don't seem to be there yet. It is still outputing the `scaffold` query parameter as before.

This change allows the old urls to continue working (as they are still in use), and for the new route still to be ready for the new changes once they are made


## Type of change

Delete those that don't apply.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

# How Has This Been Tested?

Ran locally, can make a herokuapp on request


# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have utilized components from the Design System Library where applicable
- [ ] I have added unit tests that prove my fix is effective or that my feature works
