### PR TITLE
Added user token to pennsieve files requests

### DIFF
--- a/components/DatasetDetails/DatasetActionBox.vue
+++ b/components/DatasetDetails/DatasetActionBox.vue
@@ -148,6 +148,7 @@
             v-else
             slot="item"
             :disabled="datasetInfo.embargoAccess !== EMBARGO_ACCESS.GRANTED || !hasFiles"
+            @click="actionButtonClicked('files')"
           >
             Get Dataset
           </el-button>
@@ -294,7 +295,7 @@ export default {
         embargoAccess: access
       }
 
-      store.dispatch('pages/datasets/datasetId/setDatasetInfo', newDatasetInfo)
+      this.$store.dispatch('pages/datasets/datasetId/setDatasetInfo', newDatasetInfo)
     }
   }
 }

--- a/components/DatasetDetails/DatasetDescriptionInfo.vue
+++ b/components/DatasetDetails/DatasetDescriptionInfo.vue
@@ -64,6 +64,12 @@
           class="secondary"
           slot="item"
           :disabled="embargoed && datasetInfo.embargoAccess !== EMBARGO_ACCESS.GRANTED"
+           @click.prevent="
+            downloadItem({
+              url: downloadMetadataUrl,
+              label: 'metadata.json',
+            })
+        "
         >
           Download Metadata file
         </el-button>
@@ -97,7 +103,7 @@
 
 <script>
 import marked from '@/mixins/marked/index'
-import { mapState } from 'vuex'
+import { mapGetters, mapState } from 'vuex'
 import createAlgoliaClient from '@/plugins/algolia.js'
 import { propOr } from 'ramda'
 import _ from 'lodash'
@@ -139,6 +145,10 @@ export default {
 
   computed: {
     ...mapState('pages/datasets/datasetId', ['datasetFacetsData','datasetInfo']),
+    ...mapGetters('user', ['cognitoUserToken']),
+    userToken() {
+      return this.cognitoUserToken || this.$cookies.get('user-token')
+    },
     EMBARGO_ACCESS() {
       return EMBARGO_ACCESS
     },
@@ -192,7 +202,11 @@ export default {
      * @returns {String}
      */
     downloadMetadataUrl: function() {
-      return `${process.env.discover_api_host}/datasets/${this.datasetId}/versions/${this.versionId}/metadata`
+      var url = `${process.env.discover_api_host}/datasets/${this.datasetId}/versions/${this.versionId}/metadata`
+      if (this.userToken) {
+        url += `?api_key=${this.userToken}`
+      }
+      return url
     }
   },
 

--- a/components/DatasetDetails/DatasetFilesInfo.vue
+++ b/components/DatasetDetails/DatasetFilesInfo.vue
@@ -72,7 +72,7 @@
 </template>
 
 <script>
-import { mapState } from 'vuex'
+import { mapGetters, mapState } from 'vuex'
 import { propOr } from 'ramda'
 
 import { successMessage, failMessage } from '@/utils/notification-messages'
@@ -105,6 +105,10 @@ export default {
      * @returns {Object}
      */
     ...mapState('pages/datasets/datasetId', ['datasetInfo']),
+    ...mapGetters('user', ['cognitoUserToken']),
+    userToken() {
+      return this.cognitoUserToken || this.$cookies.get('user-token')
+    },
     /**
      * Checks whether the dataset download size is larger or smaller than 5GB
      * @returns {Boolean}
@@ -139,7 +143,11 @@ export default {
      * @returns {String}
      */
     downloadUrl: function() {
-      return `${process.env.discover_api_host}/datasets/${this.datasetId}/versions/${this.versionId}/download?downloadOrigin=SPARC`
+      var url = `${process.env.discover_api_host}/datasets/${this.datasetId}/versions/${this.versionId}/download?downloadOrigin=SPARC`
+      if (this.userToken) {
+        url += `?api_key=${this.userToken}`
+      }
+      return url
     }
   },
 


### PR DESCRIPTION
# Description

Added the user token to the pennsieve discover api requests in order to account for viewing embargoed data that users that have granted permission for

## Type of change

- [X] New feature (non-breaking change which adds functionality)

# How Has This Been Tested?

Locally via Postman, but cannot fully test until on staging

# Checklist:

- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my own code
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] I have utilized components from the Design System Library where applicable
