### PR TITLE
Imagine Gallery: Use rat flatmap when other flatmaps are not available

### DIFF
--- a/components/CitationDetails/CitationDetails.vue
+++ b/components/CitationDetails/CitationDetails.vue
@@ -4,15 +4,16 @@
       Dataset Citation
     </div>
     <body>
-      To promote reproducibility and give credit to SPARC investigators who
-      publish their data, we recommend citing your usage of SPARC datasets.
-      To make it easy, the SPARC Portal provides the full data citation, including
-      the option of different formats, under the Cite tab of each dataset page. 
-      For more Information, please see our 
-      <a href="https://sparc.science/help/1lmX4FWezRPTCOfGsBATnt"
+      To promote reproducibility and give credit to investigators who publish
+      their data, we recommend citing your usage of SPARC datasets. To make it
+      easy, the SPARC Portal provides the full data citation, including the
+      option of different formats, under the Cite tab of each dataset page. For
+      more Information, please see our
+      <a
+        href="https://sparc.science/help/1lmX4FWezRPTCOfGsBATnt"
         target="_blank"
       >
-        Help page
+        Help page.
       </a>
     </body>
     <br />

--- a/components/CitationDetails/CitationDetails.vue
+++ b/components/CitationDetails/CitationDetails.vue
@@ -13,8 +13,9 @@
         href="https://sparc.science/help/1lmX4FWezRPTCOfGsBATnt"
         target="_blank"
       >
-        Help page.
+        Help page
       </a>
+      .
     </body>
     <br />
     <div v-for="citationType in citationTypes" :key="citationType.type">

