### PR TITLE
hide timeseries viewer behind a flag

### DIFF
--- a/nuxt.config.js
+++ b/nuxt.config.js
@@ -112,6 +112,7 @@ export default {
     ORCID_API_URL: process.env.ORCID_API_URL || 'https://pub.orcid.org/v2.1',
     GOOGLE_ANALYTICS_GA4: process.env.GOOGLE_ANALYTICS_GA4,
     GOOGLE_ANALYTICS_UA: process.env.GOOGLE_ANALYTICS_UA,
+    SHOW_TIMESERIES_VIEWER: process.env.SHOW_TIMESERIES_VIEWER || false
   },
 
   serverMiddleware: [

--- a/pages/datasets/_datasetId.vue
+++ b/pages/datasets/_datasetId.vue
@@ -95,7 +95,7 @@
 <script>
 import marked from 'marked'
 import { mapState } from 'vuex'
-import { clone, propOr, pathOr, head, compose } from 'ramda'
+import { clone, propOr, isEmpty, pathOr, head, compose } from 'ramda'
 import { getAlgoliaFacets, facetPropPathMapping } from '../../pages/data/utils'
 import createAlgoliaClient from '@/plugins/algolia.js'
 import { EMBARGO_ACCESS } from '@/utils/constants'
@@ -434,7 +434,8 @@ export default {
       })
     
     // Get all timeseries files (those with an '.edf' extension)
-    const timeseriesData = await $axios.$get(`${process.env.discover_api_host}/search/files?fileType=edf&datasetId=${datasetId}`)
+    const timeseriesData = process.env.SHOW_TIMESERIES_VIEWER
+      ? await $axios.$get(`${process.env.discover_api_host}/search/files?fileType=edf&datasetId=${datasetId}`)
         .then(({ files }) => {
           let data = []
           files.forEach(file => {
@@ -454,7 +455,8 @@ export default {
         })
         .catch(() => {
           return []
-        })
+        }) 
+      : []
 
     const changelogFileRequests = []
     versions.forEach(({ version }) => {
@@ -760,7 +762,7 @@ export default {
         ('mbf-segmentation' in this.scicrunchData) ||
         ('abi-plot' in this.scicrunchData) ||
         ('common-images' in this.scicrunchData) ||
-        this.timeseriesData != [])
+        !isEmpty(this.timeseriesData))
     },
     fileCount: function() {
       return propOr('0', 'fileCount', this.datasetInfo)

--- a/pages/datasets/timeseriesviewer/index.vue
+++ b/pages/datasets/timeseriesviewer/index.vue
@@ -120,7 +120,7 @@ export default {
     if (sourcePackageId !== 'details') {
       packageType = file.packageType
     }
-    const hasTimeseriesViewer = packageType === 'TimeSeries'
+    const hasTimeseriesViewer = packageType === 'TimeSeries' && process.env.SHOW_TIMESERIES_VIEWER
 
     return {
       datasetInfo,

--- a/pages/file/_datasetId/_datasetVersion/index.vue
+++ b/pages/file/_datasetId/_datasetVersion/index.vue
@@ -129,7 +129,7 @@ export default {
       packageType = file.packageType
     }
     const hasTimeseriesViewer = packageType === 'TimeSeries'
-    if (hasTimeseriesViewer) {
+    if (hasTimeseriesViewer && process.env.SHOW_TIMESERIES_VIEWER) {
       redirect(`/datasets/timeseriesviewer?dataset_id=${route.params.datasetId}&dataset_version=${route.params.datasetVersion}&file_path=${filePath}`)
     }
 


### PR DESCRIPTION
# Description

Added an env var flag for showing/hiding the timeseries viewer while we work on getting its implementation compliant with the requirements hugh outlined here: https://www.wrike.com/workspace.htm?acc=3203588#/task-view?id=644373841&pid=416152743&cid=415614298

## Type of change

- [X] New feature (non-breaking change which adds functionality)

# How Has This Been Tested?

Locally

# Checklist:

- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my own code
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] I have utilized components from the Design System Library where applicable
