### PR TITLE
Click on thumbnails/titles bring users to external links on T/R page.

### DIFF
--- a/components/Resources/FeaturedResource.vue
+++ b/components/Resources/FeaturedResource.vue
@@ -2,7 +2,15 @@
   <div class="featured-resource">
     <div v-if="thumbnailUrl !== null" class="thumbnail">
       <div class="image-container">
-        <div class="image-border">
+        <a
+          v-if="externalUrl"
+          class="image-border"
+          :href="externalUrl"
+          target="_blank"
+        >
+          <img :src="thumbnailUrl" />
+        </a>
+        <div v-else class="image-border">
           <img :src="thumbnailUrl" />
         </div>
       </div>
@@ -10,7 +18,12 @@
     <div class="resource-info">
       <div>
         <div class="header">
-          <h3>{{ title }}</h3>
+          <h3 v-if="externalUrl">
+            <a :href="externalUrl" target="_blank">
+              {{ title }}
+            </a>
+          </h3>
+          <h3 v-else >{{ title }}</h3>
           <sparc-pill v-if="tag !== null">
             {{ tag }}
           </sparc-pill>
@@ -62,7 +75,11 @@ export default {
     thumbnailUrl: {
       type: String,
       default: null
-    }
+    },
+    externalUrl: {
+      type: String,
+      default: null
+    },
   }
 }
 </script>

--- a/pages/resources/index.vue
+++ b/pages/resources/index.vue
@@ -27,8 +27,9 @@
             :subtitle="resource.fields.resourceType.join(', ')"
             :tag="'SPARC'"
             :description="resource.fields.description"
-            :thumbnailUrl="resource.fields.logo.fields.file.url"
-            :buttonLink="`/resources/${resource.sys.id}`"
+            :thumbnail-url="resource.fields.logo.fields.file.url"
+            :button-link="`/resources/${resource.sys.id}`"
+            :external-url="resource.fields.url"
           />
         </div>
       </div>


### PR DESCRIPTION
# Description

This pull request address the issue reported here - https://www.wrike.com/open.htm?id=689977061
Clicking on the thumbnails / titles now take users  directly to the external resources without going through the details page.

## Type of change

Delete those that don't apply.

- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

This has been tested manually and here - https://mapcore-demo.org/staging/sparc-integrated-features/resources
Please note that the "View resource" button above will not work on the link above but it should not be a problem on staging and production site.


# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [x] I have utilized components from the Design System Library where applicable
- [ ] I have added unit tests that prove my fix is effective or that my feature works
