### PR TITLE
Update mapintegratedvuer dependencies.

### DIFF
--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
   "dependencies": {
     "@abi-software/flatmapvuer": "0.2.5",
     "@abi-software/gallery": "0.3.1",
-    "@abi-software/mapintegratedvuer": "0.3.1",
+    "@abi-software/mapintegratedvuer": "0.3.2",
     "@abi-software/plotvuer": "^0.3.0",
     "@abi-software/scaffoldvuer": "0.1.52",
     "@abi-software/simulationvuer": "^0.5.9",

--- a/yarn.lock
+++ b/yarn.lock
@@ -24,16 +24,16 @@
     minisearch "^2.2.1"
     polylabel "^1.1.0"
 
-"@abi-software/flatmap-viewer@2.2.0-beta.12":
-  version "2.2.0-beta.12"
-  resolved "https://registry.yarnpkg.com/@abi-software/flatmap-viewer/-/flatmap-viewer-2.2.0-beta.12.tgz#87d11b1255281e9e1c032ef0a3806275429a32f8"
-  integrity sha512-2bDHZ3DSp3AFsUHYmJ6MPYyj6BHQv0GHU6Q+NSuK8eFUQZwYKJvlw4vkx9x+rPEZwuZUmxv7RrQQdw5FgOU6qA==
+"@abi-software/flatmap-viewer@^2.2.0-beta.16":
+  version "2.2.0-beta.16"
+  resolved "https://registry.yarnpkg.com/@abi-software/flatmap-viewer/-/flatmap-viewer-2.2.0-beta.16.tgz#d807d600361998a19878001e9ce440f08ac67f74"
+  integrity sha512-1Eu4IRJFcQANNBuNK/kRVyzP8kRz+FXulPZKoWS62Mvf2B9D1YjmqQ1+ldO5bbCxZiwH5xhH4AGOFi2KJ54lkQ==
   dependencies:
     "@babel/runtime" "^7.10.4"
     "@turf/area" "^6.0.1"
     "@turf/bbox" "^6.0.1"
     "@turf/helpers" "^6.1.4"
-    maplibre-gl "^2.1.0"
+    maplibre-gl ">=1.15.3"
     minisearch "^2.2.1"
     polylabel "^1.1.0"
 
@@ -52,12 +52,12 @@
     lodash "^4.17.21"
     vue "^2.6.10"
 
-"@abi-software/flatmapvuer@0.2.5-beta-1":
-  version "0.2.5-beta-1"
-  resolved "https://registry.yarnpkg.com/@abi-software/flatmapvuer/-/flatmapvuer-0.2.5-beta-1.tgz#cc2681219516428aa66eef8f52e1cf2963404412"
-  integrity sha512-wKNJHqMg2+xwtrAjpAlbH/KNZWjJorYPsrAgAIcCu8qKOQU+djp8XiGTFmYOawnUwVOR6uHclb/Hn2v3QF/r6Q==
+"@abi-software/flatmapvuer@^0.3.0":
+  version "0.3.0"
+  resolved "https://registry.yarnpkg.com/@abi-software/flatmapvuer/-/flatmapvuer-0.3.0.tgz#f43d3974da1c61d6e176f716a1e1e3a18723b5b0"
+  integrity sha512-k3Wf23X407DbU5Uw+tNwYkfgtymRvjAXIFl8IFdFBb5R9qpiqDcz759+1kTlX1Tb9XKyS0t72LiscZOtvtWDvQ==
   dependencies:
-    "@abi-software/flatmap-viewer" "2.2.0-beta.10"
+    "@abi-software/flatmap-viewer" "^2.2.0-beta.16"
     "@abi-software/svg-sprite" "^0.1.14"
     core-js "^3.3.2"
     css-element-queries "^1.2.2"
@@ -80,10 +80,10 @@
     element-ui "^2.15.0"
     vue "^2.6.11"
 
-"@abi-software/map-side-bar@^1.3.1":
-  version "1.3.1"
-  resolved "https://registry.yarnpkg.com/@abi-software/map-side-bar/-/map-side-bar-1.3.1.tgz#87fd6f47dea77bfc90de1d01b9ca022d897dcb1e"
-  integrity sha512-C0QFQDJgKRow1RsrU94VnLB1nCzgTtpC+mgbLYYJyUchrV33EK75cMJE98g/wG5txY/zc2Hs+wUhW+fUtpLSQw==
+"@abi-software/map-side-bar@^1.3.18":
+  version "1.3.18"
+  resolved "https://registry.yarnpkg.com/@abi-software/map-side-bar/-/map-side-bar-1.3.18.tgz#bd8afecfcb2fa4a18881bbd21d099f803df0df80"
+  integrity sha512-1BxGBjcjzo45BVrTTU/uy7g/2/qLiLoYFwF9s9pbJ/GHVJA/DdzATKgYF2RVwjIh8cd72qrzktY12Fw3uEHrIQ==
   dependencies:
     "@abi-software/gallery" "^0.3.1"
     "@abi-software/svg-sprite" "^0.1.14"
@@ -91,14 +91,13 @@
     element-ui "^2.13.0"
     vue "^2.6.10"
 
-"@abi-software/mapintegratedvuer@0.3.1":
-  version "0.3.1"
-  resolved "https://registry.yarnpkg.com/@abi-software/mapintegratedvuer/-/mapintegratedvuer-0.3.1.tgz#cbbdea29ca269dd98f3d433d6b0adf62d6f6b0ec"
-  integrity sha512-YYWNl8UknfLii0ZB217NjQJ9+DUko3JDN5BPLM3PkOq6S9e84BLfzyiUlouIXfJah5bt7mkyKitzTAJZPegfvQ==
+"@abi-software/mapintegratedvuer@0.3.2":
+  version "0.3.2"
+  resolved "https://registry.yarnpkg.com/@abi-software/mapintegratedvuer/-/mapintegratedvuer-0.3.2.tgz#4e697e7c162cc74807455ee0e5b7544dda1f8d8b"
+  integrity sha512-CRp+UHdDCZt0qmnRxwvs3DH43XnzyJfDtNJntOdqFBjpgFew9UXkcPF916hzMbY30FNzgrkS1z5FX+D/pvx8Ew==
   dependencies:
-    "@abi-software/flatmap-viewer" "2.2.0-beta.12"
-    "@abi-software/flatmapvuer" "0.2.5-beta-1"
-    "@abi-software/map-side-bar" "^1.3.1"
+    "@abi-software/flatmapvuer" "^0.3.0"
+    "@abi-software/map-side-bar" "^1.3.18"
     "@abi-software/plotvuer" "^0.3.9"
     "@abi-software/scaffoldvuer" "^0.1.52"
     "@abi-software/simulationvuer" "^0.5.9"
@@ -3013,6 +3012,11 @@
   dependencies:
     "@types/webpack" "*"
 
+"@types/geojson@*", "@types/geojson@^7946.0.8":
+  version "7946.0.10"
+  resolved "https://registry.yarnpkg.com/@types/geojson/-/geojson-7946.0.10.tgz#6dfbf5ea17142f7f9a043809f1cd4c448cb68249"
+  integrity sha512-Nmh0K3iWQJzniTuPRcJn5hxXkfB1T1pgB89SBig5PlJQU5yocazeu4jATJlaA0GYFKWMqDdvYemoSnF2pXgLVA==
+
 "@types/html-minifier-terser@^5.0.0":
   version "5.1.1"
   resolved "https://registry.yarnpkg.com/@types/html-minifier-terser/-/html-minifier-terser-5.1.1.tgz#3c9ee980f1a10d6021ae6632ca3e79ca2ec4fb50"
@@ -3074,6 +3078,20 @@
   resolved "https://registry.yarnpkg.com/@types/long/-/long-4.0.1.tgz#459c65fa1867dafe6a8f322c4c51695663cc55e9"
   integrity sha512-5tXH6Bx/kNGd3MgffdmP4dy2Z+G4eaXw0SE81Tq3BNadtnMR5/ySMzX4SLEzHJzSmPNn4HIdpQsBvXMUykr58w==
 
+"@types/mapbox__point-geometry@*", "@types/mapbox__point-geometry@^0.1.2":
+  version "0.1.2"
+  resolved "https://registry.yarnpkg.com/@types/mapbox__point-geometry/-/mapbox__point-geometry-0.1.2.tgz#488a9b76e8457d6792ea2504cdd4ecdd9860a27e"
+  integrity sha512-D0lgCq+3VWV85ey1MZVkE8ZveyuvW5VAfuahVTQRpXFQTxw03SuIf1/K4UQ87MMIXVKzpFjXFiFMZzLj2kU+iA==
+
+"@types/mapbox__vector-tile@^1.3.0":
+  version "1.3.0"
+  resolved "https://registry.yarnpkg.com/@types/mapbox__vector-tile/-/mapbox__vector-tile-1.3.0.tgz#8fa1379dbaead1e1b639b8d96cfd174404c379d6"
+  integrity sha512-kDwVreQO5V4c8yAxzZVQLE5tyWF+IPToAanloQaSnwfXmIcJ7cyOrv8z4Ft4y7PsLYmhWXmON8MBV8RX0Rgr8g==
+  dependencies:
+    "@types/geojson" "*"
+    "@types/mapbox__point-geometry" "*"
+    "@types/pbf" "*"
+
 "@types/memory-fs@*":
   version "0.3.2"
   resolved "https://registry.yarnpkg.com/@types/memory-fs/-/memory-fs-0.3.2.tgz#5d4753f9b390cb077c8c8af97bc96463399ceccd"
@@ -3119,6 +3137,11 @@
   integrity sha512-kOeZHQyoeau/6Obelj5/iow7uo5rH2KpbdWPEGCqbC4bxkiteg794tU4LqKFlQKdM5QGCp5Hbapl+zDdQzBNkQ==
   dependencies:
     "@types/webpack" "*"
+
+"@types/pbf@*", "@types/pbf@^3.0.2":
+  version "3.0.2"
+  resolved "https://registry.yarnpkg.com/@types/pbf/-/pbf-3.0.2.tgz#8d291ad68b4b8c533e96c174a2e3e6399a59ed61"
+  integrity sha512-EDrLIPaPXOZqDjrkzxxbX7UlJSeQVgah3i0aA4pOSzmK9zq3BIh7/MZIQxED7slJByvKM4Gc6Hypyu2lJzh3SQ==
 
 "@types/pug@^2.0.4":
   version "2.0.4"
@@ -10068,6 +10091,35 @@ mapbox-gl@1.10.1:
     supercluster "^7.0.0"
     tinyqueue "^2.0.3"
     vt-pbf "^3.1.1"
+
+maplibre-gl@>=1.15.3:
+  version "2.1.9"
+  resolved "https://registry.yarnpkg.com/maplibre-gl/-/maplibre-gl-2.1.9.tgz#042f3ef4224fa890ecf7a410145243f1fc943dcd"
+  integrity sha512-pnWJmILeZpgA5QSI7K7xFK3yrkyYTd9srw3fCi2Ca52Phm78hsznPwUErEQcZLfxXKn/1h9t8IPdj0TH0NBNbg==
+  dependencies:
+    "@mapbox/geojson-rewind" "^0.5.1"
+    "@mapbox/jsonlint-lines-primitives" "^2.0.2"
+    "@mapbox/mapbox-gl-supported" "^2.0.1"
+    "@mapbox/point-geometry" "^0.1.0"
+    "@mapbox/tiny-sdf" "^2.0.4"
+    "@mapbox/unitbezier" "^0.0.1"
+    "@mapbox/vector-tile" "^1.3.1"
+    "@mapbox/whoots-js" "^3.1.0"
+    "@types/geojson" "^7946.0.8"
+    "@types/mapbox__point-geometry" "^0.1.2"
+    "@types/mapbox__vector-tile" "^1.3.0"
+    "@types/pbf" "^3.0.2"
+    csscolorparser "~1.0.3"
+    earcut "^2.2.3"
+    geojson-vt "^3.2.1"
+    gl-matrix "^3.4.3"
+    murmurhash-js "^1.0.0"
+    pbf "^3.2.1"
+    potpack "^1.0.2"
+    quickselect "^2.0.0"
+    supercluster "^7.1.4"
+    tinyqueue "^2.0.3"
+    vt-pbf "^3.1.3"
 
 maplibre-gl@^2.1.0:
   version "2.1.6"


### PR DESCRIPTION
# Description

This update uses the latest version of mapvuer. It contains the following changes:

Upstream downstream pop ups - https://github.com/ABI-Software/flatmapvuer/pull/64
Dynamic flatmap markers - https://github.com/ABI-Software/mapintegratedvuer/pull/102

## Type of change

Delete those that don't apply.

- [x] New feature (non-breaking change which adds functionality)

# How Has This Been Tested?

Manually tested and deploy here - https://alan-wu-sparc-app.herokuapp.com/maps
The map vuer itself passes the e2e testing - https://autotest.bioeng.auckland.ac.nz/jenkins/job/mapintegratedvuer/304/

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have utilized components from the Design System Library where applicable
- [x] I have added unit tests that prove my fix is effective or that my feature works
