### PR TITLE
Make it clear that the dataset will be compressed upon direct download.

### DIFF
--- a/components/DatasetDetails/DatasetFilesInfo.vue
+++ b/components/DatasetDetails/DatasetFilesInfo.vue
@@ -31,7 +31,7 @@
       <div class="bx--row">
         <div class="bx--col-sm-4 bx--col-md-8 bx--col left-column">
           <div v-if="!isDatasetSizeLarge">
-            <div><span class="label4">Option 1 - Direct download: </span>Download a zip archive of the raw files and metadata directly to your computer free of charge.</div>
+            <div><span class="label4">Option 1 - Direct download: </span>Download a zip archive of the raw files and metadata directly to your computer free of charge, please note that the files will be compressed upon download.</div>
             <a :href="downloadUrl">
               <el-button class="my-16">Download full dataset</el-button>
             </a>

--- a/components/DatasetDetails/DatasetFilesInfo.vue
+++ b/components/DatasetDetails/DatasetFilesInfo.vue
@@ -31,7 +31,7 @@
       <div class="bx--row">
         <div class="bx--col-sm-4 bx--col-md-8 bx--col left-column">
           <div v-if="!isDatasetSizeLarge">
-            <div><span class="label4">Option 1 - Direct download: </span>Download a zip archive of the raw files and metadata directly to your computer free of charge, please note that the files will be compressed upon download.</div>
+            <div><span class="label4">Option 1 - Direct download: </span>Download a zip archive of the raw files and metadata directly to your computer free of charge. Please note that the files will be compressed upon download.</div>
             <a :href="downloadUrl">
               <el-button class="my-16">Download full dataset</el-button>
             </a>


### PR DESCRIPTION
# Description

Make it clear that the dataset will be compressed upon direct download. This is to address the issue reported in the ticket [here](https://www.wrike.com/open.htm?id=912390744).

## Type of change

Delete those that don't apply.

- [ ] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

The added statement can be found on this page - https://alan-wu-sparc-app.herokuapp.com/datasets/86?type=dataset&datasetDetailsTab=files

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have utilized components from the Design System Library where applicable
- [ ] I have added unit tests that prove my fix is effective or that my feature works
