### PR TITLE
Fix where no context card was breaking scaffolds

### DIFF
--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
   "dependencies": {
     "@abi-software/flatmapvuer": "0.2.5",
     "@abi-software/gallery": "0.3.1",
-    "@abi-software/mapintegratedvuer": "^0.3.7",
+    "@abi-software/mapintegratedvuer": "^0.3.8",
     "@abi-software/plotvuer": "^0.3.0",
     "@abi-software/scaffoldvuer": "0.1.52",
     "@abi-software/simulationvuer": "^0.5.9",

--- a/yarn.lock
+++ b/yarn.lock
@@ -80,10 +80,10 @@
     element-ui "^2.15.0"
     vue "^2.6.11"
 
-"@abi-software/map-side-bar@^1.3.23":
-  version "1.3.23"
-  resolved "https://registry.yarnpkg.com/@abi-software/map-side-bar/-/map-side-bar-1.3.23.tgz#3235f924a1249c6566e963ef83fc82510de7bd8d"
-  integrity sha512-jdm6vmgWPTDYci0IClMUbz4yqscMamsP/V3dSETYwP9QBygWPDUNH22n5zsIfyqpwaGotVp6umtB+fBxzoOVLA==
+"@abi-software/map-side-bar@^1.3.25":
+  version "1.3.25"
+  resolved "https://registry.yarnpkg.com/@abi-software/map-side-bar/-/map-side-bar-1.3.25.tgz#c6373f2ec785f13e4ce2fd4f8b10ab7b3ebf9e74"
+  integrity sha512-puDs/tTL/XO218GfV0M0bSodLu3s9fDTNdxZ+1FaJlrOYMDBZBU5vVIEomEc4EdZ64ZfAM9iZIxiRTfkLwSUIg==
   dependencies:
     "@abi-software/gallery" "^0.3.1"
     "@abi-software/svg-sprite" "^0.1.14"
@@ -91,13 +91,13 @@
     element-ui "^2.13.0"
     vue "^2.6.10"
 
-"@abi-software/mapintegratedvuer@^0.3.7":
-  version "0.3.7"
-  resolved "https://registry.yarnpkg.com/@abi-software/mapintegratedvuer/-/mapintegratedvuer-0.3.7.tgz#f02d82bc91a8ec2f709f2442b66c0c13534c2e08"
-  integrity sha512-vbUPmIyDbPWxbq4JApPY5PQK4PQbkmxiaNj6A3fL5Cilw84iovem3xPVVG/Agqso39xOMzObZJGmbXK8gpe2kg==
+"@abi-software/mapintegratedvuer@^0.3.8":
+  version "0.3.8"
+  resolved "https://registry.yarnpkg.com/@abi-software/mapintegratedvuer/-/mapintegratedvuer-0.3.8.tgz#570cc4f9e819bc222016f90dbd9b338691d99868"
+  integrity sha512-dqbzRyvvE/IjItBa9y9xTtSSUOySOy9GbfkeypyqDUF+qN3sV5jJZ/iur0fbO91j6M38IG4fSxRKgX1OfSXJfw==
   dependencies:
     "@abi-software/flatmapvuer" "^0.3.3"
-    "@abi-software/map-side-bar" "^1.3.23"
+    "@abi-software/map-side-bar" "^1.3.25"
     "@abi-software/plotvuer" "^0.3.9"
     "@abi-software/scaffoldvuer" "^0.1.52"
     "@abi-software/simulationvuer" "^0.5.9"


### PR DESCRIPTION
# Description

Fix issue where no context cards annotated would crash a scaffold on the maps page. (This can be reproduced with dataset 77 by opening a scaffold from the sidebar)


## Type of change

Delete those that don't apply.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

# How Has This Been Tested?

Can be tested at:

https://context-cards-demo.herokuapp.com/maps

(will be available 10minutes after this PR)

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have utilized components from the Design System Library where applicable
- [ ] I have added unit tests that prove my fix is effective or that my feature works
