### PR TITLE
Addressed intermittent bugs with viewing embargoed data

### DIFF
--- a/components/DatasetDetails/DatasetActionBox.vue
+++ b/components/DatasetDetails/DatasetActionBox.vue
@@ -1,7 +1,7 @@
 <template>
   <div class="dataset-action-box mt-16 p-8">
     <dataset-banner-image :src="datasetImage" />
-    <sparc-pill class="sparc-pill" v-if="datasetInfo.embargo">
+    <sparc-pill class="sparc-pill" v-if="embargoed">
       Embargoed
     </sparc-pill>
     <div class="button-container" v-if="datasetTypeName === 'scaffold' && !datasetInfo.study">
@@ -9,16 +9,16 @@
         <sparc-tooltip
           placement="left-center"
         >
-          <div v-if="!userToken && datasetInfo.embargoAccess !== EMBARGO_ACCESS.GRANTED" slot="data">
+          <div v-if="!userToken && embargoAccess !== EMBARGO_ACCESS.GRANTED" slot="data">
             This scaffold is currently embargoed.<br />SPARC datasets are subject to a 1-year<br />embargo during which time the datasets<br />are visible only to members of the<br />SPARC consortium. During embargo, the<br />public will be able to view basic<br />metadata about these datasets as well<br />as their release date. Log in to request<br />access to embargoed data
           </div>
           <div v-else slot="data">
             This scaffold is currently embargoed.<br />SPARC datasets are subject to a 1-year<br />embargo during which time the datasets<br />are visible only to members of the<br />SPARC consortium. During embargo, the<br />public will be able to view basic<br />metadata about these datasets as well<br />as their release date. You may request<br />access to the embargoed data<br />from the author
           </div>
           <el-button
-            v-if="userToken && datasetInfo.embargoAccess !== EMBARGO_ACCESS.GRANTED"
+            v-if="userToken && embargoAccess !== EMBARGO_ACCESS.GRANTED"
             slot="item"
-            :disabled="datasetInfo.embargoAccess != null"
+            :disabled="embargoAccess != null"
             @click="requestAccess()"
           >
             Request Access
@@ -26,12 +26,12 @@
           <el-button
             v-else
             slot="item"
-            :disabled="datasetInfo.embargoAccess !== EMBARGO_ACCESS.GRANTED || !hasFiles"
+            :disabled="embargoAccess !== EMBARGO_ACCESS.GRANTED || !hasFiles"
           >
             Get Scaffold
           </el-button>
         </sparc-tooltip>
-        <div class="body4" v-if="datasetInfo.embargoAccess === EMBARGO_ACCESS.REQUESTED">
+        <div class="body4" v-if="embargoAccess === EMBARGO_ACCESS.REQUESTED">
           Your request is pending approval...
         </div>
       </div>
@@ -70,16 +70,16 @@
         <sparc-tooltip
           placement="left-center"
         >
-          <div v-if="!userToken && datasetInfo.embargoAccess !== EMBARGO_ACCESS.GRANTED" slot="data">
+          <div v-if="!userToken && embargoAccess !== EMBARGO_ACCESS.GRANTED" slot="data">
             This model is currently embargoed.<br />SPARC datasets are subject to a 1-year<br />embargo during which time the datasets<br />are visible only to members of the<br />SPARC consortium. During embargo, the<br />public will be able to view basic<br />metadata about these datasets as well<br />as their release date. Log in to request<br />access to embargoed data
           </div>
           <div v-else slot="data">
             This model is currently embargoed.<br />SPARC datasets are subject to a 1-year<br />embargo during which time the datasets<br />are visible only to members of the<br />SPARC consortium. During embargo, the<br />public will be able to view basic<br />metadata about these datasets as well<br />as their release date. You may request<br />access to the embargoed data<br />from the author
           </div>
           <el-button
-            v-if="userToken && datasetInfo.embargoAccess !== EMBARGO_ACCESS.GRANTED"
+            v-if="userToken && embargoAccess !== EMBARGO_ACCESS.GRANTED"
             slot="item"
-            :disabled="datasetInfo.embargoAccess != null"
+            :disabled="embargoAccess != null"
             @click="requestAccess()"
           >
             Request Access
@@ -87,12 +87,12 @@
           <el-button
             v-else
             slot="item"
-            :disabled="datasetInfo.embargoAccess !== EMBARGO_ACCESS.GRANTED || !hasFiles"
+            :disabled="embargoAccess !== EMBARGO_ACCESS.GRANTED || !hasFiles"
           >
             Get Model
           </el-button>
         </sparc-tooltip>
-        <div class="body4" v-if="datasetInfo.embargoAccess === EMBARGO_ACCESS.REQUESTED">
+        <div class="body4" v-if="embargoAccess === EMBARGO_ACCESS.REQUESTED">
           Your request is pending approval...
         </div>
       </div>
@@ -130,16 +130,16 @@
         <sparc-tooltip
           placement="left-center"
         >
-          <div v-if="!userToken && datasetInfo.embargoAccess !== EMBARGO_ACCESS.GRANTED" slot="data">
+          <div v-if="!userToken && embargoAccess !== EMBARGO_ACCESS.GRANTED" slot="data">
             This dataset is currently embargoed.<br />SPARC datasets are subject to a 1-year<br />embargo during which time the datasets<br />are visible only to members of the<br />SPARC consortium. During embargo, the<br />public will be able to view basic<br />metadata about these datasets as well<br />as their release date. Log in to request<br />access to embargoed data
           </div>
           <div v-else slot="data">
             This dataset is currently embargoed.<br />SPARC datasets are subject to a 1-year<br />embargo during which time the datasets<br />are visible only to members of the<br />SPARC consortium. During embargo, the<br />public will be able to view basic<br />metadata about these datasets as well<br />as their release date. You may request<br />access to the embargoed data<br />from the author
           </div>
           <el-button
