### PR TITLE
Rename the 'citation-info' component to 'references'

### DIFF
--- a/components/DatasetDetails/DatasetHeader.vue
+++ b/components/DatasetDetails/DatasetHeader.vue
@@ -222,7 +222,7 @@ export default {
     },
     numCitationsClicked: function() {
       this.$router.replace({
-        query: { ...this.$route.query, datasetDetailsTab: 'citations' }
+        query: { ...this.$route.query, datasetDetailsTab: 'references' }
       }).finally(() => {
         this.scrollToDatasetDetailsTabArea()
       })

--- a/components/DatasetDetails/DatasetReferences.vue
+++ b/components/DatasetDetails/DatasetReferences.vue
@@ -1,5 +1,5 @@
 <template>
-  <div class="dataset-citations-info">
+  <div class="dataset-references">
     <div v-if="primaryPublications">
       <div class="heading2 mb-8">
         Primary Publications for this Dataset
@@ -37,7 +37,7 @@ import { isEmpty } from 'ramda'
 const PREPRINT_DOI_LINKS = ['https://doi.org/10.1101/']
 
 export default {
-  name: 'DatasetCitationsInfo',
+  name: 'DatasetReferences',
 
   components: {
     ApaCitation
@@ -45,11 +45,11 @@ export default {
   props: {
     primaryPublications: {
       type: Array,
-      default: []
+      default: () => []
     },
     associatedPublications: {
       type: Array,
-      default: []
+      default: () => []
     },
   },
   computed: {
@@ -59,8 +59,7 @@ export default {
       allPublications = this.associatedPublications ? allPublications.concat(this.associatedPublications) : allPublications
       allPublications.forEach(publication => {
         const publicationDoiLink = `https://doi.org/${publication.doi}`
-        if(PREPRINT_DOI_LINKS.some(preprintDoiLink => publicationDoiLink.includes(preprintDoiLink)))
-        {
+        if(PREPRINT_DOI_LINKS.some(preprintDoiLink => publicationDoiLink.includes(preprintDoiLink))){
           preprintPublications.push(publication)
         }
       })
@@ -71,7 +70,7 @@ export default {
 </script>
 
 <style lang="scss" scoped>
-.dataset-citations-info {
+.dataset-references {
   hr {
     margin-top: 1rem;
     border-top: none;

--- a/pages/datasets/_datasetId.vue
+++ b/pages/datasets/_datasetId.vue
@@ -58,9 +58,9 @@
                   :dataset-biolucida="biolucidaImageData"
                   :dataset-scicrunch="scicrunchData"
                 />
-                <dataset-citations-info
+                <dataset-references
                   v-if="hasCitations"
-                  v-show="activeTabId === 'citations'"
+                  v-show="activeTabId === 'references'"
                   :primary-publications="primaryPublications"
                   :associated-publications="associatedPublications"
                 />
@@ -96,7 +96,7 @@ import DatasetActionBox from '@/components/DatasetDetails/DatasetActionBox.vue'
 import Breadcrumb from '@/components/Breadcrumb/Breadcrumb'
 import CitationDetails from '@/components/CitationDetails/CitationDetails.vue'
 import DatasetAboutInfo from '@/components/DatasetDetails/DatasetAboutInfo.vue'
-import DatasetCitationsInfo from '@/components/DatasetDetails/DatasetCitationsInfo.vue'
+import DatasetReferences from '~/components/DatasetDetails/DatasetReferences.vue'
 import DatasetDescriptionInfo from '@/components/DatasetDetails/DatasetDescriptionInfo.vue'
 import DatasetFilesInfo from '@/components/DatasetDetails/DatasetFilesInfo.vue'
 import SimilarDatasetsInfoBox from '@/components/DatasetDetails/SimilarDatasetsInfoBox.vue'
@@ -331,7 +331,7 @@ export default {
     DatasetHeader,
     DatasetActionBox,
     CitationDetails,
-    DatasetCitationsInfo,
+    DatasetReferences,
     DatasetAboutInfo,
     DatasetDescriptionInfo,
     DatasetFilesInfo,
@@ -713,9 +713,9 @@ export default {
     hasCitations: {
       handler: function(newValue) {
         if (newValue) {
-          const hasCitationsTab = this.tabs.find(tab => tab.id === 'citations') !== undefined
+          const hasCitationsTab = this.tabs.find(tab => tab.id === 'references') !== undefined
           if (!hasCitationsTab) {
-            this.tabs.splice(5, 0, { label: 'References', id: 'citations' })
+            this.tabs.splice(5, 0, { label: 'References', id: 'references' })
           }
         }
       },


### PR DESCRIPTION

# Description

Rename the 'citation-info' Vue component to 'references'

This is done to have consistency with the fact that this tab now relates
to references, not citations.

It also changes the url route required to get to the 'references' tab.
(Previously this url route was 'citations'). In example: 
https://staging.sparc.science/datasets/231?type=dataset&datasetDetailsTab=citations


## Type of change

Delete those that don't apply.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

# How Has This Been Tested?

Can test this branch at:
https://jesse-sprint-19.herokuapp.com/datasets/231?type=dataset&datasetDetailsTab=references


# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have utilized components from the Design System Library where applicable
- [ ] I have added unit tests that prove my fix is effective or that my feature works
