### PR TITLE
timeseries page refactor

### DIFF
--- a/components/DatasetDetails/DatasetHeader.vue
+++ b/components/DatasetDetails/DatasetHeader.vue
@@ -244,6 +244,7 @@ export default {
   }
   .bx--grid {
     padding: 0;
+    width: 100%;
     [class*="bx--col"] {
       padding: 0 0.5rem;
     }

--- a/pages/datasets/timeseriesviewer/index.vue
+++ b/pages/datasets/timeseriesviewer/index.vue
@@ -97,15 +97,8 @@ export default {
     if (userToken) {
       datasetUrl += `?api_key=${userToken}`
     }
-    const datasetInfo = await $axios.$get(datasetUrl).catch((error) => { 
-      const status = pathOr('', ['data', 'status'], error.response)
-      if (status === 'UNPUBLISHED') {
-        const details = error.response.data
-        return {
-          isUnpublished: true,
-          ...details
-        }
-      }
+    const datasetInfo = await $axios.$get(datasetUrl).catch((error) => {
+      console.log(`Could not get the dataset's info: ${error}`)
     })
     const file = await FetchPennsieveFile.methods.fetchPennsieveFile(
       $axios,

--- a/pages/datasets/timeseriesviewer/index.vue
+++ b/pages/datasets/timeseriesviewer/index.vue
@@ -1,0 +1,171 @@
+<template>
+  <div class="file-detail-page">
+    <div class="page-wrap container">
+      <content-tab-card
+        v-if="hasTimeseriesViewer"
+        class="tabs p-32"
+        :tabs="tabs"
+        :active-tab-id="activeTabId"
+      >
+        <ts-viewer
+          v-if="userToken"
+          v-show="activeTabId === 'timeseriesViewer'"
+          :user-token="userToken"
+          :package-id="sourcePackageId"
+          :package-type="packageType"
+        />
+        <div v-else>
+          Sign in to the SPARC Portal to view timeseries data
+        </div>
+      </content-tab-card>
+      <div class="subpage pt-0 pb-16">
+        <div class="file-detail">
+          <strong class="file-detail__column_1">Dataset</strong>
+          <div class="file-detail__column_2">
+            <nuxt-link
+              :to="{
+                name: 'datasets-datasetId',
+                params: {
+                  datasetId,
+                  datasetVersion
+                }
+              }"
+            >
+              {{ title }}
+            </nuxt-link>
+          </div>
+        </div>
+        <div class="file-detail">
+          <strong class="file-detail__column_1">Filename</strong>
+          <div class="file-detail__column_2">
+            {{ fileName }}
+          </div>
+        </div>
+        <div v-if="filePath" class="file-detail">
+          <strong class="file-detail__column_1">File location</strong>
+          <div class="file-detail__column_2">
+            <nuxt-link
+              :to="{
+                name: `datasets-datasetId`,
+                params: {
+                  datasetId: datasetId
+                },
+                query: {
+                  datasetDetailsTab: 'files',
+                  path: fileFolderLocation
+                }
+              }"
+            >
+              {{ filePath }}
+            </nuxt-link>
+          </div>
+        </div>
+        <div v-if="filePath" class="pt-16">
+          <bf-button @click="requestDownloadFile(file)">
+            Download file
+          </bf-button>
+        </div>
+      </div>
+    </div>
+  </div>
+</template>
+
+<script>
+import { mapGetters } from 'vuex'
+import DetailTabs from '@/components/DetailTabs/DetailTabs.vue'
+import BfButton from '@/components/shared/BfButton/BfButton.vue'
+import { pathOr, propOr } from 'ramda'
+
+import RequestDownloadFile from '@/mixins/request-download-file'
+import FetchPennsieveFile from '@/mixins/fetch-pennsieve-file'
+import FileDetails from '@/mixins/file-details'
+
+export default {
+  name: 'TimeseriesViewerPage',
+
+  components: {
+    BfButton,
+    DetailTabs,
+  },
+
+  mixins: [FileDetails, RequestDownloadFile, FetchPennsieveFile],
+
+  async asyncData({ app, route, $axios }) {
+    const url = `${process.env.discover_api_host}/datasets/${route.query.dataset_id}`
+    var datasetUrl = route.query.dataset_version ? `${url}/versions/${route.query.dataset_version}` : url
+    const userToken = app.$cookies.get('user-token')
+    if (userToken) {
+      datasetUrl += `?api_key=${userToken}`
+    }
+    const datasetInfo = await $axios.$get(datasetUrl).catch((error) => { 
+      const status = pathOr('', ['data', 'status'], error.response)
+      if (status === 'UNPUBLISHED') {
+        const details = error.response.data
+        return {
+          isUnpublished: true,
+          ...details
+        }
+      }
+    })
+    const file = await FetchPennsieveFile.methods.fetchPennsieveFile(
+      $axios,
+      route.query.file_path,
+      route.query.dataset_id,
+      route.query.dataset_version
+    )
+    const sourcePackageId = file.sourcePackageId
+    let packageType = "None"
+    if (sourcePackageId !== 'details') {
+      packageType = file.packageType
+    }
+    const hasTimeseriesViewer = packageType === 'TimeSeries'
+
+    return {
+      datasetInfo,
+      file,
+      sourcePackageId,
+      packageType,
+      hasTimeseriesViewer
+    }
+  },
+
+  data: () => {
+    return {
+      tabs: [
+        {
+          label: 'Timeseries Viewer',
+          id: 'timeseriesViewer'
+        }
+      ],
+      activeTabId: 'timeseriesViewer',
+    }
+  },
+
+  computed: {
+    ...mapGetters('user', ['cognitoUserToken']),
+    userToken() {
+      return this.cognitoUserToken || this.$cookies.get('user-token')
+    },
+    title: function() {
+      return propOr(undefined, 'name', this.datasetInfo)
+    },
+    datasetId: function() {
+      return this.$route.query.dataset_id
+    },
+    datasetVersion: function() {
+      return this.$route.query.dataset_version
+    },
+    filePath: function() {
+      return this.$route.query.file_path
+    }
+  },
+}
+</script>
+
+<style scoped lang="scss">
+@import '@/assets/_viewer.scss';
+@import '@nih-sparc/sparc-design-system-components/src/assets/_variables.scss';
+.tabs {
+  border: 1px solid $lineColor2;
+}
+</style>


### PR DESCRIPTION
# Description

Added a timeseries viewer page and redirected to it when a user attempts to view a timeseries file. This was done in order to follow the pattern already established by other viewers and to maintain a consistent view

## Type of change

- [X] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

Locally

# Checklist:

- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my own code
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] I have utilized components from the Design System Library where applicable
