### PR TITLE
Fix for scicrunch now using an array on 'isDerivedFrom.path'. (Previously broke scaffold views in FilesTable)

### DIFF
--- a/components/FilesTable/FilesTable.vue
+++ b/components/FilesTable/FilesTable.vue
@@ -650,7 +650,7 @@ export default {
         const currentDirectoryPath = scope.row.path.split(scope.row.name)[0]
 
         // Create paths for fetching the files from 'sparc-api/s3-resource/'
-        const scaffoldPath = `${currentDirectoryPath}${viewMetadata.datacite.isDerivedFrom.path}`
+        const scaffoldPath = `${currentDirectoryPath}${viewMetadata.datacite.isDerivedFrom.relative.path[0]}`
         const s3Path = `${id}/${version}/${scaffoldPath}`
 
         // View paths need to be relative


### PR DESCRIPTION
# Description

Scaffold views broke when scicrunch switched to using an array for 'isDerivedFrom.path'

This PR fixes the scaffold views in the filesTable

## Type of change

Delete those that don't apply.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration


# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have utilized components from the Design System Library where applicable
- [ ] I have added unit tests that prove my fix is effective or that my feature works
