### PR TITLE
Implemented redirect logic for documentation hub

### DIFF
--- a/middleware/documentationHubRedirects.js
+++ b/middleware/documentationHubRedirects.js
@@ -1,0 +1,12 @@
+import getRedirectsMapping from "~/plugins/documentation-hub-redirects";
+import { propOr } from 'ramda'
+
+export default function ({ route, redirect }) {
+  const redirectsMapping = getRedirectsMapping()
+  const redirectUrls = propOr([], 'redirectUrls', redirectsMapping)
+  redirectUrls.forEach(redirectUrl => {
+    if (route.path.includes(redirectUrl.oldUrl)) {
+      redirect(redirectUrl.newUrl)
+    }
+  })
+}

--- a/nuxt.config.js
+++ b/nuxt.config.js
@@ -85,6 +85,7 @@ export default {
     ctf_terms_id: '6XCER8v1TVVCoZdaBWg66t',
     ctf_privacy_policy_id: '2p44GCn1rrWUETwTRF2ElS',
     ctf_success_story_id: 'successStory',
+    ctf_documentation_hub_redirects_id: 'yhBSKvDSpBQbeHQWHgj9j',
     CTF_SPACE_ID: process.env.CTF_SPACE_ID,
     CTF_CDA_ACCESS_TOKEN: process.env.CTF_CDA_ACCESS_TOKEN,
     CTF_API_HOST: process.env.CTF_API_HOST,
@@ -138,7 +139,7 @@ export default {
         component: '@/pages/datasets/_datasetId.vue'
       })
     },
-    middleware: ['verifyUserProfileComplete']
+    middleware: ['verifyUserProfileComplete', 'documentationHubRedirects']
   },
   /*
    ** Global CSS
@@ -150,7 +151,8 @@ export default {
   plugins: [
     '@/plugins/bootstrap', 
     '@/plugins/contentful', 
-    '@/plugins/amplify', 
+    '@/plugins/amplify',
+    '@/plugins/documentation-hub-redirects',
     {
       src: '@/plugins/system-design-components', mode: 'client'
     }

--- a/plugins/documentation-hub-redirects.js
+++ b/plugins/documentation-hub-redirects.js
@@ -1,0 +1,14 @@
+import createClient from "~/plugins/contentful";
+import { propOr } from 'ramda'
+
+const client = createClient()
+
+let redirectsMapping = {}
+
+client.getEntry(process.env.ctf_documentation_hub_redirects_id).then(({fields}) => {
+  redirectsMapping = propOr({}, 'redirectsMapping', fields)
+})
+
+export default function getRedirectsMapping() {
+  return redirectsMapping
+}


### PR DESCRIPTION
# Description

Implemented logic for pulling in a list of redirect urls from contentful that we use to redirect a user to the documentation hub if they are using a legacy sparc documentation url

## Type of change

- [X] New feature (non-breaking change which adds functionality)

# How Has This Been Tested?

Locally, by attempting to navigate to: /help/2022-sparc-fair-codeathon

# Checklist:

- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my own code
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] I have utilized components from the Design System Library where applicable
