### PR TITLE
Added ability to download dataset changelog

### DIFF
--- a/components/VersionHistory/VersionHistory.vue
+++ b/components/VersionHistory/VersionHistory.vue
@@ -17,7 +17,10 @@
         <el-col :span="4">
           Date 
         </el-col>
-        <el-col :span="8" :push="2">
+        <el-col :span="4">
+          Changelog 
+        </el-col>
+        <el-col :span="4" :push="1">
           DOI
         </el-col>
       </el-row>
@@ -50,7 +53,15 @@
         <el-col :span="4">
           {{ formatDate(getVersionRevisionDate(version)) }}
         </el-col>
-        <el-col :span="8" :push="2">
+        <el-col v-if="isChangelogAvailable" :span="4">
+          <a class="changelog-file" @click="requestDownloadFile(changelogFile)">
+            Download
+          </a>
+        </el-col>
+        <el-col v-else :span="4">
+          Not available
+        </el-col>
+        <el-col :span="4" :push="1">
           <a
             :href="getDoiLink(version.doi)"
           >
@@ -65,20 +76,25 @@
 
 <script>
 import { mapState } from 'vuex'
-import { propOr } from 'ramda'
+import { propOr, isEmpty } from 'ramda'
 
+import RequestDownloadFile from '@/mixins/request-download-file'
 import FormatDate from '@/mixins/format-date'
 
 export default {
   name: 'VersionHistory',
 
-  mixins: [FormatDate],
+  mixins: [FormatDate, RequestDownloadFile],
 
   props: {
     versions: {
       type: Array,
       default: () => []
     },
+    changelogFile: {
+      type: Object,
+      default: () => {}
+    }
   },
   computed: {
     /**
@@ -110,6 +126,9 @@ export default {
     embargoed: function() {
       return propOr(false, 'embargo', this.datasetInfo)
     },
+    isChangelogAvailable: function() {
+      return !isEmpty(this.changelogFile)
+    }
   },
   methods: {
     getDoiLink(doi) {
@@ -142,6 +161,9 @@ export default {
     a {
       text-decoration: underline;
     }
+  }
+  .changelog-file {
+    cursor: pointer;
   }
 }
 </style>

--- a/pages/datasets/_datasetId.vue
+++ b/pages/datasets/_datasetId.vue
@@ -74,6 +74,7 @@
                     v-if="canViewVersions"
                     v-show="activeTabId === 'versions'"
                     :versions="versions"
+                    :changelog-file="changelogFile"
                   />
                 </content-tab-card>
               </div>
@@ -425,6 +426,14 @@ export default {
         return {}
       })
 
+    const changelogEndpoint = `${process.env.discover_api_host}/datasets/${datasetId}/versions/${route.params.version || 1}/files?path=changelog.md`
+    const changelogFile = await $axios.$get(changelogEndpoint).then(response => {
+        return response 
+      }).catch(() => {
+        console.log("There is no changelog file associated with this dataset")
+        return {}
+      })
+
     store.dispatch('pages/datasets/datasetId/setDatasetInfo', datasetDetails)
     store.dispatch('pages/datasets/datasetId/setDatasetFacetsData', datasetFacetsData)
     store.dispatch('pages/datasets/datasetId/setDatasetTypeName', datasetTypeName)
@@ -438,7 +447,8 @@ export default {
       versions,
       datasetTypeName,
       downloadsSummary,
-      showTombstone: datasetDetails.isUnpublished
+      showTombstone: datasetDetails.isUnpublished,
+      changelogFile
     }
   },
 


### PR DESCRIPTION
# Description

added a changelog column to the versions tab on the dataset details page as per https://www.wrike.com/open.htm?id=795603064 allowing a user to download that dataset version's changelog if one is present.


## Type of change

- [X] New feature (non-breaking change which adds functionality)

# How Has This Been Tested?

Locally via dataset 270

# Checklist:

- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my own code
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] I have utilized components from the Design System Library where applicable
