### PR TITLE
Add associated projects to project details page

### DIFF
--- a/components/ToolAndResourcesPage/ToolsAndResourcesPage.vue
+++ b/components/ToolAndResourcesPage/ToolsAndResourcesPage.vue
@@ -8,7 +8,7 @@
       </p>
     </page-hero>
     <div class="page-wrap container">
-      <div class="subpage">
+      <div class="subpage mb-32">
         <!-- eslint-disable vue/no-v-html -->
         <!-- marked will sanitize the HTML injected -->
         <slot />
@@ -123,9 +123,6 @@ export default {
 
 <style lang="scss" scoped>
 @import '@nih-sparc/sparc-design-system-components/src/assets/_variables.scss';
-.subpage {
-  margin-bottom: 2rem;
-}
 .content {
   & ::v-deep img,
   & ::v-deep video {

--- a/components/header/Header.vue
+++ b/components/header/Header.vue
@@ -245,7 +245,7 @@ export default {
         {
           key: 'data',
           value: 'data',
-          label: 'Datasets'
+          label: 'Data'
         },
         {
           key: 'resources-biological',

--- a/pages/about/about-sparc/index.vue
+++ b/pages/about/about-sparc/index.vue
@@ -103,7 +103,7 @@ const client = createClient()
 
 const searchTypes = [
   {
-    label: 'About Sparc',
+    label: 'About SPARC',
     path: 'about-sparc'
   },
   {

--- a/pages/about/policies-and-standards/index.vue
+++ b/pages/about/policies-and-standards/index.vue
@@ -103,7 +103,7 @@ const client = createClient()
 
 const searchTypes = [
   {
-    label: 'About Sparc',
+    label: 'About SPARC',
     path: 'about-sparc'
   },
   {

--- a/pages/news-and-events/community-spotlight/success-stories/_id.vue
+++ b/pages/news-and-events/community-spotlight/success-stories/_id.vue
@@ -33,44 +33,44 @@
               />
             </div>
             <div class="seperator-path my-32" />
-            <div class="body4 story-bold-field">
-              Author
+            <div class="label4">
+              AUTHOR
             </div>
-            <div class="body4">
+            <div class="content body4">
               {{ author }}
             </div>
             <br />
             <template v-if="entry.publishedDate">
-              <div class="body4 story-bold-field">
-                Published Date
+              <div class="label4">
+                PUBLISHED DATE
               </div>
-              <div class="body4">
+              <div class="content body4">
                 {{ formatDate(entry.publishedDate) }}
               </div>
               <br />
             </template>
             <template v-if="entry.contributorsMarkdown">
-              <div class="body4 story-bold-field">
-                Team Members
+              <div class="label4">
+                TEAM MEMBERS
               </div>
               <div class="content body4" v-html="parseMarkdown(entry.contributorsMarkdown)" />
               <br />
             </template>
             <template v-if="entry.referencesMarkdown">
-              <div class="body4 story-bold-field">
-                Supporting information
+              <div class="label4">
+                SUPPORTING INFORMATION
               </div>
               <div class="content body4" v-html="parseMarkdown(entry.referencesMarkdown)" />
               <br />
             </template>
-            <div class="body4 story-bold-field">
+            <div class="label4">
               Share
             </div>
             <share-links />
             <div class="seperator-path my-32" />
             <template v-if="entry.associatedDatasets">
-              <div class="body4 story-bold-field">
-                Associated Datasets
+              <div class="label4">
+                ASSOCIATED DATASETS
               </div>
               <br />
               <div
@@ -284,12 +284,6 @@ export default {
   height: 0.125rem;
   background: $lineColor1;
   border-radius: 0px;
-}
-
-.story-bold-field {
-  font-size: 14px;
-  font-weight: 600;
-  text-transform: uppercase;
 }
 
 .btn-copy-permalink {

--- a/pages/projects/_projectId.vue
+++ b/pages/projects/_projectId.vue
@@ -1,8 +1,8 @@
 <template>
-  <div class="page">
+  <div class="page pb-32">
     <breadcrumb :breadcrumb="breadcrumb" :title="title" />
     <div class="page-wrap container">
-      <div class="subpage">
+      <div class="subpage mb-32">
         <div class="row">
           <el-col class="first-column mr-24">
             <div class="image-container p-16 mx-32 mb-32">
@@ -54,6 +54,22 @@
               </div>
               <share-links class="share-links" />
             </div>
+            <template v-if="showAssociatedDatasets">
+              <hr class="mt-16" />
+              <div class="label4">
+                ASSOCIATED DATASETS
+              </div>
+              <br />
+              <div class="associated-datasets-container">
+                <div
+                  v-for="(dataset, index) in associatedDatasets"
+                  :key="index"
+                  class="body4 "
+                >
+                  <dataset-card :id="dataset.id" />
+                </div>
+              </div>
+            </template>
           </el-col>
           <el-col>
             <div class="heading2 mb-32">
@@ -65,15 +81,19 @@
           </el-col>
         </div>
       </div>
+      <nuxt-link class="back-link" to="/data?type=projects">
+        View All Projects >
+      </nuxt-link>
     </div>
   </div>
 </template>
 
 <script>
 import Breadcrumb from '@/components/Breadcrumb/Breadcrumb.vue'
-import DatasetSearchResults from '@/components/SearchResults/DatasetSearchResults.vue'
+import DatasetCard from '@/components/DatasetCard/DatasetCard.vue'
 import ShareLinks from '@/components/ShareLinks/ShareLinks.vue'
 import { isInternalLink } from '@/mixins/marked/index'
+import { propOr, isEmpty } from 'ramda'
 
 import createClient from '@/plugins/contentful.js'
 
@@ -83,7 +103,7 @@ export default {
   name: 'ProjectDetails',
   components: {
     Breadcrumb,
-    DatasetSearchResults,
+    DatasetCard,
     ShareLinks
   },
 
@@ -91,15 +111,15 @@ export default {
     try {
       const project = await client.getEntry(route.params.projectId)
 
-      const datasets = await $axios
-        .$get(`${process.env.portal_api}/projects/${project.fields.awardId}`)
+      const associatedDatasets = await $axios
+        .$get(`${process.env.portal_api}/project/${project.fields.awardId}`)
         .catch(() => {
           return {}
         })
 
       return {
         fields: project.fields,
-        datasets
+        associatedDatasets: propOr([], 'datasets', associatedDatasets)
       }
     } catch (e) {
       console.error(e)
@@ -108,19 +128,6 @@ export default {
 
   data() {
     return {
-      datasets: {
-        datasets: [],
-        limit: 0,
-        offset: 0,
-        totalCount: 0
-      },
-      tabs: [
-        {
-          label: 'Datasets',
-          type: 'datasets'
-        }
-      ],
-      activeTab: 'datasets',
       breadcrumb: [
         {
           to: {
@@ -186,17 +193,13 @@ export default {
       return this.fields.projectSection
         ? this.fields.projectSection.fields.title
         : ''
+    },
+    showAssociatedDatasets: function() {
+      return !isEmpty(this.associatedDatasets)
     }
   },
 
   methods: {
-    /**
-     * Sets active tab
-     * @param {String} activeLabel
-     */
-    setActiveTab: function(activeLabel) {
-      this.activeTab = activeLabel
-    },
     isInternalLink,
   }
 }
@@ -204,8 +207,15 @@ export default {
 
 <style lang="scss" scoped>
 @import '@nih-sparc/sparc-design-system-components/src/assets/_variables.scss';
+.page {
+  background-color: $background;
+}
 .row {
   display: flex;
+}
+.back-link {
+  color: $darkBlue;
+  font-weight: 700;
 }
 .first-column {
   max-width: 25rem;
@@ -225,11 +235,20 @@ hr {
   border-left: none;
   border-right: none;
 }
+.associated-datasets-container {
+  max-height: 20rem;
+  overflow: auto;
+  overflow-x: hidden;
+  text-overflow: hidden;
+}
 @media screen and (max-width: 760px) {
   .row {
     flex-direction: column;
   }
   .share-links {
+    margin-bottom: 1rem;
+  }
+  .associated-datasets-container {
     margin-bottom: 1rem;
   }
 }


### PR DESCRIPTION
# Description

Add associated datasets to projects details page as outlined in the wireframes here: https://app.abstract.com/share/80fd63dd-eee3-4bb6-9578-284f19eb868b

Updated styling for success stories details page

## Type of change

Delete those that don't apply.

- [X] New feature (non-breaking change which adds functionality)

# How Has This Been Tested?

Locally

# Checklist:

- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my own code
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] I have utilized components from the Design System Library where applicable
