### PR TITLE
applied case sensitivity fix

### DIFF
--- a/mixins/fetch-pennsieve-file/index.js
+++ b/mixins/fetch-pennsieve-file/index.js
@@ -11,7 +11,8 @@ export default {
       const filesUrl = `${process.env.discover_api_host}/datasets/${datasetId}/versions/${datasetVersion}/files/browse?path=${filesLocation}`
       const filesResponse = await axios.$get(filesUrl)
       const files = filesResponse.files
-      return files.find(element => filePath === element.path || filePath.includes(element.uri.substring(element.uri.lastIndexOf('/'))))
+      filePath = filePath.toLowerCase()
+      return files.find(element => filePath === element.path.toLowerCase() || filePath.includes(element.uri.substring(element.uri.lastIndexOf('/')).toLowerCase()))
     }
   }
 }


### PR DESCRIPTION
# Description

Some files paths letter casing does not match their s3 uri path and it is causing errors when finding the file

## Type of change

- [X] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

Locally. You can verify with:

localhost:3000/datasets/biolucidaviewer/1989?view=MTk4OS1jb2wtMTI3&dataset_version=3&dataset_id=77&item_id=N%3Apackage%3A4988880f-edf3-4b4d-b630-abaf5389b02a

# Checklist:

- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my own code
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] I have utilized components from the Design System Library where applicable
