### PR TITLE
Patch for how file is retrieved

### DIFF
--- a/components/FilesTable/FilesTable.vue
+++ b/components/FilesTable/FilesTable.vue
@@ -84,7 +84,7 @@
                           datasetVersion: datasetInfo.version
                         },
                         query: {
-                          path: scope.row.path
+                          path: s3Path(scope.row.path)
                         }
                       }"
                     >
@@ -667,6 +667,11 @@ export default {
       if (a < b) 
          return -1 
       return 0; 
+    },
+    s3Path(path) {
+      // patch for discrepancy between file paths containing spaces and/or commas and the s3 path. s3 paths appear to use underscores instead
+      path = path.replaceAll(' ', '_')
+      return path.replaceAll(',', '_')
     }
   }
 }

--- a/components/ImagesGallery/ImagesGallery.vue
+++ b/components/ImagesGallery/ImagesGallery.vue
@@ -233,7 +233,10 @@ export default {
           items.push(
             ...Array.from(scicrunchData['mbf-segmentation'], segmentation => {
               const id = segmentation.id
-              const file_path = segmentation.dataset.path
+              let file_path = segmentation.dataset.path
+              // patch for discrepancy between file paths containing spaces and/or commas and the s3 path. s3 paths appear to use underscores instead
+              file_path = file_path.replaceAll(' ', '_')
+              file_path = file_path.replaceAll(',', '_')
               const link = `${baseRoute}datasets/segmentationviewer?dataset_id=${datasetId}&dataset_version=${datasetVersion}&file_path=files/${file_path}`
 
               this.getSegmentationThumbnail(items, {


### PR DESCRIPTION
# Description

Updated what pennsieve endpoint is used to retrieve a file from pennsieve for the files/_index route. Running into an issue getting file containing multiple extensions.

Also contains a patch for discrepancy between file paths that contain spaces and/or commas and their corresponding s3 uri

## Type of change

- [X] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

Locally

# Checklist:

- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my own code
- [X] I have commented my code, particularly in hard-to-understand areas
