### PR TITLE
Hide tooltips if not necessary

### DIFF
--- a/components/DatasetDetails/DatasetHeader.vue
+++ b/components/DatasetDetails/DatasetHeader.vue
@@ -67,15 +67,6 @@
                 </span>
               </div>
               <div class="metics-container">
-                <span class="label4 mr-16">
-                  Citations: 
-                  <a v-if="showCitations" class="citations-link" v-on:click="numCitationsClicked">
-                    {{numCitationsText}}
-                  </a>
-                  <span v-else>
-                    {{numCitationsText}}
-                  </span>
-                </span>
                 <span class="label4">Downloads: {{numDownloadsText}}</span>
               </div>
             </div>

--- a/components/DatasetDetails/SimilarDatasetsInfoBox.vue
+++ b/components/DatasetDetails/SimilarDatasetsInfoBox.vue
@@ -19,12 +19,12 @@
         <div v-if="facet.children && showFacet(facet)">
           <div class="capitalize mb-8">{{facet.label}}:</div>
           <div class="facet-button-container" v-for="child in facet.children" :key="child.id">
-            <sparc-tooltip placement="left-center" :content="capitalize(child.label)">
+            <sparc-tooltip placement="left-center" :content="capitalize(child.label)" :ref="child.label">
               <nuxt-link
                 slot="item"
                 :to="getSelectedFacetLink(getFacetId(child))"
               >
-                <div class="my-2 px-12 facet-button capitalize label2">
+                <div @mouseenter="onEnterTooltipItem($event, child.label)" class="my-2 px-12 facet-button capitalize label2">
                   {{child.label}}
                 </div>
               </nuxt-link>
@@ -40,8 +40,8 @@
           v-for="contributor in contributors"
           :key="contributor.id"
         >
-          <li class="contributor-list">
-            <sparc-tooltip placement="left-center" :content="getContributorFullName(contributor)">
+          <li class="contributor-list" @mouseenter="onEnterTooltipItem($event, getContributorFullName(contributor))">
+            <sparc-tooltip placement="left-center" :content="getContributorFullName(contributor)" :ref="getContributorFullName(contributor)">
               <nuxt-link
                 slot="item"
                 :to="getSelectedContributorLink(contributor)"
@@ -153,6 +153,11 @@ export default {
       const firstName = propOr('', 'firstName', contributor)
       const lastName = propOr('', 'lastName', contributor)
       return `${firstName} ${lastName}`
+    },
+    onEnterTooltipItem: function(e, refId) {
+      const target = e.target
+      const hideTooltip = target.scrollWidth <= target.offsetWidth
+      this.$refs[refId][0].hide(hideTooltip)
     },
   }
 }

--- a/components/FilesTable/FilesTable.vue
+++ b/components/FilesTable/FilesTable.vue
@@ -41,13 +41,13 @@
             <div class="file-name-wrap">
               <template v-if="scope.row.type === 'Directory'">
                 <i class="file-icon el-icon-folder" />
-                <sparc-tooltip placement="left-center" :content="scope.row.name">
+                <sparc-tooltip placement="left-center" :content="scope.row.name" :ref="scope.row.name">
                   <nuxt-link
                     slot="item"
                     class="file-name truncated"
                     :to="{ query: { ...$route.query, path: scope.row.path } }"
                   >
-                    {{ scope.row.name }}
+                    <div @mouseenter="onEnterTooltipItem($event, scope.row.name)">{{ scope.row.name }}</div>
                   </nuxt-link>
                 </sparc-tooltip>
               </template>
@@ -59,28 +59,28 @@
                 />
                 <i v-else class="file-icon el-icon-document" />
                 <div v-if="isFileOpenable(scope)" class="truncated">
-                  <sparc-tooltip placement="left-center" :content="scope.row.name">
+                  <sparc-tooltip placement="left-center" :content="scope.row.name" :ref="scope.row.name">
                     <a class="truncated" slot="item" href="#" @click.prevent="openFile(scope)">
-                      {{ scope.row.name }}
+                      <div @mouseenter="onEnterTooltipItem($event, scope.row.name)">{{ scope.row.name }}</div>
                     </a>
                   </sparc-tooltip>
                 </div>
                 <div v-else-if="isScaffoldMetaFile(scope)" class="truncated">
-                  <sparc-tooltip placement="left-center" :content="scope.row.name">
+                  <sparc-tooltip placement="left-center" :content="scope.row.name" :ref="scope.row.name">
                     <nuxt-link slot="item" class="truncated" :to="getScaffoldLink(scope)">
-                      {{ scope.row.name }}
+                      <div @mouseenter="onEnterTooltipItem($event, scope.row.name)">{{ scope.row.name }}</div>
                     </nuxt-link>
                   </sparc-tooltip>
                 </div>
                 <div v-else-if="isScaffoldViewFile(scope)" class="truncated">
