### PR TITLE
Updated hasFiles to include embargoed datasets

### DIFF
--- a/components/DatasetDetails/DatasetFilesInfo.vue
+++ b/components/DatasetDetails/DatasetFilesInfo.vue
@@ -145,7 +145,7 @@ export default {
     downloadUrl: function() {
       var url = `${process.env.discover_api_host}/datasets/${this.datasetId}/versions/${this.versionId}/download?downloadOrigin=SPARC`
       if (this.userToken) {
-        url += `?api_key=${this.userToken}`
+        url += `&api_key=${this.userToken}`
       }
       return url
     }

--- a/components/DatasetDetails/DatasetInformationBox.vue
+++ b/components/DatasetDetails/DatasetInformationBox.vue
@@ -112,7 +112,7 @@ export default {
       if (this.embargoed) {
         return 'To be confirmed'
       }
-      return propOr('', 'fileCount', this.datasetInfo)
+      return propOr('0', 'fileCount', this.datasetInfo)
     },
     /**
      * Get the dataset DOI and return the url

--- a/pages/datasets/_datasetId.vue
+++ b/pages/datasets/_datasetId.vue
@@ -97,6 +97,7 @@ import { mapState } from 'vuex'
 import { clone, propOr, pathOr, head, compose } from 'ramda'
 import { getAlgoliaFacets, facetPropPathMapping } from '../../pages/data/utils'
 import createAlgoliaClient from '@/plugins/algolia.js'
+import { EMBARGO_ACCESS } from '@/utils/constants'
 
 import DatasetHeader from '@/components/DatasetDetails/DatasetHeader.vue'
 import DatasetActionBox from '@/components/DatasetDetails/DatasetActionBox.vue'
@@ -511,6 +512,9 @@ export default {
      * Compute if the dataset is the latest version
      * @returns {Boolean}
      */
+    embargoAccess() {
+      return propOr(null, 'embargoAccess', this.datasetInfo)
+    },
     isLatestVersion() {
       if (this.versions !== undefined && this.versions.length) {
         const latestVersion = compose(propOr(1, 'version'), head)(this.versions)
@@ -715,7 +719,10 @@ export default {
       return numDownloads
     },
     hasFiles: function() {
-      return !this.embargoed && this.fileCount >= 1
+      if (this.embargoed && this.embargoAccess !== EMBARGO_ACCESS.GRANTED) {
+        return false
+      }
+      return this.fileCount >= 1
     },
     hasGalleryImages: function() {
       //Check if the data compatible with image gallery exists in biolucida image data and scicrunch data


### PR DESCRIPTION
# Description

Files were never getting shown for embargoed datasets even if the user had been granted permission

## Type of change

- [X] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

Locally

# Checklist:

- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my own code
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] I have utilized components from the Design System Library where applicable