-            v-if="userToken && datasetInfo.embargoAccess !== EMBARGO_ACCESS.GRANTED"
+            v-if="userToken && embargoAccess !== EMBARGO_ACCESS.GRANTED"
             slot="item"
-            :disabled="datasetInfo.embargoAccess != null"
+            :disabled="embargoAccess != null"
             @click="requestAccess()"
           >
             Request Access
@@ -147,13 +147,13 @@
           <el-button
             v-else
             slot="item"
-            :disabled="datasetInfo.embargoAccess !== EMBARGO_ACCESS.GRANTED || !hasFiles"
+            :disabled="embargoAccess !== EMBARGO_ACCESS.GRANTED || !hasFiles"
             @click="actionButtonClicked('files')"
           >
             Get Dataset
           </el-button>
         </sparc-tooltip>
-        <div class="body4" v-if="datasetInfo.embargoAccess === EMBARGO_ACCESS.REQUESTED">
+        <div class="body4" v-if="embargoAccess === EMBARGO_ACCESS.REQUESTED">
           Your request is pending approval...
         </div>
       </div>
@@ -195,6 +195,9 @@ export default {
     },
     EMBARGO_ACCESS() {
       return EMBARGO_ACCESS
+    },
+    embargoAccess() {
+      return propOr(null, 'embargoAccess', this.datasetInfo)
     },
     /**
      * Gets dataset version

--- a/components/DatasetDetails/DatasetDescriptionInfo.vue
+++ b/components/DatasetDetails/DatasetDescriptionInfo.vue
@@ -57,13 +57,13 @@
         v-if="datasetInfo.embargo"
         placement="left-center"
       >
-        <div v-if="embargoed && datasetInfo.embargoAccess !== EMBARGO_ACCESS.GRANTED" slot="data">
+        <div v-if="embargoed && embargoAccess !== EMBARGO_ACCESS.GRANTED" slot="data">
           This dataset is currently embargoed.<br />SPARC datasets are subject to a 1-year<br />embargo during which time the datasets<br />are visible only to members of the<br />SPARC consortium. During embargo, the<br />public will be able to view basic<br />metadata about these datasets as well<br />as their release date.
         </div>
         <el-button
           class="secondary"
           slot="item"
-          :disabled="embargoed && datasetInfo.embargoAccess !== EMBARGO_ACCESS.GRANTED"
+          :disabled="embargoed && embargoAccess !== EMBARGO_ACCESS.GRANTED"
            @click.prevent="
             downloadItem({
               url: downloadMetadataUrl,
@@ -151,6 +151,9 @@ export default {
     },
     EMBARGO_ACCESS() {
       return EMBARGO_ACCESS
+    },
+    embargoAccess() {
+      return propOr(null, 'embargoAccess', this.datasetInfo)
     },
     embargoed: function() {
       return propOr(false, 'embargo', this.datasetInfo)

--- a/components/DatasetDetails/DatasetInformationBox.vue
+++ b/components/DatasetDetails/DatasetInformationBox.vue
@@ -46,6 +46,7 @@ import { propOr, compose, split } from 'ramda'
 
 import FormatStorage from '@/mixins/bf-storage-metrics'
 import DateUtils from '@/mixins/format-date'
+import { EMBARGO_ACCESS } from '@/utils/constants'
 
 export default {
   name: 'DatasetInformationBox',
@@ -69,6 +70,12 @@ export default {
      * @returns {Object}
      */
     ...mapState('pages/datasets/datasetId', ['datasetInfo', 'datasetTypeName','showAllVersionsModal']),
+    embargoAccess() {
+      return propOr(null, 'embargoAccess', this.datasetInfo)
+    },
+    fileCount() {
+      return propOr('0', 'fileCount', this.datasetInfo)
+    },
     /**
      * Gets dataset version
      * @returns {Number}
@@ -109,10 +116,10 @@ export default {
      * @returns {String}
      */
     datasetFiles: function() {
-      if (this.embargoed) {
-        return 'To be confirmed'
+      if (this.embargoed && this.embargoAccess !== EMBARGO_ACCESS.GRANTED) {
+        return 0
       }
-      return propOr('0', 'fileCount', this.datasetInfo)
+      return this.fileCount
     },
     /**
      * Get the dataset DOI and return the url

--- a/components/FilesTable/FilesTable.vue
+++ b/components/FilesTable/FilesTable.vue
@@ -434,11 +434,13 @@ export default {
   },
 
   watch: {
-    '$route.query.path': 'pathQueryChanged'
-  },
-
-  created: function() {
-    this.getFiles()
+    '$route.query.path': 'pathQueryChanged',
+    userToken: {
+      handler: function() {
+        this.getFiles()
+      },
+      immediate: true
+    }
   },
 
   methods: {


### PR DESCRIPTION
# Description

There were some inconsistencies when attempting to view files for embargoed test dataset 275 which I believe were a result of nested properties not triggering re-renders. I have created computed properties/watchers to deal with the issues

## Type of change

- [X] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

Locally via dataset 275

# Checklist:

- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my own code
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] I have utilized components from the Design System Library where applicable
