### PR TITLE
Added disabled download full dataset button

### DIFF
--- a/components/DatasetDetails/DatasetFilesInfo.vue
+++ b/components/DatasetDetails/DatasetFilesInfo.vue
@@ -38,6 +38,14 @@
           </div>
           <div v-else>
             <div><span class="label4">Option 1 - Direct download: </span>Direct downloads are only available free of charge for datasets that are 5GB or smaller. Datasets bigger than 5GB will need to be downloaded via AWS. </div>
+            <sparc-tooltip
+              placement="left-center"
+            >
+              <div slot="data">
+                Dataset size is over 5GB. To download, use <b>Option 2 - AWS download</b>
+              </div>
+              <el-button slot="item" disabled class="my-16">Download full dataset</el-button>
+            </sparc-tooltip>
           </div>
         </div>
         <div class="bx--col-sm-4 bx--col-md-8 bx--col aws-download-column">


### PR DESCRIPTION
# Description

Added disabled download button as per: https://www.wrike.com/workspace.htm?acc=3203588#/task-view?id=970450584&pid=415614298&cid=415614298

I added these changes in https://github.com/nih-sparc/sparc-app/pull/544 but I believe they got overridden by a subsequent PR

## Type of change

- [X] New feature (non-breaking change which adds functionality)

# How Has This Been Tested?

Locally

# Checklist:

- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my own code
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] I have utilized components from the Design System Library where applicable
