### PR TITLE
stop imported biolucida viewer from hiding icon

### DIFF
--- a/components/BiolucidaViewer/BiolucidaViewer.vue
+++ b/components/BiolucidaViewer/BiolucidaViewer.vue
@@ -5,16 +5,18 @@
         <bf-button class="ml-8 btn-copy-permalink-solid" @click="launchViewer">
           View in 3D
         </bf-button>
-        <button class="btn-copy-permalink" @click="queryView">
-          <sparc-tooltip placement="bottom-center" content="Copy Link">
-            <svg-icon
-              slot="item"
-              name="icon-permalink"
-              height="2rem"
-              width="1.75rem"
-            />
-          </sparc-tooltip>
-        </button>
+        <client-only>
+          <button class="btn-copy-permalink" @click="queryView">
+            <sparc-tooltip placement="bottom-center" content="Copy Link">
+              <svg-icon
+                slot="item"
+                name="icon-permalink"
+                height="2rem"
+                width="1.75rem"
+              />
+            </sparc-tooltip>
+          </button>
+        </client-only>
       </el-row>
       <iframe ref="biolucida" :src="data.share_link" @load="biolucidaLoaded" />
     </template>


### PR DESCRIPTION
# Description

Permalink icon was not being shown in staging: https://staging.sparc.science/datasets/biolucidaviewer/850?view=ODUwLWNvbC05NQ%3D%3D&dataset_version=4&dataset_id=31&item_id=N%3Apackage%3Ab35bbe09-2fcc-496c-be8b-7c0ee43f1395

I believe it has something to do with the biolucida iframe that gets loaded overriding the css. I think making it client-only will fix the problem

## Type of change

- [X] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

Locally, although we won't know for sure if this working until pushing to staging

# Checklist:

- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my own code
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] I have utilized components from the Design System Library where applicable
