### PR TITLE
add request embargoed data button

### DIFF
--- a/components/DatasetDetails/DatasetActionBox.vue
+++ b/components/DatasetDetails/DatasetActionBox.vue
@@ -5,19 +5,36 @@
       Embargoed
     </sparc-pill>
     <div class="button-container" v-if="datasetTypeName === 'scaffold' && !datasetInfo.study">
-      <sparc-tooltip
-        v-if="embargoed"
-        placement="left-center"
-      >
-        <div slot="data">
-          This scaffold is currently embargoed.<br />SPARC datasets are subject to a 1-year<br />embargo during which time the datasets<br />are visible only to members of the<br />SPARC consortium. During embargo, the<br />public will be able to view basic<br />metadata about these datasets as well<br />as their release date.
-        </div>
-        <el-button
-          slot="item"
+      <div v-if="embargoed">
+        <sparc-tooltip
+          placement="left-center"
         >
-          Get Saffold
-        </el-button>
-      </sparc-tooltip>
+          <div v-if="!cognitoUserToken && datasetInfo.embargoAccess !== EMBARGO_ACCESS.GRANTED" slot="data">
+            This scaffold is currently embargoed.<br />SPARC datasets are subject to a 1-year<br />embargo during which time the datasets<br />are visible only to members of the<br />SPARC consortium. During embargo, the<br />public will be able to view basic<br />metadata about these datasets as well<br />as their release date. Log in to request<br />access to embargoed data
+          </div>
+          <div v-else slot="data">
+            This scaffold is currently embargoed.<br />SPARC datasets are subject to a 1-year<br />embargo during which time the datasets<br />are visible only to members of the<br />SPARC consortium. During embargo, the<br />public will be able to view basic<br />metadata about these datasets as well<br />as their release date. You may request<br />access to the embargoed data<br />from the author
+          </div>
+          <el-button
+            v-if="cognitoUserToken && datasetInfo.embargoAccess !== EMBARGO_ACCESS.GRANTED"
+            slot="item"
+            :disabled="datasetInfo.embargoAccess != null"
+            @click="requestAccess()"
+          >
+            Request Access
+          </el-button> 
+          <el-button
+            v-else
+            slot="item"
+            :disabled="datasetInfo.embargoAccess !== EMBARGO_ACCESS.GRANTED || !hasFiles"
+          >
+            Get Scaffold
+          </el-button>
+        </sparc-tooltip>
+        <div class="body4" v-if="datasetInfo.embargoAccess === EMBARGO_ACCESS.REQUESTED">
+          Your request is pending approval...
+        </div>
+      </div>
       <div v-else-if="hasFiles" class="button-container" >
         <el-button
           class="dataset-button"
@@ -49,19 +66,36 @@
           Run Simulation
         </el-button>
       </a>
-      <sparc-tooltip
-        v-if="embargoed"
-        placement="left-center"
-      >
-        <div slot="data">
-          This model is currently embargoed.<br />SPARC datasets are subject to a 1-year<br />embargo during which time the datasets<br />are visible only to members of the<br />SPARC consortium. During embargo, the<br />public will be able to view basic<br />metadata about these datasets as well<br />as their release date.
-        </div>
-        <el-button
-          slot="item"
+      <div v-if="embargoed">
+        <sparc-tooltip
+          placement="left-center"
         >
-          Get Model
-        </el-button>
-      </sparc-tooltip>
+          <div v-if="!cognitoUserToken && datasetInfo.embargoAccess !== EMBARGO_ACCESS.GRANTED" slot="data">
+            This model is currently embargoed.<br />SPARC datasets are subject to a 1-year<br />embargo during which time the datasets<br />are visible only to members of the<br />SPARC consortium. During embargo, the<br />public will be able to view basic<br />metadata about these datasets as well<br />as their release date. Log in to request<br />access to embargoed data
+          </div>
+          <div v-else slot="data">
+            This model is currently embargoed.<br />SPARC datasets are subject to a 1-year<br />embargo during which time the datasets<br />are visible only to members of the<br />SPARC consortium. During embargo, the<br />public will be able to view basic<br />metadata about these datasets as well<br />as their release date. You may request<br />access to the embargoed data<br />from the author
+          </div>
+          <el-button
+            v-if="cognitoUserToken && datasetInfo.embargoAccess !== EMBARGO_ACCESS.GRANTED"
+            slot="item"
+            :disabled="datasetInfo.embargoAccess != null"
+            @click="requestAccess()"
+          >
+            Request Access
+          </el-button> 
+          <el-button
+            v-else
+            slot="item"
+            :disabled="datasetInfo.embargoAccess !== EMBARGO_ACCESS.GRANTED || !hasFiles"
+          >
+            Get Model
+          </el-button>
+        </sparc-tooltip>
+        <div class="body4" v-if="datasetInfo.embargoAccess === EMBARGO_ACCESS.REQUESTED">
+          Your request is pending approval...
+        </div>
+      </div>
       <el-button
         v-else-if="hasFiles"
         @click="actionButtonClicked('files')"
