### PR TITLE
similar fix to retrieve file as made to file table

### DIFF
--- a/mixins/fetch-pennsieve-file/index.js
+++ b/mixins/fetch-pennsieve-file/index.js
@@ -1,0 +1,17 @@
+export default {
+  methods: {
+    /**
+     * Workaround to using pennsieve endpoint https://docs.pennsieve.io/reference/getfile-1 to get the file
+     * we can replace this once the discrepencies between the getFile and browseFiles pennsieve endpoint responses are figured out
+     * for files containing multiple extensions.
+     */
+    fetchPennsieveFile: async function(axios, filePath, datasetId, datasetVersion) {
+      const fileLocationEndIndex = filePath.lastIndexOf('/')
+      const filesLocation = filePath.substring(0, fileLocationEndIndex)
+      const filesUrl = `${process.env.discover_api_host}/datasets/${datasetId}/versions/${datasetVersion}/files/browse?path=${filesLocation}`
+      const filesResponse = await axios.$get(filesUrl)
+      const files = filesResponse.files
+      return files.find(element => filePath === element.path || filePath.includes(element.uri.substring(element.uri.lastIndexOf('/'))))
+    }
+  }
+}

--- a/pages/datasets/biolucidaviewer/_id.vue
+++ b/pages/datasets/biolucidaviewer/_id.vue
@@ -153,8 +153,15 @@ export default {
       return pathOr('', ['dataset', 'path'], biolucidaObject).includes(image_info.name)
     })
     const filePath = `files/${pathOr('', ['dataset', 'path'], biolucidaObject)}`
