### PR TITLE
Fix issue where fetchPennsieve file crashes the app on the /files page

### DIFF
--- a/mixins/fetch-pennsieve-file/index.js
+++ b/mixins/fetch-pennsieve-file/index.js
@@ -21,7 +21,7 @@ export default {
         }
 
         // check if uri matches filePath query param
-        if (file.uri) {
+        else if (file.uri) {
           let uriFile = file.uri.substring(file.uri.lastIndexOf('/'))
           if (uriFile) {
             uriFile = uriFile.toLowerCase()

--- a/mixins/fetch-pennsieve-file/index.js
+++ b/mixins/fetch-pennsieve-file/index.js
@@ -11,6 +11,11 @@ export default {
       const filesUrl = `${process.env.discover_api_host}/datasets/${datasetId}/versions/${datasetVersion}/files/browse?path=${filesLocation}`
       const filesResponse = await axios.$get(filesUrl)
       const files = filesResponse.files
+      if (files.length === 0) {
+        console.warn(`
+        WARNING! the file "${filePath}" was just attempted to download from ${filesUrl} , This will likely crash the page using this file`)
+      }
+
       filePath = filePath.toLowerCase()
       let foundFile = {}
 

--- a/mixins/fetch-pennsieve-file/index.js
+++ b/mixins/fetch-pennsieve-file/index.js
@@ -18,23 +18,25 @@ export default {
 
       filePath = filePath.toLowerCase()
       let foundFile = {}
+      let keepLooking = true
 
-      files.forEach(file => {
-        // Check if path matches query param
+      files.every(file => {
+        // Check if path matches query param.
         if (filePath.toLowerCase() === file.path.toLowerCase) {
           foundFile = file
-        }
-
-        // check if uri matches filePath query param
-        else if (file.uri) {
+          keepLooking = false
+        } else if (file.uri) {
+          // Check if uri matches filePath query param.
           let uriFile = file.uri.substring(file.uri.lastIndexOf('/'))
           if (uriFile) {
             uriFile = uriFile.toLowerCase()
           }
           if (filePath.includes(uriFile)) {
             foundFile = file
+            keepLooking = false
           }
         }
+        return keepLooking
       })
 
       return foundFile

--- a/mixins/fetch-pennsieve-file/index.js
+++ b/mixins/fetch-pennsieve-file/index.js
@@ -12,7 +12,27 @@ export default {
       const filesResponse = await axios.$get(filesUrl)
       const files = filesResponse.files
       filePath = filePath.toLowerCase()
-      return files.find(element => filePath === element.path.toLowerCase() || filePath.includes(element.uri.substring(element.uri.lastIndexOf('/')).toLowerCase()))
+      let foundFile = {}
+
+      files.forEach(file => {
+        // Check if path matches query param
+        if (filePath.toLowerCase() === file.path.toLowerCase) {
+          foundFile = file
+        }
+
+        // check if uri matches filePath query param
+        if (file.uri) {
+          let uriFile = file.uri.substring(file.uri.lastIndexOf('/'))
+          if (uriFile) {
+            uriFile = uriFile.toLowerCase()
+          }
+          if (filePath.includes(uriFile)) {
+            foundFile = file
+          }
+        }
+      })
+
+      return foundFile
     }
   }
 }

--- a/nuxt.config.js
+++ b/nuxt.config.js
@@ -38,7 +38,7 @@ export default {
     ]
   },
   env: {
-    portal_api: process.env.PORTAL_API_HOST || 'https://sparc-api.herokuapp.com',
+    portal_api: process.env.PORTAL_API_HOST || 'http://localhost:5000 ',
     flatmap_api:
       process.env.FLATMAP_API_HOST || 'https://mapcore-demo.org/current/flatmap/v2/',
     crosscite_api_host:


### PR DESCRIPTION
# Description

There currently is an issue where the files page crashes when a directory is included in the 'files' object returned from pennsieve.

This PR adds more checks to keep this from crashing the app. 

You can see an example of it crashing here:
https://sparc.science/file/34/5?path=files%2Fderivative%2Fstim_proximal-colon_manometry.csv


![image](https://user-images.githubusercontent.com/37255664/183344130-e03d9076-86b0-4591-ad5b-cec2b89f4b87.png)

## Type of change

Delete those that don't apply.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

# How Has This Been Tested?

ran locally, clone this branch to test



# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have utilized components from the Design System Library where applicable
- [x] I have added unit tests that prove my fix is effective or that my feature works