@@ -92,19 +126,36 @@
       </a>
     </div>
     <div class="button-container" v-else>
-      <sparc-tooltip
-        v-if="embargoed"
-        placement="left-center"
-      >
-        <div slot="data">
-          This dataset is currently embargoed.<br />SPARC datasets are subject to a 1-year<br />embargo during which time the datasets<br />are visible only to members of the<br />SPARC consortium. During embargo, the<br />public will be able to view basic<br />metadata about these datasets as well<br />as their release date.
-        </div>
-        <el-button
-          slot="item"
+      <div v-if="embargoed">
+        <sparc-tooltip
+          placement="left-center"
         >
-          Get Dataset
-        </el-button>
-      </sparc-tooltip>
+          <div v-if="!cognitoUserToken && datasetInfo.embargoAccess !== EMBARGO_ACCESS.GRANTED" slot="data">
+            This dataset is currently embargoed.<br />SPARC datasets are subject to a 1-year<br />embargo during which time the datasets<br />are visible only to members of the<br />SPARC consortium. During embargo, the<br />public will be able to view basic<br />metadata about these datasets as well<br />as their release date. Log in to request<br />access to embargoed data
+          </div>
+          <div v-else slot="data">
+            This dataset is currently embargoed.<br />SPARC datasets are subject to a 1-year<br />embargo during which time the datasets<br />are visible only to members of the<br />SPARC consortium. During embargo, the<br />public will be able to view basic<br />metadata about these datasets as well<br />as their release date. You may request<br />access to the embargoed data<br />from the author
+          </div>
+          <el-button
+            v-if="cognitoUserToken && datasetInfo.embargoAccess !== EMBARGO_ACCESS.GRANTED"
+            slot="item"
+            :disabled="datasetInfo.embargoAccess != null"
+            @click="requestAccess()"
+          >
+            Request Access
+          </el-button> 
+          <el-button
+            v-else
+            slot="item"
+            :disabled="datasetInfo.embargoAccess !== EMBARGO_ACCESS.GRANTED || !hasFiles"
+          >
+            Get Dataset
+          </el-button>
+        </sparc-tooltip>
+        <div class="body4" v-if="datasetInfo.embargoAccess === EMBARGO_ACCESS.REQUESTED">
+          Your request is pending approval...
+        </div>
+      </div>
       <el-button
         v-else-if="hasFiles"
         @click="actionButtonClicked('files')"
@@ -119,11 +170,13 @@
 </template>
 
 <script>
-import { mapState } from 'vuex'
+import { mapGetters, mapState } from 'vuex'
 import { propOr } from 'ramda'
 
+import { successMessage, failMessage } from '@/utils/notification-messages'
 import DatasetBannerImage from '@/components/DatasetBannerImage/DatasetBannerImage.vue'
 import SparcPill from '@/components/SparcPill/SparcPill.vue'
