### PR TITLE
Fix empty image gallery

### DIFF
--- a/pages/datasets/_datasetId.vue
+++ b/pages/datasets/_datasetId.vue
@@ -327,7 +327,9 @@ const getThumbnailData = async (datasetDoi, datasetId, datasetVersion, datasetFa
             flatmapData.push(organData)
           }
         })
-        scicrunchData['flatmaps'] = flatmapData
+        //Only create a flatmaps field if flatmapData is not empty
+        if (flatmapData.length > 0)
+          scicrunchData['flatmaps'] = flatmapData
       }
     }
   } catch (e) {
@@ -668,10 +670,16 @@ export default {
       return !this.embargoed && this.fileCount >= 1
     },
     hasGalleryImages: function() {
+      //Check if the data compatible with image gallery exists in biolucida image data and scicrunch data
       return !this.embargoed &&
         (('dataset_images' in this.biolucidaImageData &&
           this.biolucidaImageData.dataset_images.length > 0) ||
-        Object.keys(this.scicrunchData).length > 0)
+        ('abi-scaffold-metadata-file' in this.scicrunchData) ||
+        ('video' in this.scicrunchData) ||
+        ('flatmaps' in this.scicrunchData) ||
+        ('mbf-segmentation' in this.scicrunchData) ||
+        ('abi-plot' in this.scicrunchData) ||
+        ('common-images' in this.scicrunchData))
     },
     fileCount: function() {
       return propOr('0', 'fileCount', this.datasetInfo)


### PR DESCRIPTION
# Description

Fix empty image gallery on some datasets including the following page - https://staging.sparc.science/datasets/237?type=dataset


## Type of change

Delete those that don't apply.

- [ ] Bug fix (non-breaking change which fixes an issue)


# How Has This Been Tested?

This has been fixed manually and deployed here - https://mapcore-demo.org/current/sparc-app/datasets/237?type=dataset


# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have utilized components from the Design System Library where applicable
- [x] I have added unit tests that prove my fix is effective or that my feature works
