### PR TITLE
Add GA4 tracking. GA4 and UA tracking id to be set from environment variable.

### DIFF
--- a/nuxt.config.js
+++ b/nuxt.config.js
@@ -109,8 +109,8 @@ export default {
     SHOW_LOGIN_FEATURE: process.env.SHOW_LOGIN_FEATURE || 'false',
     LOGIN_API_URL: process.env.LOGIN_API_URL || 'https://api.pennsieve.net',
     ORCID_API_URL: process.env.ORCID_API_URL || 'https://pub.orcid.org/v2.1',
-    google_analytics_ga4: process.env.GOOGLE_ANALYTICS_GA4,
-    google_analytics_ua: process.env.GOOGLE_ANALYTICS_UA,
+    GOOGLE_ANALYTICS_GA4: process.env.GOOGLE_ANALYTICS_GA4,
+    GOOGLE_ANALYTICS_UA: process.env.GOOGLE_ANALYTICS_UA,
   },
 
   serverMiddleware: [

--- a/nuxt.config.js
+++ b/nuxt.config.js
@@ -108,7 +108,9 @@ export default {
     AWS_OAUTH_RESPONSE_TYPE: process.env.AWS_OAUTH_RESPONSE_TYPE || "token",
     SHOW_LOGIN_FEATURE: process.env.SHOW_LOGIN_FEATURE || 'false',
     LOGIN_API_URL: process.env.LOGIN_API_URL || 'https://api.pennsieve.net',
-    ORCID_API_URL: process.env.ORCID_API_URL || 'https://pub.orcid.org/v2.1'
+    ORCID_API_URL: process.env.ORCID_API_URL || 'https://pub.orcid.org/v2.1',
+    google_analytics_ga4: process.env.GOOGLE_ANALYTICS_GA4,
+    google_analytics_ua: process.env.GOOGLE_ANALYTICS_UA,
   },
 
   serverMiddleware: [
@@ -152,6 +154,7 @@ export default {
     '@/plugins/contentful',
     '@/plugins/amplify',
     '@/plugins/documentation-hub-redirects',
+    "@/plugins/vue-gtag.client.js",
     { src: '@/plugins/postscribe', mode: 'client' },
     { src: '@/plugins/system-design-components', mode: 'client' },
     { src: '@/plugins/tsviewer', mode: 'client' }
@@ -164,7 +167,7 @@ export default {
     [
       '@nuxtjs/google-analytics',
       {
-        id: 'UA-143804703-1'
+        id: process.env.GOOGLE_ANALYTICS_UA
       }
     ]
   ],

--- a/package.json
+++ b/package.json
@@ -54,6 +54,7 @@
     "tsviewer": "^0.1.0",
     "vue": "^2.6.10",
     "vue-clipboard2": "^0.3.1",
+    "vue-gtag": "1.16.1",
     "vue-infinite-loading": "^2.4.4",
     "vue-meta": "^2.3.2",
     "vue-social-sharing": "^3.0.4",

--- a/plugins/vue-gtag.client.js
+++ b/plugins/vue-gtag.client.js
@@ -1,0 +1,10 @@
+
+import Vue from 'vue'
+import VueGtag from 'vue-gtag'
+
+export default ({ app }) => {
+  Vue.use(VueGtag, {
+    config: { id: process.env.google_analytics_ga4 },
+    appName: 'SPARC Portal',
+  }, app.router)
+}

--- a/plugins/vue-gtag.client.js
+++ b/plugins/vue-gtag.client.js
@@ -4,7 +4,7 @@ import VueGtag from 'vue-gtag'
 
 export default ({ app }) => {
   Vue.use(VueGtag, {
-    config: { id: process.env.google_analytics_ga4 },
+    config: { id: process.env.GOOGLE_ANALYTICS_GA4 },
     appName: 'SPARC Portal',
   }, app.router)
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -15233,6 +15233,11 @@ vue-eslint-parser@^7.0.0:
     esquery "^1.4.0"
     lodash "^4.17.15"
 
+vue-gtag@1.16.1:
+  version "1.16.1"
+  resolved "https://registry.yarnpkg.com/vue-gtag/-/vue-gtag-1.16.1.tgz#edb2f20ab4f6c4d4d372dfecf8c1fcc8ab890181"
+  integrity sha512-5vs0pSGxdqrfXqN1Qwt0ZFXG0iTYjRMu/saddc7QIC5yp+DKgjWQRpGYVa7Pq+KbThxwzzMfo0sGi7ISa6NowA==
+
 vue-hot-reload-api@^2.3.0:
   version "2.3.4"
   resolved "https://registry.yarnpkg.com/vue-hot-reload-api/-/vue-hot-reload-api-2.3.4.tgz#532955cc1eb208a3d990b3a9f9a70574657e08f2"


### PR DESCRIPTION
# Description

Add GA4 tracking. The tracking id should now be set using the environment variables - GOOGLE_ANALYTICS_GA4 and GOOGLE_ANALYTICS_UA .
The variables have been setup for both staging and production instances already. There are now four properties setup on Google Analytics, one GA4 and one UA tracking properties for each of the staging and production sites.

## Type of change

Delete those that don't apply.

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)

# How Has This Been Tested?
This has been tested locally and I can confirm that the dual tracking is working currently.


# Checklist:

- [ ] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have utilized components from the Design System Library where applicable
- [ ] I have added unit tests that prove my fix is effective or that my feature works