+import { EMBARGO_ACCESS } from '@/utils/constants'
 
 export default {
   name: 'DatasetActionBox',
@@ -134,11 +187,11 @@ export default {
   },
 
   computed: {
-    /**
-     * Get dataset info from the store
-     * @returns {Object}
-     */
     ...mapState('pages/datasets/datasetId', ['datasetInfo', 'datasetTypeName']),
+    ...mapGetters('user', ['cognitoUserToken']),
+    EMBARGO_ACCESS() {
+      return EMBARGO_ACCESS
+    },
     /**
      * Gets dataset version
      * @returns {Number}
@@ -212,6 +265,33 @@ export default {
 
       link.click()
       link.remove()
+    },
+    requestAccess(){
+       const url = `${process.env.discover_api_host}/datasets/${this.datasetInfo.id}/preview?api_key=${this.cognitoUserToken}`
+
+       this.$axios
+        .$post(url, {
+          datasetId: this.datasetInfo.id,
+        })
+        .then(() => {
+          this.updateEmbargoAccess(EMBARGO_ACCESS.REQUESTED)
+
+          this.$message(successMessage('Your request has been successfully submitted.'))
+        })
+        .catch((error) => {
+          this.$message(failMessage('Unable to submit request at this time.'))
+
+          throw error
+        })
+
+    },
+    updateEmbargoAccess(access) {
+      const newDatasetInfo = {
+        ...this.datasetDetails,
+        embargoAccess: access
+      }
+
+      store.dispatch('pages/datasets/datasetId/setDatasetInfo', newDatasetInfo)
     }
   }
 }

--- a/components/DatasetDetails/DatasetActionBox.vue
+++ b/components/DatasetDetails/DatasetActionBox.vue
@@ -9,14 +9,14 @@
         <sparc-tooltip
           placement="left-center"
         >
-          <div v-if="!cognitoUserToken && datasetInfo.embargoAccess !== EMBARGO_ACCESS.GRANTED" slot="data">
+          <div v-if="!userToken && datasetInfo.embargoAccess !== EMBARGO_ACCESS.GRANTED" slot="data">
             This scaffold is currently embargoed.<br />SPARC datasets are subject to a 1-year<br />embargo during which time the datasets<br />are visible only to members of the<br />SPARC consortium. During embargo, the<br />public will be able to view basic<br />metadata about these datasets as well<br />as their release date. Log in to request<br />access to embargoed data
           </div>
           <div v-else slot="data">
             This scaffold is currently embargoed.<br />SPARC datasets are subject to a 1-year<br />embargo during which time the datasets<br />are visible only to members of the<br />SPARC consortium. During embargo, the<br />public will be able to view basic<br />metadata about these datasets as well<br />as their release date. You may request<br />access to the embargoed data<br />from the author
           </div>
           <el-button
-            v-if="cognitoUserToken && datasetInfo.embargoAccess !== EMBARGO_ACCESS.GRANTED"
+            v-if="userToken && datasetInfo.embargoAccess !== EMBARGO_ACCESS.GRANTED"
             slot="item"
             :disabled="datasetInfo.embargoAccess != null"
             @click="requestAccess()"
@@ -70,14 +70,14 @@
         <sparc-tooltip
           placement="left-center"
         >
-          <div v-if="!cognitoUserToken && datasetInfo.embargoAccess !== EMBARGO_ACCESS.GRANTED" slot="data">
+          <div v-if="!userToken && datasetInfo.embargoAccess !== EMBARGO_ACCESS.GRANTED" slot="data">
             This model is currently embargoed.<br />SPARC datasets are subject to a 1-year<br />embargo during which time the datasets<br />are visible only to members of the<br />SPARC consortium. During embargo, the<br />public will be able to view basic<br />metadata about these datasets as well<br />as their release date. Log in to request<br />access to embargoed data
           </div>
           <div v-else slot="data">
             This model is currently embargoed.<br />SPARC datasets are subject to a 1-year<br />embargo during which time the datasets<br />are visible only to members of the<br />SPARC consortium. During embargo, the<br />public will be able to view basic<br />metadata about these datasets as well<br />as their release date. You may request<br />access to the embargoed data<br />from the author
           </div>
           <el-button
-            v-if="cognitoUserToken && datasetInfo.embargoAccess !== EMBARGO_ACCESS.GRANTED"
+            v-if="userToken && datasetInfo.embargoAccess !== EMBARGO_ACCESS.GRANTED"
             slot="item"
             :disabled="datasetInfo.embargoAccess != null"
             @click="requestAccess()"
@@ -130,14 +130,14 @@
         <sparc-tooltip
           placement="left-center"
         >
-          <div v-if="!cognitoUserToken && datasetInfo.embargoAccess !== EMBARGO_ACCESS.GRANTED" slot="data">
+          <div v-if="!userToken && datasetInfo.embargoAccess !== EMBARGO_ACCESS.GRANTED" slot="data">
             This dataset is currently embargoed.<br />SPARC datasets are subject to a 1-year<br />embargo during which time the datasets<br />are visible only to members of the<br />SPARC consortium. During embargo, the<br />public will be able to view basic<br />metadata about these datasets as well<br />as their release date. Log in to request<br />access to embargoed data
           </div>
           <div v-else slot="data">
             This dataset is currently embargoed.<br />SPARC datasets are subject to a 1-year<br />embargo during which time the datasets<br />are visible only to members of the<br />SPARC consortium. During embargo, the<br />public will be able to view basic<br />metadata about these datasets as well<br />as their release date. You may request<br />access to the embargoed data<br />from the author
           </div>
           <el-button
-            v-if="cognitoUserToken && datasetInfo.embargoAccess !== EMBARGO_ACCESS.GRANTED"
+            v-if="userToken && datasetInfo.embargoAccess !== EMBARGO_ACCESS.GRANTED"
             slot="item"
             :disabled="datasetInfo.embargoAccess != null"
             @click="requestAccess()"
@@ -189,6 +189,9 @@ export default {
   computed: {
     ...mapState('pages/datasets/datasetId', ['datasetInfo', 'datasetTypeName']),
     ...mapGetters('user', ['cognitoUserToken']),
+    userToken() {
+      return this.cognitoUserToken || this.$cookies.get('user-token')
+    },
     EMBARGO_ACCESS() {
       return EMBARGO_ACCESS
     },
@@ -267,7 +270,7 @@ export default {
       link.remove()
     },
     requestAccess(){
-       const url = `${process.env.discover_api_host}/datasets/${this.datasetInfo.id}/preview?api_key=${this.cognitoUserToken}`
+       const url = `${process.env.discover_api_host}/datasets/${this.datasetInfo.id}/preview?api_key=${this.userToken}`
 
        this.$axios
         .$post(url, {

--- a/components/DatasetDetails/DatasetDescriptionInfo.vue
+++ b/components/DatasetDetails/DatasetDescriptionInfo.vue
@@ -57,12 +57,13 @@
         v-if="datasetInfo.embargo"
         placement="left-center"
       >
-        <div slot="data">
+        <div v-if="embargoed && datasetInfo.embargoAccess !== EMBARGO_ACCESS.GRANTED" slot="data">
           This dataset is currently embargoed.<br />SPARC datasets are subject to a 1-year<br />embargo during which time the datasets<br />are visible only to members of the<br />SPARC consortium. During embargo, the<br />public will be able to view basic<br />metadata about these datasets as well<br />as their release date.
         </div>
         <el-button
           class="secondary"
           slot="item"
+          :disabled="embargoed && datasetInfo.embargoAccess !== EMBARGO_ACCESS.GRANTED"
         >
           Download Metadata file
         </el-button>
@@ -101,6 +102,7 @@ import createAlgoliaClient from '@/plugins/algolia.js'
 import { propOr } from 'ramda'
 import _ from 'lodash'
 import axios from 'axios'
+import { EMBARGO_ACCESS } from '@/utils/constants'
 
 const algoliaClient = createAlgoliaClient()
 const algoliaIndex = algoliaClient.initIndex(process.env.ALGOLIA_INDEX)
@@ -137,6 +139,12 @@ export default {
 
   computed: {
     ...mapState('pages/datasets/datasetId', ['datasetFacetsData','datasetInfo']),
+    EMBARGO_ACCESS() {
+      return EMBARGO_ACCESS
+    },
+    embargoed: function() {
+      return propOr(false, 'embargo', this.datasetInfo)
+    },
     anatomicalStructureText: function() {
       return this.getFacetText('Anatomical Structure')
     },

--- a/components/FilesTable/FilesTable.vue
+++ b/components/FilesTable/FilesTable.vue
@@ -305,7 +305,7 @@ import {
 
 import BfDownloadFile from '@/components/BfDownloadFile/BfDownloadFile'
 import OsparcFileViewersDialog from '@/components/FilesTable/OsparcFileViewersDialog.vue'
-import { mapState } from 'vuex'
+import { mapGetters, mapState } from 'vuex'
 
 import FormatStorage from '@/mixins/bf-storage-metrics/index'
 import { successMessage, failMessage } from '@/utils/notification-messages'
@@ -369,6 +369,10 @@ export default {
      * @returns {Object}
      */
     ...mapState('pages/datasets/datasetId', ['datasetInfo']),
+    ...mapGetters('user', ['cognitoUserToken']),
+    userToken() {
+      return this.cognitoUserToken || this.$cookies.get('user-token')
+    },
     /**
      * Compute the current path for the dataset's files.
      * @returns {String}
@@ -391,8 +395,9 @@ export default {
       const id = pathOr('', ['params', 'datasetId'], this.$route)
       const version = this.datasetVersion
       const url = `${process.env.discover_api_host}/datasets/${id}/versions/${version}/files/browse`
-
-      return `${url}?path=${this.path}&limit=${this.limit}`
+      var filesUrl = `${url}?path=${this.path}&limit=${this.limit}`
+      if (this.userToken) { filesUrl += `&api_key=${this.userToken}`}
+      return filesUrl
     },
 
     /**

--- a/mixins/fetch-pennsieve-file/index.js
+++ b/mixins/fetch-pennsieve-file/index.js
@@ -1,4 +1,9 @@
 export default {
+  computed: {
+    userToken: function() {
+      return this.$store.getters['user/cognitoUserToken'] || this.$cookies.get('user-token')
+    },
+  },
   methods: {
     /**
      * Workaround to using pennsieve endpoint https://docs.pennsieve.io/reference/getfile-1 to get the file
@@ -9,6 +14,7 @@ export default {
       const fileLocationEndIndex = filePath.lastIndexOf('/')
       const filesLocation = filePath.substring(0, fileLocationEndIndex)
       const filesUrl = `${process.env.discover_api_host}/datasets/${datasetId}/versions/${datasetVersion}/files/browse?path=${filesLocation}`
+      if (this.userToken) { filesUrl += `&api_key=${this.userToken}` }
       const filesResponse = await axios.$get(filesUrl)
       const files = filesResponse.files
       if (files.length === 0) {

--- a/pages/datasets/_datasetId.vue
+++ b/pages/datasets/_datasetId.vue
@@ -197,9 +197,12 @@ const getAssociatedProject = async (sparcAwardNumber) => {
  * @param {Function} $axios
  * @returns {Object}
  */
-const getDatasetDetails = async (datasetId, version, datasetTypeName, $axios) => {
+const getDatasetDetails = async (datasetId, version, userToken, datasetTypeName, $axios) => {
   const url = `${process.env.discover_api_host}/datasets/${datasetId}`
-  const datasetUrl = version ? `${url}/versions/${version}` : url
+  var datasetUrl = version ? `${url}/versions/${version}` : url
+  if (userToken) {
+    datasetUrl += `?api_key=${userToken}`
+  }
 
   const simulationUrl = `${process.env.portal_api}/sim/dataset/${datasetId}`
 
@@ -388,7 +391,7 @@ export default {
 
   mixins: [Request, DateUtils, FormatStorage],
 
-  async asyncData({ route, $axios, store }) {
+  async asyncData({ route, $axios, store, app }) {
     let tabsData = clone(tabs)
 
     const datasetId = pathOr('', ['params', 'datasetId'], route)
@@ -396,12 +399,14 @@ export default {
     const datasetFacetsData = await getDatasetFacetsData(route)
     const typeFacet = datasetFacetsData.find(child => child.key === 'item.types.name')
     const datasetTypeName = typeFacet !== undefined ? typeFacet.children[0].label : 'dataset'
+    const userToken = app.$cookies.get('user-token')
 
     const [organEntries, datasetDetails, versions, downloadsSummary] = await Promise.all([
       getOrganEntries(),
       getDatasetDetails(
         datasetId,
         route.params.version,
+        userToken,
         datasetTypeName,
         $axios
       ),

--- a/pages/datasets/_datasetId.vue
+++ b/pages/datasets/_datasetId.vue
@@ -433,7 +433,8 @@ export default {
 
     const changelogFileRequests = []
     versions.forEach(({ version }) => {
-      const changelogEndpoint = `${process.env.discover_api_host}/datasets/${datasetId}/versions/${version}/files?path=changelog.md`
+      var changelogEndpoint = `${process.env.discover_api_host}/datasets/${datasetId}/versions/${version}/files?path=changelog.md`
+      if (userToken) { changelogEndpoint += `&api_key=${userToken}` }
       changelogFileRequests.push(
         $axios.$get(changelogEndpoint).then(response => {
           return [{

--- a/utils/constants.js
+++ b/utils/constants.js
@@ -1,0 +1,4 @@
+export const EMBARGO_ACCESS = Object.freeze({
+  REQUESTED: 'requested',
+  GRANTED: 'granted'
+})


### PR DESCRIPTION
# Description

Added the ability for a  logged in user to request access to an embargoed dataset

## Type of change

- [X] New feature (non-breaking change which adds functionality)

# How Has This Been Tested?

Locally via test dataset 275. However cannot verify %100 until in staging for now since we do not have a pennsieve.net test dataset yet and localhost is not whitelisted in pennsieve.io

# Checklist:

- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my own code
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] I have utilized components from the Design System Library where applicable
