### PR TITLE
Addressed Gazelle Feedback for news and events page refactor

### DIFF
--- a/components/CommunitySpotlight/CommunitySpotlightItem.vue
+++ b/components/CommunitySpotlight/CommunitySpotlightItem.vue
@@ -59,6 +59,14 @@
             {{ story.spotlightType }}
           </td>
         </tr>
+        <tr>
+          <td class="property-name-column">
+            Anatomical Structure
+          </td>
+          <td>
+            {{ anatomicalStructureText }}
+          </td>
+        </tr>
       </table>
     </div>
   </div>
@@ -77,6 +85,9 @@ export default {
   computed: {
     embeddedVideoSrc: function() {
       return youtubeEmbeddedSource(this.story.fields.youtubeUrl)
+    },
+    anatomicalStructureText: function() {
+      return this.story.anatomicalStructure ? this.story.anatomicalStructure.join(', ') : 'n/a'
     }
   }
 }
@@ -127,6 +138,7 @@ export default {
   }
   border: none;
   padding: 0;
+  padding-bottom: 1rem;
 }
 // The outermost bottom border of the table. Element UI adds psuedo elements to create the bottom table border that we must hide to remove
 table:not([class^='el-table__'])::before {

--- a/components/CommunitySpotlight/CommunitySpotlightItem.vue
+++ b/components/CommunitySpotlight/CommunitySpotlightItem.vue
@@ -96,7 +96,7 @@ export default {
   top: 0;
   left: 0;
   width: 100%;
-  height: fit-content;
+  height: auto;
 }
 
 .story-result {

--- a/components/CommunitySpotlight/CommunitySpotlightListings.vue
+++ b/components/CommunitySpotlight/CommunitySpotlightListings.vue
@@ -63,13 +63,15 @@ export default {
     // The community spotlight item component needs to use the properties off the actual success stories/fireside chats
     getLinkedItem(communitySpotlightItem) {
       const linkedItem = pathOr('', ['fields','linkedItem'], communitySpotlightItem)
+      const anatomicalStructure = pathOr('', ['fields','anatomicalStructure'], communitySpotlightItem)
       const spotlightTypeId = pathOr('', ['fields','itemType'], communitySpotlightItem)
       const spotlightType = SPOTLIGHT_TYPE_MAPPING.find(item => {
         return item.id == spotlightTypeId
       })?.label
       return {
         ...linkedItem,
-        spotlightType
+        spotlightType,
+        anatomicalStructure
       }
     }
   }

--- a/components/EventListItem/EventListItem.vue
+++ b/components/EventListItem/EventListItem.vue
@@ -145,6 +145,7 @@ table:not([class^='el-table__'])::before {
   flex-direction: row;
   img {
     display: block;
+    object-fit: cover;
     width: 86px;
     height: 86px;
   }

--- a/components/EventListItem/EventListItem.vue
+++ b/components/EventListItem/EventListItem.vue
@@ -146,11 +146,12 @@ table:not([class^='el-table__'])::before {
   img {
     display: block;
     object-fit: cover;
-    width: 86px;
-    height: 86px;
+    width: 8rem;
+    height: 8rem;
   }
 
   .image {
+    position: relative;
     margin: 2px;
   }
 

--- a/components/FacetMenu/EventsFacetMenu.vue
+++ b/components/FacetMenu/EventsFacetMenu.vue
@@ -87,7 +87,6 @@ export default {
 
   data() {
     return {
-      eventTypeOptions,
       eventTypeOptions: eventTypeOptions,
       selectedEventTypeOptions: [],
       eventDateOption: 'show all',

--- a/components/NewsListItem/NewsListItem.vue
+++ b/components/NewsListItem/NewsListItem.vue
@@ -1,7 +1,10 @@
 <template>
   <div class="news-list-item">
     <div v-if="item.fields.image" class="image">
-      <event-banner-image :src="item.fields.image.fields.file.url" />
+      <event-banner-image :src="item.fields.image.fields.file.url"/>
+      <sparc-pill class="sparc-pill" v-if="fundingOpportunity">
+        Funding
+      </sparc-pill>
     </div>
     <div class="news-content-wrap">
       <h3>
@@ -32,8 +35,10 @@
 </template>
 
 <script>
+import { pathOr } from 'ramda'
 import FormatDate from '@/mixins/format-date'
 import EventBannerImage from '@/components/EventBannerImage/EventBannerImage.vue'
+import SparcPill from '@/components/SparcPill/SparcPill.vue'
 
 import { isInternalLink } from '@/mixins/marked/index'
 
@@ -41,7 +46,8 @@ export default {
   name: 'NewsListItem',
 
   components: {
-    EventBannerImage
+    EventBannerImage,
+    SparcPill
   },
 
   mixins: [FormatDate],
@@ -50,7 +56,7 @@ export default {
     item: {
       type: Object,
       default: () => {}
-    }
+    },
   },
 
   computed: {
@@ -60,6 +66,10 @@ export default {
      */
     publishedDate: function() {
       return this.formatDate(this.item.fields.publishedDate || '')
+    },
+    fundingOpportunity: function() {
+      const subjectTag = pathOr([], ['fields', 'subject'], this.item)
+      return subjectTag == 'Funding Opportunity'
     }
   },
 
@@ -90,16 +100,22 @@ p {
   img {
     display: block;
     object-fit: cover;
-    width: 86px;
-    height: 86px;
+    width: 8rem;
+    height: 8rem;
   }
 
   .image {
+    position: relative;
     margin: 2px;
   }
 
   .news-content-wrap {
     margin-left: 16px;
   }
+}
+.sparc-pill {
+  position: absolute;
+  right: .25rem;
+  top: .25rem;
 }
 </style>

--- a/components/NewsListItem/NewsListItem.vue
+++ b/components/NewsListItem/NewsListItem.vue
@@ -1,38 +1,48 @@
 <template>
   <div class="news-list-item">
-    <h3>
-      <nuxt-link
-        v-if="item.fields.requiresADetailsPage"
-        :to="{
-          name: 'news-and-events-news-id',
-          params: { id: item.sys.id }
-        }"
-      >
-        {{ item.fields.title }}
-      </nuxt-link>
-      <a
-        v-else
-        :href="item.fields.url"
-        :target="isInternalLink('item.fields.url') ? '_self' : '_blank'"
-      >
-        {{ item.fields.title }}
-        <svg-icon v-if="!isInternalLink('item.fields.url')" name="icon-open" height="30" width="30" />
-      </a>
-    </h3>
-    <p>{{ item.fields.summary }}</p>
-    <p class="news-list-item__date">
-      {{ publishedDate }}
-    </p>
+    <div v-if="item.fields.image" class="image">
+      <event-banner-image :src="item.fields.image.fields.file.url" />
+    </div>
+    <div class="news-content-wrap">
+      <h3>
+        <nuxt-link
+          v-if="item.fields.requiresADetailsPage"
+          :to="{
+            name: 'news-and-events-news-id',
+            params: { id: item.sys.id }
+          }"
+        >
+          {{ item.fields.title }}
+        </nuxt-link>
+        <a
+          v-else
+          :href="item.fields.url"
+          :target="isInternalLink('item.fields.url') ? '_self' : '_blank'"
+        >
+          {{ item.fields.title }}
+          <svg-icon v-if="!isInternalLink('item.fields.url')" name="icon-open" height="30" width="30" />
+        </a>
+      </h3>
+      <p>{{ item.fields.summary }}</p>
+      <p class="news-list-item__date">
+        {{ publishedDate }}
+      </p>
+    </div>
   </div>
 </template>
 
 <script>
 import FormatDate from '@/mixins/format-date'
+import EventBannerImage from '@/components/EventBannerImage/EventBannerImage.vue'
 
 import { isInternalLink } from '@/mixins/marked/index'
 
 export default {
   name: 'NewsListItem',
+
+  components: {
+    EventBannerImage
+  },
 
   mixins: [FormatDate],
 
@@ -73,5 +83,23 @@ p {
   font-size: 0.875rem;
   font-style: italic;
   margin: 0;
+}
+.news-list-item {
+  display: flex;
+  flex-direction: row;
+  img {
+    display: block;
+    object-fit: cover;
+    width: 86px;
+    height: 86px;
+  }
+
+  .image {
+    margin: 2px;
+  }
+
+  .news-content-wrap {
+    margin-left: 16px;
+  }
 }
 </style>

--- a/pages/news-and-events/community-spotlight/index.vue
+++ b/pages/news-and-events/community-spotlight/index.vue
@@ -181,7 +181,7 @@ export default Vue.extend<CommunitySpotlightData, CommunitySpotlightMethods, Com
   // multiple content types while applying a field filter or order in contentful api as outlined here:
   // https://www.contentfulcommunity.com/t/how-to-query-on-multiple-content-types/473
   async asyncData({ route }) {
-    const communitySpotlightItems = await fetchCommunitySpotlightItems(client, route.query.search, undefined, undefined, 10, 0)
+    const communitySpotlightItems = await fetchCommunitySpotlightItems(client, route.query.search, undefined, undefined, undefined, 10, 0)
 
     return {
       communitySpotlightItems
@@ -213,7 +213,7 @@ export default Vue.extend<CommunitySpotlightData, CommunitySpotlightMethods, Com
       handler: async function() {
         // we use next tick to wait for the facet menu to be mounted
         this.$nextTick(async () => {
-          this.communitySpotlightItems = await fetchCommunitySpotlightItems(client, this.$route.query.search, this.spotlightTypes, this.sortOrder, 10, 0)
+          this.communitySpotlightItems = await fetchCommunitySpotlightItems(client, this.$route.query.search, this.spotlightTypes, this.anatomicalStructures, this.sortOrder, 10, 0)
         })
       },
       immediate: true
@@ -221,7 +221,10 @@ export default Vue.extend<CommunitySpotlightData, CommunitySpotlightMethods, Com
   },
   computed: {
     spotlightTypes: function() {
-      return this.$route.query.selectedSpotlightTypeOptions || undefined
+      return this.$route.query.selectedSpotlightTypes || undefined
+    },
+    anatomicalStructures: function() {
+      return this.$route.query.selectedAnatomicalStructures || undefined
     },
     sortOrder: function() {
       return propOr('-fields.startDate', 'sortOrder', this.selectedSortOption)
@@ -235,7 +238,7 @@ export default Vue.extend<CommunitySpotlightData, CommunitySpotlightMethods, Com
     async onPaginationPageChange(page) {
       const { limit } = this.communitySpotlightItems
       const offset = (page - 1) * limit
-      const response = await fetchCommunitySpotlightItems(client, this.$route.query.search, this.spotlightTypes, this.sortOrder, limit, offset)
+      const response = await fetchCommunitySpotlightItems(client, this.$route.query.search, this.spotlightTypes, this.anatomicalStructures, this.sortOrder, limit, offset)
       this.communitySpotlightItems = response
     },
     /**
@@ -244,24 +247,26 @@ export default Vue.extend<CommunitySpotlightData, CommunitySpotlightMethods, Com
      */
     async onPaginationLimitChange(limit) {
       const newLimit = limit === 'View All' ? this.communitySpotlightItems.total : limit
-      const response = await fetchCommunitySpotlightItems(client, this.$route.query.search, this.spotlightTypes, this.sortOrder, newLimit, 0)
+      const response = await fetchCommunitySpotlightItems(client, this.$route.query.search, this.spotlightTypes, this.anatomicalStructures, this.sortOrder, newLimit, 0)
       this.communitySpotlightItems = response
     },
     async onSortOptionChange(option) {
       this.selectedSortOption = option
-      const response = await fetchCommunitySpotlightItems(client, this.$route.query.search, this.spotlightTypes, this.sortOrder, this.communitySpotlightItems.limit, 0)
+      const response = await fetchCommunitySpotlightItems(client, this.$route.query.search, this.spotlightTypes, this.anatomicalStructures, this.sortOrder, this.communitySpotlightItems.limit, 0)
       this.communitySpotlightItems = response
     },
     // The community spotlight item component needs to use the properties off the actual success stories/fireside chats
     getLinkedItem(communitySpotlightItem) {
       const linkedItem = pathOr('', ['fields','linkedItem'], communitySpotlightItem)
+      const anatomicalStructure = pathOr('', ['fields','anatomicalStructure'], communitySpotlightItem)
       const spotlightTypeId = pathOr('', ['fields','itemType'], communitySpotlightItem)
       const spotlightType = SPOTLIGHT_TYPE_MAPPING.find(item => {
         return item.id == spotlightTypeId
       })?.label
       return {
         ...linkedItem,
-        spotlightType
+        spotlightType,
+        anatomicalStructure
       }
     }
   },

--- a/pages/news-and-events/community-spotlight/index.vue
+++ b/pages/news-and-events/community-spotlight/index.vue
@@ -147,6 +147,11 @@ const sortOptions = [
     id: 'alphabatical',
     sortOrder: 'fields.title'
   },
+  {
+    label: 'Z-A',
+    id: 'reverseAlphabatical',
+    sortOrder: '-fields.title'
+  },
 ]
 
 const SPOTLIGHT_TYPE_MAPPING = [

--- a/pages/news-and-events/events/index.vue
+++ b/pages/news-and-events/events/index.vue
@@ -147,6 +147,11 @@ const sortOptions = [
     id: 'alphabatical',
     sortOrder: 'fields.title'
   },
+  {
+    label: 'Z-A',
+    id: 'reverseAlphabatical',
+    sortOrder: '-fields.title'
+  },
 ]
 
 export default Vue.extend<EventsData, EventsMethods, EventsComputed, never>({

--- a/pages/news-and-events/index.vue
+++ b/pages/news-and-events/index.vue
@@ -250,7 +250,7 @@ export default Vue.extend<Data, Methods, Computed, never>({
      * Get all news
      */
     getAllNews: async function() {
-      const news = await fetchNews(client, this.$route.query.search as string, undefined, undefined, undefined, this.news.total, 2)
+      const news = await fetchNews(client, this.$route.query.search as string, undefined, undefined, undefined, undefined, this.news.total, 2)
       this.news = { ...this.news, items: { ...this.news.items, ...news.items } }
     },
     eventsTabChanged(newTab) {

--- a/pages/news-and-events/model.ts
+++ b/pages/news-and-events/model.ts
@@ -37,11 +37,11 @@ export const fetchData = async (client: ContentfulClientApi, terms?: string, lim
       limit
     })
 
-    const news = await fetchNews(client, query, undefined, undefined, undefined, limit)
+    const news = await fetchNews(client, query, undefined, undefined, undefined, undefined, limit)
 
     const page = await client.getEntry<PageData>(process.env.ctf_news_and_events_page_id ?? '')
 
-    const stories = await fetchCommunitySpotlightItems(client, query, undefined, undefined, 2, 0)
+    const stories = await fetchCommunitySpotlightItems(client, query, undefined, undefined, undefined, 2, 0)
 
     return {
       upcomingEvents,
@@ -83,7 +83,7 @@ export const fetchEvents = async (client: ContentfulClientApi, terms?: string, e
   }
 }
 
-export const fetchNews = async (client: ContentfulClientApi, terms?: string, publishedLessThanDate?: string, publishedGreaterThanOrEqualToDate?: string, sortOrder?: string, limit?: number, skip?: number) : Promise<NewsCollection> => {
+export const fetchNews = async (client: ContentfulClientApi, terms?: string, publishedLessThanDate?: string, publishedGreaterThanOrEqualToDate?: string, subjects?: Array<string>, sortOrder?: string, limit?: number, skip?: number) : Promise<NewsCollection> => {
 
   const query = replaceTerms(terms)
 
@@ -96,6 +96,7 @@ export const fetchNews = async (client: ContentfulClientApi, terms?: string, pub
       skip,
       'fields.publishedDate[lt]': publishedLessThanDate,
       'fields.publishedDate[gte]': publishedGreaterThanOrEqualToDate,
+      'fields.subject[in]': subjects
     })
   } catch (e) {
     console.error(e)
@@ -103,7 +104,7 @@ export const fetchNews = async (client: ContentfulClientApi, terms?: string, pub
   }
 }
 
-export const fetchCommunitySpotlightItems = async (client: ContentfulClientApi, terms?: string, spotlightTypes?: Array<string>, sortOrder?: string, limit?: number, skip?: number) : Promise<CommunitySpotlightItemsCollection> => {
+export const fetchCommunitySpotlightItems = async (client: ContentfulClientApi, terms?: string, spotlightTypes?: Array<string>, anatomicalStructures?: Array<string>, sortOrder?: string, limit?: number, skip?: number) : Promise<CommunitySpotlightItemsCollection> => {
 
   const query = replaceTerms(terms)
 
@@ -114,7 +115,8 @@ export const fetchCommunitySpotlightItems = async (client: ContentfulClientApi, 
       query,
       limit,
       skip,
-      'fields.itemType[in]': spotlightTypes
+      'fields.itemType[in]': spotlightTypes,
+      'fields.anatomicalStructure[in]': anatomicalStructures
     })
   } catch (e) {
     console.error(e)

--- a/pages/news-and-events/news/index.vue
+++ b/pages/news-and-events/news/index.vue
@@ -148,6 +148,11 @@ const sortOptions = [
     id: 'alphabatical',
     sortOrder: 'fields.title'
   },
+  {
+    label: 'Z-A',
+    id: 'reverseAlphabatical',
+    sortOrder: '-fields.title'
+  },
 ]
 
 export default Vue.extend<NewsData, NewsMethods, NewsComputed, never>({

--- a/pages/news-and-events/news/index.vue
+++ b/pages/news-and-events/news/index.vue
@@ -167,7 +167,7 @@ export default Vue.extend<NewsData, NewsMethods, NewsComputed, never>({
   },
 
   async asyncData({ route }) {
-    const news = await fetchNews(client, route.query.search, undefined, undefined, undefined, 10, 0)
+    const news = await fetchNews(client, route.query.search, undefined, undefined, undefined, undefined, 10, 0)
 
     return {
       news
@@ -201,7 +201,7 @@ export default Vue.extend<NewsData, NewsMethods, NewsComputed, never>({
       handler: function() {
         // we use next tick to wait for the facet menu to be mounted
         this.$nextTick(async () => {
-          this.news = await fetchNews(client, this.$route.query.search, this.publishedLessThanDate, this.publishedGreaterThanOrEqualToDate, this.sortOrder, 10, 0)
+          this.news = await fetchNews(client, this.$route.query.search, this.publishedLessThanDate, this.publishedGreaterThanOrEqualToDate, this.subjects, this.sortOrder, 10, 0)
         })
       },
       immediate: true
@@ -222,6 +222,9 @@ export default Vue.extend<NewsData, NewsMethods, NewsComputed, never>({
     publishedGreaterThanOrEqualToDate: function() {
       return this.$refs.newsFacetMenu?.getPublishedGreaterThanOrEqualToDate()
     },
+    subjects: function() {
+      return this.$route.query.selectedNewsSubjectIds || undefined
+    },
     sortOrder: function() {
       return propOr('-fields.publishedDate', 'sortOrder', this.selectedSortOption)
     }
@@ -235,7 +238,7 @@ export default Vue.extend<NewsData, NewsMethods, NewsComputed, never>({
     async onPaginationPageChange(page) {
       const { limit } = this.news
       const offset = (page - 1) * limit
-      const response = await fetchNews(client, this.$route.query.search, this.publishedLessThanDate, this.publishedGreaterThanOrEqualToDate, this.sortOrder, limit, offset)
+      const response = await fetchNews(client, this.$route.query.search, this.publishedLessThanDate, this.publishedGreaterThanOrEqualToDate, this.subjects, this.sortOrder, limit, offset)
       this.news = response
     },
     /**
@@ -244,12 +247,12 @@ export default Vue.extend<NewsData, NewsMethods, NewsComputed, never>({
      */
     async onPaginationLimitChange(limit) {
       const newLimit = limit === 'View All' ? this.news.total : limit
-      const response = await fetchNews(client, this.$route.query.search, this.publishedLessThanDate, this.publishedGreaterThanOrEqualToDate, this.sortOrder, newLimit, 0)
+      const response = await fetchNews(client, this.$route.query.search, this.publishedLessThanDate, this.publishedGreaterThanOrEqualToDate, this.subjects, this.sortOrder, newLimit, 0)
       this.news = response
     },
     async onSortOptionChange(option) {
       this.selectedSortOption = option
-      const response = await fetchNews(client, this.$route.query.search, this.publishedLessThanDate, this.publishedGreaterThanOrEqualToDate, this.sortOrder, this.news.limit, 0)
+      const response = await fetchNews(client, this.$route.query.search, this.publishedLessThanDate, this.publishedGreaterThanOrEqualToDate, this.subjects, this.sortOrder, this.news.limit, 0)
       this.news = response
     }
   }


### PR DESCRIPTION
# Description

Addressed the following feedback from Dominic:

-Images on the News & Events landing page for Community Spotlight are very tall (Tested on Safari)
-Images on the Community Spotlight FB for Community Spotlight are very tall (Tested on Safari)
-Images on the News & Events landing page for News articles are missing
-Images on the News FB for News articles are missing
-Can we also include sorting “Z - A”
-Ability to tag News content types as either “News Article” or “Funding opportunity” (and adding this into the facets on News FB)
-Ability to tag Community Spotlight content types with Anatomical Structure (and adding this into the facets on Community Spotlight FB)

## Type of change

- [X] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

Locally

# Checklist:

- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my own code
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] I have utilized components from the Design System Library where applicable
