### PR TITLE
Add embargoed tooltip to files tab

### DIFF
--- a/components/DatasetDetails/DatasetActionBox.vue
+++ b/components/DatasetDetails/DatasetActionBox.vue
@@ -5,37 +5,18 @@
       Embargoed
     </sparc-pill>
     <div class="button-container" v-if="datasetTypeName === 'scaffold' && !datasetInfo.study">
-      <div v-if="embargoed">
-        <sparc-tooltip
-          placement="left-center"
+      <div v-if="hasFiles && embargoed && userToken && embargoAccess !== EMBARGO_ACCESS.GRANTED">
+        <el-button
+          :disabled="embargoAccess != null"
+          @click="openAgreementPopup()"
         >
-          <div v-if="!userToken && embargoAccess !== EMBARGO_ACCESS.GRANTED" slot="data">
-            This scaffold is currently embargoed.<br />SPARC datasets are subject to a 1-year<br />embargo during which time the datasets<br />are visible only to members of the<br />SPARC consortium. During embargo, the<br />public will be able to view basic<br />metadata about these datasets as well<br />as their release date. Log in to request<br />access to embargoed data
-          </div>
-          <div v-else slot="data">
-            This scaffold is currently embargoed.<br />SPARC datasets are subject to a 1-year<br />embargo during which time the datasets<br />are visible only to members of the<br />SPARC consortium. During embargo, the<br />public will be able to view basic<br />metadata about these datasets as well<br />as their release date. You may request<br />access to the embargoed data<br />from the author
-          </div>
-          <el-button
-            v-if="userToken && embargoAccess !== EMBARGO_ACCESS.GRANTED"
-            slot="item"
-            :disabled="embargoAccess != null"
-            @click="openAgreementPopup()"
-          >
-            Request Access
-          </el-button> 
-          <el-button
-            v-else
-            slot="item"
-            :disabled="embargoAccess !== EMBARGO_ACCESS.GRANTED || !hasFiles"
-          >
-            Get Scaffold
-          </el-button>
-        </sparc-tooltip>
+          Request Access
+        </el-button> 
         <div class="body4" v-if="embargoAccess === EMBARGO_ACCESS.REQUESTED">
           Your request is pending approval...
         </div>
       </div>
-      <div v-else-if="hasFiles" class="button-container" >
+      <div v-else-if="hasFiles" class="button-container">
         <el-button
           class="dataset-button"
           @click="actionButtonClicked('images')"
@@ -66,32 +47,13 @@
           Run Simulation
         </el-button>
       </a>
-      <div v-if="embargoed">
-        <sparc-tooltip
-          placement="left-center"
+      <div v-if="hasFiles && embargoed && userToken && embargoAccess !== EMBARGO_ACCESS.GRANTED">
+        <el-button
+          :disabled="embargoAccess != null"
+          @click="openAgreementPopup()"
         >
-          <div v-if="!userToken && embargoAccess !== EMBARGO_ACCESS.GRANTED" slot="data">
-            This model is currently embargoed.<br />SPARC datasets are subject to a 1-year<br />embargo during which time the datasets<br />are visible only to members of the<br />SPARC consortium. During embargo, the<br />public will be able to view basic<br />metadata about these datasets as well<br />as their release date. Log in to request<br />access to embargoed data
-          </div>
-          <div v-else slot="data">
-            This model is currently embargoed.<br />SPARC datasets are subject to a 1-year<br />embargo during which time the datasets<br />are visible only to members of the<br />SPARC consortium. During embargo, the<br />public will be able to view basic<br />metadata about these datasets as well<br />as their release date. You may request<br />access to the embargoed data<br />from the author
-          </div>
-          <el-button
-            v-if="userToken && embargoAccess !== EMBARGO_ACCESS.GRANTED"
-            slot="item"
-            :disabled="embargoAccess != null"
-            @click="openAgreementPopup()"
-          >
-            Request Access
-          </el-button> 
-          <el-button
-            v-else
-            slot="item"
-            :disabled="embargoAccess !== EMBARGO_ACCESS.GRANTED || !hasFiles"
-          >
-            Get Model
-          </el-button>
-        </sparc-tooltip>
+          Request Access
+        </el-button>
         <div class="body4" v-if="embargoAccess === EMBARGO_ACCESS.REQUESTED">
           Your request is pending approval...
         </div>