-    const fileUrl = `${process.env.discover_api_host}/datasets/${route.query.dataset_id}/versions/${route.query.dataset_version}/files?path=${filePath}`
-    const file = await $axios.$get(fileUrl)
+    const fileLocationEndIndex = filePath.lastIndexOf('/')
+    const filesLocation = filePath.substring(0, fileLocationEndIndex)
+    const filesUrl = `${process.env.discover_api_host}/datasets/${route.query.dataset_id}/versions/${route.query.dataset_version}/files/browse?path=${filesLocation}`
+    const response = await $axios.$get(filesUrl)
+    const files = response.files
+    // workaround to using pennsieve endpoint https://docs.pennsieve.io/reference/getfile-1 to get the file
+    // we can replace this once the discrepencies between the getFile and browseFiles pennsieve endpoint responses are figured out
+    // for files containing multiple extensions. i.e. the file pCm165_AAV_05Z_20x_20200212_S2.lsm.jpx found in dataset 221
+    const file = files.find(element => filePath === element.path || filePath.includes(element.uri.substring(element.uri.lastIndexOf('/'))))
 
     return {
       image_info,

--- a/pages/datasets/imageviewer/_id.vue
+++ b/pages/datasets/imageviewer/_id.vue
@@ -78,6 +78,7 @@
 import DetailTabs from '@/components/DetailTabs/DetailTabs.vue'
 import discover from '@/services/discover'
 import BfButton from '@/components/shared/BfButton/BfButton.vue'
+import FetchPennsieveFile from '@/mixins/fetch-pennsieve-file'
 import RequestDownloadFile from '@/mixins/request-download-file'
 
 import { baseName } from '@/utils/common'
@@ -90,7 +91,7 @@ export default {
     BfButton
   },
 
-  mixins: [RequestDownloadFile],
+  mixins: [RequestDownloadFile, FetchPennsieveFile],
 
   async asyncData({ route, $axios }) {
     const response = await discover.fetch(
@@ -108,8 +109,8 @@ export default {
       location: `files/${route.query.file_path}`
     }
 
-    const fileUrl = `${process.env.discover_api_host}/datasets/${route.query.dataset_id}/versions/${route.query.dataset_version}/files?path=${imageInfo.location}`
-    const file = await $axios.$get(fileUrl)
+    const filePath = imageInfo.location
+    const file = await FetchPennsieveFile.methods.fetchPennsieveFile($axios, filePath, route.query.dataset_id, route.query.dataset_version)
 
     return {
       imageInfo,

--- a/pages/datasets/plotviewer/_id.vue
+++ b/pages/datasets/plotviewer/_id.vue
@@ -77,6 +77,7 @@ import discover from '@/services/discover'
 
 import BfButton from '@/components/shared/BfButton/BfButton.vue'
 import RequestDownloadFile from '@/mixins/request-download-file'
+import FetchPennsieveFile from '@/mixins/fetch-pennsieve-file'
 
 export default {
   name: 'PlotViewerPage',
@@ -89,7 +90,7 @@ export default {
       : null
   },
 
-  mixins: [RequestDownloadFile],
+  mixins: [RequestDownloadFile, FetchPennsieveFile],
 
   async asyncData({ route, $axios }) {
     const identifier = route.query.identifier
@@ -111,8 +112,8 @@ export default {
       source_url = `${process.env.portal_api}/s3-resource/${file_path}`
     }
 
-    const fileUrl = `${process.env.discover_api_host}/datasets/${route.query.dataset_id}/versions/${route.query.dataset_version}/files?path=files/${plot_info.dataset.path}`
-    const file = await $axios.$get(fileUrl)
+    const filePath = `files/${plot_info.dataset.path}`
+    const file = await FetchPennsieveFile.methods.fetchPennsieveFile($axios, filePath, route.query.dataset_id, route.query.dataset_version)
 
     const metadata = JSON.parse(
       plot_annotation.supplemental_json_metadata.description

--- a/pages/datasets/scaffoldviewer/_id.vue
+++ b/pages/datasets/scaffoldviewer/_id.vue
@@ -80,6 +80,7 @@
 <script>
 // :scaffold-selected="scaffoldSelected"
 import DetailTabs from '@/components/DetailTabs/DetailTabs.vue'
+import FetchPennsieveFile from '@/mixins/fetch-pennsieve-file'
 import { successMessage, failMessage } from '@/utils/notification-messages'
 
 import FirstCol from '@/mixins/first-col/index'
@@ -94,11 +95,11 @@ export default {
       : null
   },
 
-  mixins: [FirstCol],
+  mixins: [FirstCol, FetchPennsieveFile],
 
   async asyncData({ route, $axios }) {
-    const fileUrl = `${process.env.discover_api_host}/datasets/${route.query.dataset_id}/versions/${route.query.dataset_version}/files?path=${route.query.file_path}`
-    const file = await $axios.$get(fileUrl)
+    const filePath = route.query.file_path
+    const file = await FetchPennsieveFile.methods.fetchPennsieveFile($axios, filePath, route.query.dataset_id, route.query.dataset_version)
 
     return {
       file,

--- a/pages/datasets/segmentationviewer/_id.vue
+++ b/pages/datasets/segmentationviewer/_id.vue
@@ -108,6 +108,7 @@ import DetailTabs from '@/components/DetailTabs/DetailTabs.vue'
 import BfButton from '@/components/shared/BfButton/BfButton.vue'
 
 import RequestDownloadFile from '@/mixins/request-download-file'
+import FetchPennsieveFile from '@/mixins/fetch-pennsieve-file'
 import MarkedMixin from '@/mixins/marked'
 
 import { extractSection } from '@/utils/common'
@@ -122,7 +123,7 @@ export default {
     BfButton
   },
 
-  mixins: [MarkedMixin, RequestDownloadFile],
+  mixins: [MarkedMixin, RequestDownloadFile, FetchPennsieveFile],
 
   async asyncData({ route, $axios }) {
     const identifier = route.query.dataset_id
@@ -153,8 +154,8 @@ export default {
         dataset_info = { readme: '', title: '' }
       }
 
-      const fileUrl = `${process.env.discover_api_host}/datasets/${route.query.dataset_id}/versions/${route.query.dataset_version}/files?path=${route.query.file_path}`
-      const file = await $axios.$get(fileUrl)
+      const filePath = route.query.file_path
+      const file = await FetchPennsieveFile.methods.fetchPennsieveFile($axios, filePath, route.query.dataset_id, route.query.dataset_version)
 
       return {
         segmentation_info,

--- a/pages/datasets/videoviewer/_id.vue
+++ b/pages/datasets/videoviewer/_id.vue
@@ -60,7 +60,6 @@
           <strong class="file-detail__column">Version</strong>
           <div class="file-detail__column">
             {{ versionNumber }}
-            {{fileQueryParam}}
           </div>
         </div>
         <div class="pt-16">
@@ -79,6 +78,7 @@ import Plyr from 'plyr'
 import DetailTabs from '@/components/DetailTabs/DetailTabs.vue'
 import BfButton from '@/components/shared/BfButton/BfButton.vue'
 import RequestDownloadFile from '@/mixins/request-download-file'
+import FetchPennsieveFile from '@/mixins/fetch-pennsieve-file'
 
 export default {
   name: 'VideoViewerPage',
@@ -88,7 +88,7 @@ export default {
     BfButton
   },
 
-  mixins: [RequestDownloadFile],
+  mixins: [RequestDownloadFile, FetchPennsieveFile],
 
   async asyncData({ route, $axios }) {
     let signedUrl = await $axios
@@ -100,8 +100,7 @@ export default {
       })
     let filePath = route.query.file_path
     filePath = filePath.substring(filePath.indexOf("files"))
-    const fileUrl = `${process.env.discover_api_host}/datasets/${route.query.dataset_id}/versions/${route.query.dataset_version}/files?path=${filePath}`
-    const file = await $axios.$get(fileUrl)
+    const file = await FetchPennsieveFile.methods.fetchPennsieveFile($axios, filePath, route.query.dataset_id, route.query.dataset_version)
     return {
       video_src: signedUrl,
       mimetype: route.query.mimetype,

--- a/pages/file/_datasetId/_datasetVersion/index.vue
+++ b/pages/file/_datasetId/_datasetVersion/index.vue
@@ -82,7 +82,7 @@ export default {
     // workaround to using pennsieve endpoint https://docs.pennsieve.io/reference/getfile-1 to get the file
     // we can replace this once the discrepencies between the getFile and browseFiles pennsieve endpoint responses are figured out
     // for files containing multiple extensions. i.e. the file pCm165_AAV_05Z_20x_20200212_S2.lsm.jpx found in dataset 221
-    const file = files.find(element => element.path === route.query.path || element.uri.includes(route.query.path))
+    const file = files.find(element => element.path === route.query.path || route.query.path.includes(element.uri.substring(element.uri.lastIndexOf('/'))))
 
     const sourcePackageId = file.sourcePackageId
     const biolucidaData = await $axios.$get(

--- a/pages/file/_datasetId/_datasetVersion/index.vue
+++ b/pages/file/_datasetId/_datasetVersion/index.vue
@@ -60,6 +60,7 @@ import BfButton from '@/components/shared/BfButton/BfButton.vue'
 
 import BfStorageMetrics from '@/mixins/bf-storage-metrics'
 import FormatDate from '@/mixins/format-date'
+import FetchPennsieveFile from '@/mixins/fetch-pennsieve-file'
 import RequestDownloadFile from '@/mixins/request-download-file'
 
 export default {
@@ -71,18 +72,11 @@ export default {
     BfButton
   },
 
-  mixins: [BfStorageMetrics, FormatDate, RequestDownloadFile],
+  mixins: [BfStorageMetrics, FormatDate, RequestDownloadFile, FetchPennsieveFile],
 
   async asyncData({ route, $axios }) {
-    const fileLocationEndIndex = route.query.path.lastIndexOf('/')
-    const filesLocation = route.query.path.substring(0, fileLocationEndIndex)
-    const filesUrl = `${process.env.discover_api_host}/datasets/${route.params.datasetId}/versions/${route.params.datasetVersion}/files/browse?path=${filesLocation}`
-    const response = await $axios.$get(filesUrl)
-    const files = response.files
-    // workaround to using pennsieve endpoint https://docs.pennsieve.io/reference/getfile-1 to get the file
-    // we can replace this once the discrepencies between the getFile and browseFiles pennsieve endpoint responses are figured out
-    // for files containing multiple extensions. i.e. the file pCm165_AAV_05Z_20x_20200212_S2.lsm.jpx found in dataset 221
-    const file = files.find(element => element.path === route.query.path || route.query.path.includes(element.uri.substring(element.uri.lastIndexOf('/'))))
+    const filePath = route.query.path
+    const file = await FetchPennsieveFile.methods.fetchPennsieveFile($axios, filePath, route.params.datasetId, route.params.datasetVersion)
 
     const sourcePackageId = file.sourcePackageId
     const biolucidaData = await $axios.$get(


### PR DESCRIPTION
# Description

Same fix for accessing file from pennsieve is now being made to the biolucida viewer route accessed via the gallery tab as was made to the route accessed via the files table.

## Type of change

Delete those that don't apply.

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

# How Has This Been Tested?

Locally. You can verify the fix by navigating to dataset 221 and using the gallery to view images

# Checklist:

- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my own code
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] I have utilized components from the Design System Library where applicable