--- a/components/ImagesGallery/ImagesGallery.vue
+++ b/components/ImagesGallery/ImagesGallery.vue
@@ -219,7 +219,7 @@ export default {
               let title = f.uberonid ? f.uberonid : null
               if (f.organ) title = this.capitalize(f.organ)
 
-              const linkUrl = `${baseRoute}datasets/flatmapviewer?dataset_version=${datasetVersion}&dataset_id=${datasetId}&taxo=${f.taxo}&uberonid=${f.uberonid}`
+              const linkUrl = `${baseRoute}datasets/flatmapviewer?dataset_version=${datasetVersion}&dataset_id=${datasetId}&taxo=${f.taxo}&uberonid=${f.uberonid}&for_species=${f.species}&organ=${f.organ}`
               const item = {
                 id: f.uberonid,
                 title: title,

--- a/pages/datasets/_datasetId.vue
+++ b/pages/datasets/_datasetId.vue
@@ -294,7 +294,7 @@ const getThumbnailData = async (datasetDoi, datasetId, datasetVersion, datasetFa
           if (speciesArray && speciesArray.length > 0)
             species = speciesArray[0].children[0].label.toLowerCase()
         }
-        
+
         // check if there is a flatmap for the given species
         let taxo = species && species in Uberons.species ? Uberons.species[species] : undefined
 
@@ -302,20 +302,16 @@ const getThumbnailData = async (datasetDoi, datasetId, datasetVersion, datasetFa
         // if a flatmap of (species) has (anatomy)
         let foundAnatomy = []
         if (scicrunchData.organs[0]) { // Check if dataset has organ annotation
-          let data = {}
-          // If we do not have a flatmap for the species, check the rat flatmap
-          if (taxo) {
-            // if we do ahve a flatmap for the species, check if it has the anatomy annotated
-            let anatomy = scicrunchData.organs.map(organ => organ.curie)
-            data = await flatmaps.anatomyQuery(taxo, anatomy)
-          } else {
+          if (!taxo) {
+            // If we do not have a flatmap for the species, we will check the rat flatmap
             taxo = Uberons.species['rat']
-            let anatomy = scicrunchData.organs.map(organ => organ.curie)
-            data = await flatmaps.anatomyQuery(taxo, anatomy)
           }
+          // Send a requst to flatmap knowledgebase
+          const anatomy = scicrunchData.organs.map(organ => organ.curie)
+          const data = await flatmaps.anatomyQuery(taxo, anatomy)
 
-          //check request was successful
-          let anatomyResponse = data.data ? data.data.values : undefined
+          // Check request was successful
+          const anatomyResponse = data.data ? data.data.values : undefined
           if (anatomyResponse && anatomyResponse.length > 0) {
             foundAnatomy = anatomyResponse.map(val => val[1]) // uberon is stored in second element of tuple
           }

--- a/pages/datasets/_datasetId.vue
+++ b/pages/datasets/_datasetId.vue
@@ -307,12 +307,12 @@ const getThumbnailData = async (datasetDoi, datasetId, datasetVersion, datasetFa
         if (scicrunchData.organs[0]) { // Check if dataset has organ annotation
           let data = {}
           // If we do not have a flatmap for the species, check the rat flatmap
-          if (!taxo) {
-            taxo = Uberons.species['rat']
+          if (taxo) {
+            // if we do ahve a flatmap for the species, check if it has the anatomy annotated
             let anatomy = scicrunchData.organs.map(organ => organ.curie)
             data = await flatmaps.anatomyQuery(taxo, anatomy)
           } else {
-            // if we do ahve a flatmap for the species, check if it has the anatomy annotated
+            taxo = Uberons.species['rat']
             let anatomy = scicrunchData.organs.map(organ => organ.curie)
             data = await flatmaps.anatomyQuery(taxo, anatomy)
           }

--- a/pages/datasets/_datasetId.vue
+++ b/pages/datasets/_datasetId.vue
@@ -295,11 +295,8 @@ const getThumbnailData = async (datasetDoi, datasetId, datasetVersion, datasetFa
             species = speciesArray[0].children[0].label.toLowerCase()
         }
         
-        let taxo = undefined
-
         // check if there is a flatmap for the given species
-        if (species && species in Uberons.species)
-          taxo = Uberons.species[species]
+        let taxo = species && species in Uberons.species ? Uberons.species[species] : undefined
 
         // Check if flatmap has the anatomy for this species. This is done by asking the flatmap knowledge base
         // if a flatmap of (species) has (anatomy)

--- a/pages/datasets/_datasetId.vue
+++ b/pages/datasets/_datasetId.vue
@@ -295,17 +295,13 @@ const getThumbnailData = async (datasetDoi, datasetId, datasetVersion, datasetFa
             species = speciesArray[0].children[0].label.toLowerCase()
         }
 
-        // check if there is a flatmap for the given species
-        let taxo = species && species in Uberons.species ? Uberons.species[species] : undefined
+        // check if there is a flatmap for the given species, use a rat if there is not
+        const taxo = species && species in Uberons.species ? Uberons.species[species] : Uberons.species['rat']
 
         // Check if flatmap has the anatomy for this species. This is done by asking the flatmap knowledge base
         // if a flatmap of (species) has (anatomy)
         let foundAnatomy = []
         if (scicrunchData.organs[0]) { // Check if dataset has organ annotation
-          if (!taxo) {
-            // If we do not have a flatmap for the species, we will check the rat flatmap
-            taxo = Uberons.species['rat']
-          }
           // Send a requst to flatmap knowledgebase
           const anatomy = scicrunchData.organs.map(organ => organ.curie)
           const data = await flatmaps.anatomyQuery(taxo, anatomy)

--- a/pages/datasets/flatmapviewer/_id.vue
+++ b/pages/datasets/flatmapviewer/_id.vue
@@ -138,7 +138,7 @@ export default {
       return undefined
     },
     /**
-     * Get the species name of the dataset. This is used if the datasts's species does not have a flatmap. (It will then use a rat flatmap)
+     * Get the species name of the dataset. This is used if the datasets's species does not have a flatmap. (It will then use a rat flatmap)
      * @returns String
      */
     forSpecies: function() {

--- a/pages/datasets/flatmapviewer/_id.vue
+++ b/pages/datasets/flatmapviewer/_id.vue
@@ -76,8 +76,11 @@
 <script>
 import DetailTabs from '@/components/DetailTabs/DetailTabs.vue'
 import idMaps from '@/static/js/uberon-map.js'
+import flatmaps from '@/services/flatmaps'
 import scicrunch from '@/services/scicrunch'
 import FormatString from '@/mixins/format-string'
+
+import { failMessage } from '@/utils/notification-messages'
 
 export default {
   name: 'FlatmapViewerPage',
@@ -130,10 +133,16 @@ export default {
      */
     species: function() {
       for (const [key, value] of Object.entries(idMaps.species)) {
-        if (value === this.$route.query.taxo)
-          return key
+        if (value === this.$route.query.taxo) return key
       }
-      return undefined;
+      return undefined
+    },
+    /**
+     * Get the species name of the dataset. This is used if the datasts's species does not have a flatmap. (It will then use a rat flatmap)
+     * @returns String
+     */
+    forSpecies: function() {
+      return this.$route.query.for_species
     },
     /**
      * Get the uberon id from the query parameter.
@@ -141,6 +150,13 @@ export default {
      */
     uberonid: function() {
       return this.$route.query.uberonid
+    },
+    /**
+     * Get the organ from the query parameter.
+     * @returns Number
+     */
+    organ: function() {
+      return this.$route.query.organ
     },
     /**
      * Return the dataset id from the route query.
@@ -156,6 +172,9 @@ export default {
     versionNumber: function() {
       return this.$route.query.dataset_version
     }
+  },
+  mounted: function() {
+    this.checkSpeciesMatch()
   },
   methods: {
     flatmapReady: function(component) {
@@ -173,6 +192,18 @@ export default {
         return 'ilxtr:' + id
       }
       return id
+    },
+    checkSpeciesMatch: function() {
+      if (
+        this.forSpecies &&
+        this.forSpecies !== flatmaps.speciesMap[this.taxo] // if they don't match, we know that a rat was used
+      ) {
+        this.$message(
+          failMessage(
+            `Sorry! A flatmap for a ${this.forSpecies} does not yet exist. The ${this.organ} of a rat has been shown instead.`
+          )
+        )
+      }
     }
   }
 }


### PR DESCRIPTION
# Description
![image](https://user-images.githubusercontent.com/37255664/168744366-d66f323f-0676-4312-90d8-877c2f919900.png)
 - Now use rat flatmap if the species of flatmap does not exist
 - A message is given to the user letting them know this has happened
 
 This has been requested for the sprint 19 QA in this ticket:
 https://www.wrike.com/open.htm?id=844804093
 
 This PR also implements a small citation text change from this ticket:
 https://www.wrike.com/open.htm?id=830385307




## Type of change

Delete those that don't apply.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

# How Has This Been Tested?

Tested locally and can be tested here:
https://jesse-sprint-19.herokuapp.com/datasets/flatmapviewer?dataset_version=2&dataset_id=142&taxo=NCBITaxon%3A10114&uberonid=UBERON%3A0001155&for_species=dog&organ=colon

https://jesse-sprint-19.herokuapp.com/datasets/142?type=dataset&datasetDetailsTab=images
# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have utilized components from the Design System Library where applicable
- [ ] I have added unit tests that prove my fix is effective or that my feature works