@@ -119,40 +81,20 @@
               osparc.io
             </a>
           </div>
-          <el-button slot="item" class="secondary">
+          <el-button slot="item" style="width: 100%;" class="secondary">
             Go to oSPARC
           </el-button>
         </sparc-tooltip>
       </a>
     </div>
     <div class="button-container" v-else>
-      <div v-if="embargoed">
-        <sparc-tooltip
-          placement="left-center"
+      <div v-if="hasFiles && embargoed && userToken && embargoAccess !== EMBARGO_ACCESS.GRANTED">
+        <el-button
+          :disabled="embargoAccess != null"
+          @click="openAgreementPopup()"
         >
-          <div v-if="!userToken && embargoAccess !== EMBARGO_ACCESS.GRANTED" slot="data">
-            This dataset is currently embargoed.<br />SPARC datasets are subject to a 1-year<br />embargo during which time the datasets<br />are visible only to members of the<br />SPARC consortium. During embargo, the<br />public will be able to view basic<br />metadata about these datasets as well<br />as their release date. Log in to request<br />access to embargoed data
-          </div>
-          <div v-else slot="data">
-            This dataset is currently embargoed.<br />SPARC datasets are subject to a 1-year<br />embargo during which time the datasets<br />are visible only to members of the<br />SPARC consortium. During embargo, the<br />public will be able to view basic<br />metadata about these datasets as well<br />as their release date. You may request<br />access to the embargoed data<br />from the author
-          </div>
-          <el-button
-            v-if="userToken && embargoAccess !== EMBARGO_ACCESS.GRANTED"
-            slot="item"
-            :disabled="embargoAccess != null"
-            @click="openAgreementPopup()"
-          >
-            Request Access
-          </el-button> 
-          <el-button
-            v-else
-            slot="item"
-            :disabled="embargoAccess !== EMBARGO_ACCESS.GRANTED || !hasFiles"
-            @click="actionButtonClicked('files')"
-          >
-            Get Dataset
-          </el-button>
-        </sparc-tooltip>
+          Request Access
+        </el-button> 
         <div class="body4" v-if="embargoAccess === EMBARGO_ACCESS.REQUESTED">
           Your request is pending approval...
         </div>

--- a/components/DatasetDetails/DatasetFilesInfo.vue
+++ b/components/DatasetDetails/DatasetFilesInfo.vue
@@ -1,73 +1,98 @@
 <template>
   <div>
     <div class="heading2 mb-8">Download Dataset</div>
-    <div class="mb-8">
-      <span class="label4">Dataset size: </span>{{ formatMetric(datasetInfo.size) }}
+    <div v-if="embargoed && userToken == null">
+      This dataset is currently embargoed.
+      SPARC datasets are subject to a 1-year
+      embargo during which time the datasets
+      are visible only to members of the
+      SPARC consortium. During embargo, the
+      public will be able to view basic
+      metadata about these datasets as well
+      as their release date. Sign in to request
+      access to embargoed data
     </div>