-                  <sparc-tooltip placement="left-center" :content="scope.row.name">
+                  <sparc-tooltip placement="left-center" :content="scope.row.name" :ref="scope.row.name">
                     <nuxt-link slot="item" class="truncated" :to="getScaffoldViewLink(scope)">
-                      {{ scope.row.name }}
+                      <div @mouseenter="onEnterTooltipItem($event, scope.row.name)">{{ scope.row.name }}</div>
                     </nuxt-link>
                   </sparc-tooltip>
                 </div>
                 <div v-else class="truncated">
-                  <sparc-tooltip placement="left-center" :content="scope.row.name">
+                  <sparc-tooltip placement="left-center" :content="scope.row.name" :ref="scope.row.name">
                     <nuxt-link
                       slot="item"
                       class="truncated"
@@ -95,7 +95,7 @@
                         }
                       }"
                     >
-                      {{ scope.row.name }}
+                      <div @mouseenter="onEnterTooltipItem($event, scope.row.name)">{{ scope.row.name }}</div>
                     </nuxt-link>
                   </sparc-tooltip>
                 </div>
@@ -774,7 +774,12 @@ export default {
       // patch for discrepancy between file paths containing spaces and/or commas and the s3 path. s3 paths appear to use underscores instead
       path = path.replaceAll(' ', '_')
       return path.replaceAll(',', '_')
-    }
+    },
+    onEnterTooltipItem: function(e, refId) {
+      const target = e.target
+      const hideTooltip = target.scrollWidth <= target.offsetWidth
+      this.$refs[refId].hide(hideTooltip)
+    },
   }
 }
 </script>

--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
     "@aws-amplify/auth": "^4.4.4",
     "@aws-amplify/core": "^4.4.2",
     "@miyaoka/nuxt-twitter-widgets-module": "^0.0.1",
-    "@nih-sparc/sparc-design-system-components": "^0.26.16",
+    "@nih-sparc/sparc-design-system-components": "^0.26.17",
     "@nuxtjs/axios": "^5.8.0",
     "@nuxtjs/google-analytics": "^2.2.3",
     "@nuxtjs/robots": "^2.4.2",

--- a/yarn.lock
+++ b/yarn.lock
@@ -2319,10 +2319,10 @@
   resolved "https://registry.yarnpkg.com/@miyaoka/nuxt-twitter-widgets-module/-/nuxt-twitter-widgets-module-0.0.1.tgz#fdca759252e7496c783e69b926623551bf8a4a01"
   integrity sha512-vYJkz9EemNS4Ur4uXI8R/tKFyXWrGypQwpFF/PSA/JZaGx19gpAfzTxHg0e7EQ1VIS+GTN2U6AUXz9MD05P+Nw==
 
-"@nih-sparc/sparc-design-system-components@^0.26.16":
-  version "0.26.16"
-  resolved "https://registry.yarnpkg.com/@nih-sparc/sparc-design-system-components/-/sparc-design-system-components-0.26.16.tgz#20d7e4a7fca76b7c448428e72a58266c6a4aaa80"
-  integrity sha512-7NTqEc1GzsXgAR7Frd3eGxHy6rYtdL2kE9Y4co4+IrjT6SZBjNrGk18cCgUZUmARitUgaeor/hKYQ1lMfpehKg==
+"@nih-sparc/sparc-design-system-components@^0.26.17":
+  version "0.26.17"
+  resolved "https://registry.yarnpkg.com/@nih-sparc/sparc-design-system-components/-/sparc-design-system-components-0.26.17.tgz#5cdc033c11cfef70c6f742950ef0ed6d5341fe6a"
+  integrity sha512-bmsCbA3fifdzMNtOy2jqLy/FEtANff8PAzsqERP+NCUwjA7jaWd/H3bZlsA0a2rjMDABTT6vCxQ1ZR6pYYZquA==
   dependencies:
     "@carbon/grid" "10.17.0"
     core-js "^3.6.5"


### PR DESCRIPTION
# Description

Hide tooltips if they are erroneous. In order to do so I listen for a mouseenter event and use the targets scrollable width and offset width to programmatically hide/show the tooltip using the system design's sparc-tooltip's newly added hide() function.

*Note that I also removed the number of citations displayed in the header for the time being to knock out this wrike ticket: https://www.wrike.com/workspace.htm?acc=3203588#path=folder&id=824490095&c=list&vid=64376648&p=589157244&a=3203588&t=895002281&so=2&bso=10&sd=0&f=&st=space-441356195

## Type of change

- [X] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

Locally

# Checklist:

- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my own code
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] I have utilized components from the Design System Library where applicable