### PR TITLE
Add Password to merge accounts request

### DIFF
--- a/components/SetupNewUser/SetupNewUser.vue
+++ b/components/SetupNewUser/SetupNewUser.vue
@@ -444,9 +444,11 @@ export default {
     onClickConnectAccounts: async function() {
       const url = `${this.mergeUserAccountsUrl}/${this.pennsieveUserIntId}`
       const headers = { 'Authorization': `bearer ${this.authenticatedUser.token}` }
+      // include password in order to pass it on to new Cognito user so that a new one doesn't need to be requested
       const body = {
         email: this.authenticatedUser.emailAddress,
-        cognitoId: this.cognitoUsername
+        cognitoId: this.cognitoUsername,
+        password: this.passwordForm.password
       }
       await this.$axios.$put(url, body, { headers }).then(async () => {
         await this.$store.dispatch('user/logout')


### PR DESCRIPTION
# Description

Add password to body of merge accounts request so that the user does not have to request the password for their Pennsieve account after linking


## Type of change

- [X] New feature (non-breaking change which adds functionality)

# How Has This Been Tested?

Locally via pennsieve.net, localhost, and orcid sandbox

# Checklist:

- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my own code
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] I have utilized components from the Design System Library where applicable