-    <div class="bx--row">
-      <div class="bx--col-sm-4 bx--col-md-8 bx--col left-column">
-        <div v-if="!isDatasetSizeLarge">
-          <div><span class="label4">Option 1 - Direct download: </span>Download a zip archive of the raw files and metadata directly to your computer free of charge.</div>
-          <a :href="downloadUrl">
-            <el-button class="my-16">Download full dataset</el-button>
-          </a>
-        </div>
-        <div v-else>
-          <div><span class="label4">Option 1 - Direct download: </span>Direct downloads are only available free of charge for datasets that are 5GB or smaller. Datasets bigger than 5GB will need to be downloaded via AWS. </div>
-        </div>
-      </div>
-      <div class="bx--col-sm-4 bx--col-md-8 bx--col aws-download-column">
-        <div class="mb-8">
-          <span class="label4">Option 2 - AWS download: </span>
-          Download or transfer the dataset to your AWS Account. The raw files and metadata are stored in an AWS S3 Requester Pays bucket. You can learn more about downloading data from AWS on our
-          <a href="https://sparc.science/help/zQfzadwADutviJjT19hA5" target="_blank">Help Page</a>.
-        </div>
-        <div class="aws-block mb-16 px-16 pb-16 pt-8">
-          <div class="heading3">Resource Type</div>
-          <div class="mb-0"><span class="heading3">Amazon S3 Bucket</span> (Requester Pays) *</div>
-          <div class="download-text-block mb-8 p-4">
-            {{ datasetArn }}
-            <button class="copy-button" @click="handleCitationCopy(datasetArn)">
-              <img src="../../static/images/copyIcon.png" />
-            </button>
-          </div>
-          <div class="heading3 mb-0">AWS Region</div>
-          <div class="download-text-block p-4 aws">
-            {{ awsMessage}}
-            <button class="copy-button" @click="handleCitationCopy(awsMessage)">
-              <img src="../../static/images/copyIcon.png" />
-            </button>
-          </div>
-        </div>
-        <div>
-          * Requester pays means that any costs associated with downloading the data will be charged to your AWS account.
-          For transfer pricing information, visit the <a href="https://aws.amazon.com/s3/pricing/" target="blank">AWS Pricing documentation.</a>
-        </div>
-      </div>
+    <div v-else-if="embargoed && !accessGranted">
+      This dataset is currently embargoed.
+      SPARC datasets are subject to a 1-year
+      embargo during which time the datasets
+      are visible only to members of the
+      SPARC consortium. During embargo, the
+      public will be able to view basic
+      metadata about these datasets as well
+      as their release date. Click 'Request
+      Access' to request permission from
+      the author to view the embargoed data.
     </div>
-    <hr />
-    <h2 class="heading2">
-      Dataset Files
-    </h2>
-    <div class="flex mb-16">
-      <span>
+    <div v-else>
+      <div class="mb-8">
         <span class="label4">Dataset size: </span>{{ formatMetric(datasetInfo.size) }}
-      </span>
-      <span class="dataset-link inline">
-        <nuxt-link
-          :to="{
-            name: 'help-helpId',
-            params: {
-              helpId: ctfDatasetNavigationInfoPageId
-            }
-          }"
-          class="dataset-link"
-        >
-          How to navigate datasets
-        </nuxt-link>
-      </span>
+      </div>
+      <div class="bx--row">
+        <div class="bx--col-sm-4 bx--col-md-8 bx--col left-column">
+          <div v-if="!isDatasetSizeLarge">
+            <div><span class="label4">Option 1 - Direct download: </span>Download a zip archive of the raw files and metadata directly to your computer free of charge.</div>
+            <a :href="downloadUrl">
+              <el-button class="my-16">Download full dataset</el-button>
+            </a>
+          </div>
+          <div v-else>
+            <div><span class="label4">Option 1 - Direct download: </span>Direct downloads are only available free of charge for datasets that are 5GB or smaller. Datasets bigger than 5GB will need to be downloaded via AWS. </div>
+          </div>
+        </div>
+        <div class="bx--col-sm-4 bx--col-md-8 bx--col aws-download-column">
+          <div class="mb-8">
+            <span class="label4">Option 2 - AWS download: </span>
+            Download or transfer the dataset to your AWS Account. The raw files and metadata are stored in an AWS S3 Requester Pays bucket. You can learn more about downloading data from AWS on our
+            <a href="https://sparc.science/help/zQfzadwADutviJjT19hA5" target="_blank">Help Page</a>.
+          </div>
+          <div class="aws-block mb-16 px-16 pb-16 pt-8">
+            <div class="heading3">Resource Type</div>
+            <div class="mb-0"><span class="heading3">Amazon S3 Bucket</span> (Requester Pays) *</div>
+            <div class="download-text-block mb-8 p-4">
+              {{ datasetArn }}
+              <button class="copy-button" @click="handleCitationCopy(datasetArn)">
+                <img src="../../static/images/copyIcon.png" />
+              </button>
+            </div>
+            <div class="heading3 mb-0">AWS Region</div>
+            <div class="download-text-block p-4 aws">
+              {{ awsMessage}}
+              <button class="copy-button" @click="handleCitationCopy(awsMessage)">
+                <img src="../../static/images/copyIcon.png" />
+              </button>
+            </div>
+          </div>
+          <div>
+            * Requester pays means that any costs associated with downloading the data will be charged to your AWS account.
+            For transfer pricing information, visit the <a href="https://aws.amazon.com/s3/pricing/" target="blank">AWS Pricing documentation.</a>
+          </div>
+        </div>
+      </div>
+      <hr />
+      <h2 class="heading2">
+        Dataset Files
+      </h2>
+      <div class="flex mb-16">
+        <span>
+          <span class="label4">Dataset size: </span>{{ formatMetric(datasetInfo.size) }}
+        </span>
+        <span class="dataset-link inline">
+          <nuxt-link
+            :to="{
+              name: 'help-helpId',
+              params: {
+                helpId: ctfDatasetNavigationInfoPageId
+              }
+            }"
+            class="dataset-link"
+          >
+            How to navigate datasets
+          </nuxt-link>
+        </span>
+      </div>
+      <files-table :osparc-viewers="osparcViewers" :dataset-scicrunch="datasetScicrunch"/>
     </div>
