### PR TITLE
Hot fix scaffold urls

### DIFF
--- a/components/DatasetDetails/DatasetFilesInfo.vue
+++ b/components/DatasetDetails/DatasetFilesInfo.vue
@@ -67,7 +67,7 @@
         </nuxt-link>
       </span>
     </div>
-    <files-table :osparc-viewers="osparcViewers" />
+    <files-table :osparc-viewers="osparcViewers" :dataset-scicrunch="datasetScicrunch"/>
   </div>
 </template>
 
@@ -90,6 +90,10 @@ export default {
 
   props: {
     osparcViewers: {
+      type: Object,
+      default: () => {}
+    },
+    datasetScicrunch: {
       type: Object,
       default: () => {}
     }

--- a/components/FilesTable/FilesTable.vue
+++ b/components/FilesTable/FilesTable.vue
@@ -72,6 +72,14 @@
                     </nuxt-link>
                   </sparc-tooltip>
                 </div>
+                <div v-else-if="isScaffoldViewFile(scope)" class="truncated">
+                  open scaf
+                  <sparc-tooltip placement="left-center" :content="scope.row.name">
+                    <nuxt-link slot="item" class="truncated" :to="getScaffoldViewLink(scope)">
+                      {{ scope.row.name }}
+                    </nuxt-link>
+                  </sparc-tooltip>
+                </div>
                 <div v-else class="truncated">
                   <sparc-tooltip placement="left-center" :content="scope.row.name">
                     <nuxt-link
@@ -157,6 +165,18 @@
                 v-if="isScaffoldMetaFile(scope)"
                 class="circle"
                 @click="openScaffold(scope)"
+              >
+                <sparc-tooltip
+                  placement="bottom-center"
+                  content="Open as 3d scaffold"
+                >
+                  <svg-icon slot="item" name="icon-view" height="1.5rem" width="1.5rem" />
+                </sparc-tooltip>
+              </div>
+              <div
+                v-if="isScaffoldViewFile(scope)"
+                class="circle"
+                @click="openScaffoldView(scope)"
               >
                 <sparc-tooltip
                   placement="bottom-center"
@@ -274,6 +294,8 @@ import { successMessage, failMessage } from '@/utils/notification-messages'
 
 import { extractExtension } from '@/pages/data/utils'
 
+import * as path from 'path'
+
 export const contentTypes = {
   pdf: 'application/pdf',
   text: 'text/plain',
@@ -298,6 +320,12 @@ export default {
     osparcViewers: {
       type: Object,
       default: function() {
+        return {}
+      }
+    },
+    datasetScicrunch: {
+      type: Object,
+      default: () => {
         return {}
       }
     }
@@ -601,6 +629,47 @@ export default {
     },
 
     /**
+     * Create nuxt-link object for opening a scaffold.
+     * @param {Object} scope
+     */
+    getScaffoldViewLink: function(scope) {
+      const id = pathOr('', ['params', 'datasetId'], this.$route)
+      const version = this.datasetVersion
+      if (
+        this.datasetScicrunch &&
+        this.datasetScicrunch['abi-scaffold-view-file']
+      ) {
+        let shortened = scope.row.path
+        shortened = shortened.replace('files/', '')
+        
+
+        // Find the file with a matching name
+        let viewMetadata = this.datasetScicrunch['abi-scaffold-view-file'].filter(
+          viewFile => viewFile.dataset.path === shortened
+        )[0]
+
+        // Find the current directory path. Note that the trailing '/' is included
+        const currentDirectoryPath = scope.row.path.split(scope.row.name)[0]
+
+        // Create paths for fetching the files from 'sparc-api/s3-resource/'
+        const scaffoldPath = `${currentDirectoryPath}${viewMetadata.datacite.isDerivedFrom.path}`
+        const s3Path = `${id}/${version}/${scaffoldPath}`
+
+        // View paths need to be relative
+        const viewPath = path.relative(
+          path.dirname(scaffoldPath),
+          scope.row.path
+        )
+        return {
+          name: 'datasets-scaffoldviewer-id',
+          params: {},
+          query: { scaffold: s3Path, viewURL: viewPath }
+        }
+      }
+      return {}
+    },
+
+    /**
      * Open scaffold
      * @param {Object} scope
      */
@@ -609,16 +678,55 @@ export default {
     },
 
     /**
+     * Open scaffold view file
+     * @param {Object} scope
+     */
+    openScaffoldView: function(scope) {
+      const scaffoldViewLink = this.getScaffoldViewLink(scope)
+      if (scaffoldViewLink) {
+        this.$router.push(scaffoldViewLink)
+      }
+    },
+
+    /**
+     * Checks if file is a scaffold view port
+     * @param {Object} scope
+     */
+    isScaffoldViewFile: function(scope) {
+      if (
+        this.datasetScicrunch &&
+        this.datasetScicrunch['abi-scaffold-view-file']
+      ) {
+        let shortened = scope.row.path
+        shortened = shortened.replace('files/', '')
+        // Filter through the scaffold view files scicrunch has, if a name matches we return true
+        this.datasetScicrunch['abi-scaffold-view-file'].forEach(viewFile => {
+          if (viewFile.dataset.path === shortened) {
+            return true
+          }
+        })
+      }
+      return false
+    },
+    /**
      * Checks if file is openable by scaffold viewer
      * @param {Object} scope
      */
     isScaffoldMetaFile: function(scope) {
-      let path = scope.row.path.toLowerCase()
-      return (
-        path.includes('scaffold') &&
-        path.includes('meta') &&
-        path.includes('json')
-      )
+      if (
+        this.datasetScicrunch &&
+        this.datasetScicrunch['abi-scaffold-metadata-file']
+      ) {
+        let shortened = scope.row.path
+        shortened = shortened.replace('files/', '')
+
+        this.datasetScicrunch['abi-scaffold-metadata-file'].forEach(metaFile => { 
+          if (metaFile.dataset.path === shortened){
+            return true
+          }
+        })
+      }
+      return false
     },
 
     /**

--- a/components/FilesTable/FilesTable.vue
+++ b/components/FilesTable/FilesTable.vue
@@ -73,7 +73,6 @@
                   </sparc-tooltip>
                 </div>
                 <div v-else-if="isScaffoldViewFile(scope)" class="truncated">
-                  open scaf
                   <sparc-tooltip placement="left-center" :content="scope.row.name">
                     <nuxt-link slot="item" class="truncated" :to="getScaffoldViewLink(scope)">
                       {{ scope.row.name }}
@@ -699,12 +698,10 @@ export default {
       ) {
         let shortened = scope.row.path
         shortened = shortened.replace('files/', '')
-        // Filter through the scaffold view files scicrunch has, if a name matches we return true
-        this.datasetScicrunch['abi-scaffold-view-file'].forEach(viewFile => {
-          if (viewFile.dataset.path === shortened) {
+        for ( let i = 0; i < this.datasetScicrunch['abi-scaffold-view-file'].length; i++) {
+          if (this.datasetScicrunch['abi-scaffold-view-file'][i].dataset.path === shortened)
             return true
-          }
-        })
+        }
       }
       return false
     },
@@ -719,12 +716,10 @@ export default {
       ) {
         let shortened = scope.row.path
         shortened = shortened.replace('files/', '')
-
-        this.datasetScicrunch['abi-scaffold-metadata-file'].forEach(metaFile => { 
-          if (metaFile.dataset.path === shortened){
+        for ( let i = 0; i < this.datasetScicrunch['abi-scaffold-metadata-file'].length; i++) {
+          if (this.datasetScicrunch['abi-scaffold-metadata-file'][i].dataset.path === shortened)
             return true
-          }
-        })
+        }
       }
       return false
     },

--- a/pages/datasets/_datasetId.vue
+++ b/pages/datasets/_datasetId.vue
@@ -50,6 +50,7 @@
                   v-if="hasFiles"
                   v-show="activeTabId === 'files'"
                   :osparc-viewers="osparcViewers"
+                  :dataset-scicrunch="scicrunchData"
                 />
                 <images-gallery
                   v-if="hasGalleryImages"


### PR DESCRIPTION
# Description

Hot fix for the files table not opening scaffolds


## Type of change

This is a rework of the scaffold hotfix to reduce the number of requests to `sparc-api`

It passes the scicrunch data from the `/data` page into the `filesTable.vue` to check if files are scaffolds or scaffold views.

- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

Tested locally and this branch can be viewed at:
https://hot-fix-scaffolds.herokuapp.com/datasets/76?datasetDetailsTab=files&path=files%2Fderivative


# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have utilized components from the Design System Library where applicable
- [ ] I have added unit tests that prove my fix is effective or that my feature works
