### PR TITLE
Update mapintegratedvuer:

### DIFF
--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
   "dependencies": {
     "@abi-software/flatmapvuer": "0.2.5",
     "@abi-software/gallery": "0.3.1",
-    "@abi-software/mapintegratedvuer": "^0.3.5",
+    "@abi-software/mapintegratedvuer": "^0.3.6",
     "@abi-software/plotvuer": "^0.3.0",
     "@abi-software/scaffoldvuer": "0.1.52",
     "@abi-software/simulationvuer": "^0.5.9",

--- a/yarn.lock
+++ b/yarn.lock
@@ -52,10 +52,10 @@
     lodash "^4.17.21"
     vue "^2.6.10"
 
-"@abi-software/flatmapvuer@^0.3.1":
-  version "0.3.1"
-  resolved "https://registry.yarnpkg.com/@abi-software/flatmapvuer/-/flatmapvuer-0.3.1.tgz#01301193df8e7e176cced3939e382cd0705c094a"
-  integrity sha512-7YVt7IMHC8AMtbHODEDu1qXidxV0b2vPbATvZna87Nt8vTBpLKwcAo5j/LlqiOM6aT2so0SRqSwPtYLy5/87Lw==
+"@abi-software/flatmapvuer@^0.3.2":
+  version "0.3.2"
+  resolved "https://registry.yarnpkg.com/@abi-software/flatmapvuer/-/flatmapvuer-0.3.2.tgz#68672b270c575b5c0e5990a9e492a2269768318b"
+  integrity sha512-1aPQrCj7rVFIEb5wAkzuG53dNMzKVfUe3xaT0ofY5XL7ybkloE/40SxVcbda5q+qccfTnq03Zu8R9nMg9m+XKg==
   dependencies:
     "@abi-software/flatmap-viewer" "^2.2.0-beta.16"
     "@abi-software/svg-sprite" "^0.1.14"
@@ -80,10 +80,10 @@
     element-ui "^2.15.0"
     vue "^2.6.11"
 
-"@abi-software/map-side-bar@^1.3.20":
-  version "1.3.20"
-  resolved "https://registry.yarnpkg.com/@abi-software/map-side-bar/-/map-side-bar-1.3.20.tgz#47675bc8601baca863d5393f2d4abcecacf44840"
-  integrity sha512-8pRB8BcPLiaOEc2K+Ljhp4RWeVntheHb4+STd9Mlj6mqIUyqeR7ksVeL6ESZwLkpg5paWbaYwB4NiYw0tHZtEg==
+"@abi-software/map-side-bar@^1.3.23":
+  version "1.3.23"
+  resolved "https://registry.yarnpkg.com/@abi-software/map-side-bar/-/map-side-bar-1.3.23.tgz#3235f924a1249c6566e963ef83fc82510de7bd8d"
+  integrity sha512-jdm6vmgWPTDYci0IClMUbz4yqscMamsP/V3dSETYwP9QBygWPDUNH22n5zsIfyqpwaGotVp6umtB+fBxzoOVLA==
   dependencies:
     "@abi-software/gallery" "^0.3.1"
     "@abi-software/svg-sprite" "^0.1.14"
@@ -91,13 +91,13 @@
     element-ui "^2.13.0"
     vue "^2.6.10"
 
-"@abi-software/mapintegratedvuer@^0.3.5":
-  version "0.3.5"
-  resolved "https://registry.yarnpkg.com/@abi-software/mapintegratedvuer/-/mapintegratedvuer-0.3.5.tgz#2c757a2a63520bb229caa48a747676c017292e11"
-  integrity sha512-kgRKCIP1hLFwRNgqS32Lp2i1t2a6GgnmVCXl6JUOAUFwxOuomzNUvIgvdYRijTYiThND+2Y4Df3o1kC7U3Y55w==
+"@abi-software/mapintegratedvuer@^0.3.6":
+  version "0.3.6"
+  resolved "https://registry.yarnpkg.com/@abi-software/mapintegratedvuer/-/mapintegratedvuer-0.3.6.tgz#ce6276413360ca5fdc7d0d0ab02308a1877788c1"
+  integrity sha512-zDr+jnpavsMy/tZbQNYGJSbMiN0jL8NcK68KpEp2vgrmO1eL72f9NcpvMAQyypveA+4qDqDwgZztr+6lwRqabQ==
   dependencies:
-    "@abi-software/flatmapvuer" "^0.3.1"
-    "@abi-software/map-side-bar" "^1.3.20"
+    "@abi-software/flatmapvuer" "^0.3.2"
+    "@abi-software/map-side-bar" "^1.3.23"
     "@abi-software/plotvuer" "^0.3.9"
     "@abi-software/scaffoldvuer" "^0.1.52"
     "@abi-software/simulationvuer" "^0.5.9"


### PR DESCRIPTION
# Description

 - Add a 'whats new?' section to the flatmap
 - Sidebar now supports opening datasets with mulitple scaffold context
   cards
 - Fix for the 'view source' throwing error on sidebar
 
 This pop-up was requested by fCCB

![image](https://user-images.githubusercontent.com/37255664/184059525-edb03e65-2a73-4027-acca-91a1710350b0.png)

Context cards now can have a card for each scaffold. This can be seen on dataset 150 (try opening the different scaffolds)
![image](https://user-images.githubusercontent.com/37255664/185036439-87000d40-9a5f-48ba-9833-f491bf5f8652.png)

## Type of change

Delete those that don't apply.

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

# How Has This Been Tested?

Run locally and can be tested at:

https://context-cards-demo.herokuapp.com/maps


# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have utilized components from the Design System Library where applicable
- [ ] I have added unit tests that prove my fix is effective or that my feature works