-    <files-table :osparc-viewers="osparcViewers" :dataset-scicrunch="datasetScicrunch"/>
   </div>
 </template>
 
@@ -76,6 +101,7 @@ import { mapGetters, mapState } from 'vuex'
 import { propOr } from 'ramda'
 
 import { successMessage, failMessage } from '@/utils/notification-messages'
+import { EMBARGO_ACCESS } from '@/utils/constants'
 import FilesTable from '@/components/FilesTable/FilesTable.vue'
 import FormatMetric from '../../mixins/bf-storage-metrics'
 
@@ -108,6 +134,15 @@ export default {
     ...mapGetters('user', ['cognitoUserToken']),
     userToken() {
       return this.cognitoUserToken || this.$cookies.get('user-token')
+    },
+    accessGranted: function() {
+      return this.embargoAccess == EMBARGO_ACCESS.GRANTED
+    },
+    embargoed: function() {
+      return propOr(false, 'embargo', this.datasetInfo)
+    },
+    embargoAccess() {
+      return propOr(null, 'embargoAccess', this.datasetInfo)
     },
     /**
      * Checks whether the dataset download size is larger or smaller than 5GB

--- a/pages/datasets/_datasetId.vue
+++ b/pages/datasets/_datasetId.vue
@@ -98,7 +98,6 @@ import { mapState } from 'vuex'
 import { clone, propOr, isEmpty, pathOr, head, compose } from 'ramda'
 import { getAlgoliaFacets, facetPropPathMapping } from '../../pages/data/utils'
 import createAlgoliaClient from '@/plugins/algolia.js'
-import { EMBARGO_ACCESS } from '@/utils/constants'
 
 import DatasetHeader from '@/components/DatasetDetails/DatasetHeader.vue'
 import DatasetActionBox from '@/components/DatasetDetails/DatasetActionBox.vue'
@@ -746,9 +745,6 @@ export default {
       return numDownloads
     },
     hasFiles: function() {
-      if (this.embargoed && this.embargoAccess !== EMBARGO_ACCESS.GRANTED) {
-        return false
-      }
       return this.fileCount >= 1
     },
     hasGalleryImages: function() {


### PR DESCRIPTION
# Description

As per Dominic's recommendation in the comments here: https://www.wrike.com/workspace.htm?acc=3203588#/task-view?id=963704786&pid=825399023&cid=441356195  

Moved the embargoed dataset tooltip text to be inside the files tab

## Type of change

- [X] New feature (non-breaking change which adds functionality)

# How Has This Been Tested?

Locally

# Checklist:

- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my own code
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] I have utilized components from the Design System Library where applicable
