### PR TITLE
Showing markdown for field 'description' in Resources search results page

### DIFF
--- a/components/Resources/ResourcesSearchResults.vue
+++ b/components/Resources/ResourcesSearchResults.vue
@@ -43,10 +43,11 @@
             </a>
           </p>
         </template>
-
-        <p class="resources-search-results__items--content-description">
-          {{ data.fields.description }}
-        </p>
+        <!-- eslint-disable vue/no-v-html -->
+        <p
+          class="resources-search-results__items--content-description"
+          v-html="parseMarkdown(data.fields.description)"
+        />
       </div>
     </div>
   </div>
@@ -54,12 +55,13 @@
 
 <script>
 import { pathOr } from 'ramda'
+import marked from '@/mixins/marked/index'
 
 import FormatDate from '@/mixins/format-date'
 export default {
   name: 'ResourceSearchResults',
 
-  mixins: [FormatDate],
+  mixins: [FormatDate, marked],
   props: {
     tableData: {
       type: Array,


### PR DESCRIPTION
# Description

When searching for Resources, it was asked that Markdown was shown for the description field of each result (Resource).
See https://www.wrike.com/open.htm?id=952119114


## Type of change

- [x] New feature (non-breaking change which adds functionality)

# How Has This Been Tested?

Manually


# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have utilized components from the Design System Library where applicable
- [ ] I have added unit tests that prove my fix is effective or that my feature works
