### PR TITLE
Make orcid api url an env var

### DIFF
--- a/components/ContributorItem/ContributorItem.vue
+++ b/components/ContributorItem/ContributorItem.vue
@@ -15,16 +15,18 @@
         </template>
         <template v-if="hasOrcidDataError">
           <!--If Orcid is down we can still print the contributor name and ID-->
-          <h2>{{ orcidName }}</h2>
+          <h2>{{ fullName }}</h2>
           <p>
             <strong>ORCID iD</strong>:
-            {{ orcidId }}
+            <a :href="orcidUri" target="_blank">
+                {{ orcidId }}
+              </a>
           </p>
         </template>
         <template
           v-if="isOrcidDataNotFound === false && hasOrcidDataError === false"
         >
-          <h2>{{ orcidName }}</h2>
+          <h2>{{ fullName }}</h2>
           <p>
             <strong>ORCID iD</strong>:
             <template v-if="orcidUri">
@@ -137,7 +139,7 @@ export default {
      * @returns {String}
      */
     orcidUri: function() {
-      return pathOr('', ['orcid-identifier', 'uri'], this.orcidData)
+      return `https://orcid.org/${this.orcidId}`
     },
 
     /**
@@ -162,7 +164,7 @@ export default {
 
       if (this.hasOrcid && Object.keys(this.orcidData).length === 0) {
         this.$axios
-          .get(`https://pub.orcid.org/v2.1/${this.orcidId}`, {
+          .get(`${process.env.ORCID_API_URL}/${this.orcidId}`, {
             headers: { Accept: 'application/json' }
           })
           .then(response => {

--- a/nuxt.config.js
+++ b/nuxt.config.js
@@ -107,7 +107,8 @@ export default {
     AWS_OAUTH_REDIRECT_SIGN_OUT_URL: process.env.AWS_OAUTH_REDIRECT_SIGN_OUT_URL || 'http://localhost:3000',
     AWS_OAUTH_RESPONSE_TYPE: process.env.AWS_OAUTH_RESPONSE_TYPE || "token",
     SHOW_LOGIN_FEATURE: process.env.SHOW_LOGIN_FEATURE || 'false',
-    LOGIN_API_URL: process.env.LOGIN_API_URL || 'https://api.pennsieve.net'
+    LOGIN_API_URL: process.env.LOGIN_API_URL || 'https://api.pennsieve.net',
+    ORCID_API_URL: process.env.ORCID_API_URL || 'https://pub.orcid.org/v2.1'
   },
 
   serverMiddleware: [


### PR DESCRIPTION
# Description

In order to show https://www.wrike.com/workspace.htm?acc=3203588#/inbox/task/830482705 is working, I created an env var  to Orcid api to mock a failed request

## Type of change

- [X] New feature (non-breaking change which adds functionality)

# How Has This Been Tested?

Locally

# Checklist:

- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my own code
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] I have utilized components from the Design System Library where applicable
