### PR TITLE
Jesses Sprint 23 - Add logic to change log display

### DIFF
--- a/components/VersionHistory/VersionHistory.vue
+++ b/components/VersionHistory/VersionHistory.vue
@@ -4,24 +4,41 @@
       :visible="dialogVisible"
       @close-download-dialog="dialogVisible = false"
     >
-      <div class="content" slot="optionalContent">
+      <div slot="optionalContent" class="content">
         <h1>Download</h1>
         <p>Download changelog file</p>
-        <el-button class="download-button" @click="downloadChangeLogFile(changeLogFileVersion)">Download</el-button>
+        <el-button
+          class="download-button"
+          @click="downloadChangeLogFile(changeLogFileVersion)"
+        >
+          Download
+        </el-button>
       </div>
-     <div class="content" slot="mainContent">
-      <h1>Changelog</h1>
-      <div v-html="parseMarkdown(markdown)"/>
-      <el-button class="secondary" @click="dialogVisible = false">
+      <div slot="mainContent" class="content">
+        <h1>Changelog</h1>
+        <div v-html="parseMarkdown(markdown)" />
+        <el-button class="secondary" @click="dialogVisible = false">
           Close
-      </el-button>
-     </div>
+        </el-button>
+      </div>
     </large-modal>
-    <div class="heading2 mb-8">Versions for this Dataset</div>
-    <div class="mb-8"><span class="label4">Current version: </span>{{latestVersionRevisionText}}</div>
-    <div class="mb-8"><span class="label4">Original version: </span>{{originalVersionRevisionText}}</div>
+    <div class="heading2 mb-8">
+      Versions for this Dataset
+    </div>
+    <div class="mb-8">
+      <span class="label4">Current version: </span
+      >{{ latestVersionRevisionText }}
+    </div>
+    <div class="mb-8">
+      <span class="label4">Original version: </span
+      >{{ originalVersionRevisionText }}
+    </div>
     <div class="mb-16">
-      A dataset version refers to a DOI-specific, version-controlled iteration of a dataset. A new version of a dataset must be released when there are any changes to the files or scientific metadata made within a dataset. A dataset revision refers to an update made to dataset metadata (i.e. title, subtitle, description, etc.) that does not require an updated DOI.
+      A dataset version refers to a DOI-specific, version-controlled iteration
+      of a dataset. A new version of a dataset must be released when there are
+      any changes to the files or scientific metadata made within a dataset. A
+      dataset revision refers to an update made to dataset metadata (i.e. title,
+      subtitle, description, etc.) that does not require an updated DOI.
     </div>
     <div class="version-table">
       <el-row class="table-header py-12" type="flex" justify="center">
@@ -32,10 +49,10 @@
           Revisions
         </el-col>
         <el-col :span="4">
-          Date 
+          Date
         </el-col>
         <el-col :span="4">
-          Changelog 
+          Changelog
         </el-col>
         <el-col :span="4" :push="1">
           DOI
@@ -73,12 +90,25 @@
         <el-col v-if="isChangelogAvailable(version.version)" :span="4">
           <div class="circle" @click="viewChangeLogFile(version.version)">
             <sparc-tooltip placement="bottom-center" content="View changelog">
-              <svg-icon slot="item" name="icon-view" height="1.5rem" width="1.5rem" />
+              <svg-icon
+                slot="item"
+                name="icon-view"
+                height="1.5rem"
+                width="1.5rem"
+              />
             </sparc-tooltip>
           </div>
           <div class="circle" @click="downloadChangeLogFile(version.version)">
-            <sparc-tooltip placement="bottom-center" content="Download changelog file">
-              <svg-icon slot="item" name="icon-download" height="1.5rem" width="1.5rem" />
+            <sparc-tooltip
+              placement="bottom-center"
+              content="Download changelog file"
+            >
+              <svg-icon
+                slot="item"
+                name="icon-download"
+                height="1.5rem"
+                width="1.5rem"
+              />
             </sparc-tooltip>
           </div>
         </el-col>
@@ -86,15 +116,18 @@
           Not available
         </el-col>
         <el-col :span="4" :push="1">
-          <a
-            :href="getDoiLink(version.doi)"
-          >
+          <a :href="getDoiLink(version.doi)">
             <u>{{ version.doi }}</u>
           </a>
         </el-col>
       </el-row>
     </div>
-    <div v-if="embargoed" class="label2"><em>NOTE: If dataset is currently embargoed, you may view the metadata pertaining to the dataset and request that access be permitted.</em></div>
+    <div v-if="embargoed" class="label2">
+      <em
+        >NOTE: If dataset is currently embargoed, you may view the metadata
+        pertaining to the dataset and request that access be permitted.</em
+      >
+    </div>
   </div>
 </template>
 
@@ -145,20 +178,23 @@ export default {
     latestVersionRevisionText: function() {
       let version = this.versions[0].version
       let revision = this.versions[0].revision || '0'
-      let latestDate = this.versions[0].revisedAt || this.versions[0].firstPublishedAt
+      let latestDate =
+        this.versions[0].revisedAt || this.versions[0].firstPublishedAt
       let date = this.formatDate(latestDate)
       return `Version ${version}, Revision ${revision}; ${date}`
     },
     originalVersionRevisionText: function() {
-      const originalVersionPosition = this.versions.length-1;
+      const originalVersionPosition = this.versions.length - 1
       let version = this.versions[originalVersionPosition].version
       let revision = this.versions[originalVersionPosition].revision || '0'
-      let date = this.formatDate(this.versions[originalVersionPosition].firstPublishedAt)
+      let date = this.formatDate(
+        this.versions[originalVersionPosition].firstPublishedAt
+      )
       return `Version ${version}, Revision ${revision}; ${date}`
     },
     embargoed: function() {
       return propOr(false, 'embargo', this.datasetInfo)
-    },
+    }
   },
   methods: {
     getDoiLink(doi) {

--- a/components/VersionHistory/VersionHistory.vue
+++ b/components/VersionHistory/VersionHistory.vue
@@ -133,11 +133,10 @@
 
 <script>
 import { mapState } from 'vuex'
-import { propOr, isEmpty } from 'ramda'
+import { propOr } from 'ramda'
 
 import RequestDownloadFile from '@/mixins/request-download-file'
 import FormatDate from '@/mixins/format-date'
-import { retry } from '@aws-amplify/core'
 import marked from '@/mixins/marked/index'
 
 export default {

--- a/mixins/request-download-file/index.js
+++ b/mixins/request-download-file/index.js
@@ -4,7 +4,7 @@ import FileDownload from 'js-file-download'
 export default {
   methods: {
     /**
-     * Request download file via axios.
+     * Request download file via axios. This will file will be saved on the users computer with file name "fileName"
      */
     requestDownloadFile: function(downloadInfo) {
       const fileName = propOr('', 'name', downloadInfo)
@@ -20,6 +20,28 @@ export default {
       }
       this.$axios.$post(process.env.zipit_api_host, payload).then(response => {
         FileDownload(response, fileName)
+      })
+    },
+    /**
+     * Request file contents via axios. This returns a promise which resolves to the contents of the file to then be used withing sparc-app (ie to display markdown)
+     */
+    requestFileContent(downloadInfo) {
+      return new Promise(resolve => {
+        const datasetVersionRegexp = /s3:\/\/pennsieve-prod-discover-publish-use1\/(?<datasetId>\d*)\/(?<version>\d*)\/(?<filePath>.*)/
+        const matches = downloadInfo.uri.match(datasetVersionRegexp)
+
+        const payload = {
+          data: {
+            paths: [matches.groups.filePath],
+            datasetId: matches.groups.datasetId,
+            version: matches.groups.version
+          }
+        }
+        this.$axios
+          .$post(process.env.zipit_api_host, payload)
+          .then(response => {
+            resolve(response)
+          })
       })
     }
   }


### PR DESCRIPTION
# Description

### This is to complete the ticket:
[Add logic to change log display](https://www.wrike.com/open.htm?id=947150591)


> Acceptance Criteria:
add logic to the change log display so that it shows what is available without downloading the file, utilizing UI/UX best practices
potentially showing full change log without downloading, or showing first 120 characters of changelog
Display text as-is for first version. 
use icons (download and view) in the changelog column

### Changes
 - Uses the `large-modal` for display
 - Added a function to 'request-download-file to obtain file contents
 - Added icons for downloading and viewing the changelogs (requested in acceptance criteria)
 - run eslint on `VersionHistory.vue`

### View live
This pr can be tested with the link below
https://jesse-sprint-23.herokuapp.com/datasets/76?type=dataset&datasetDetailsTab=versions
![image](https://user-images.githubusercontent.com/37255664/196328679-ff761eb1-8c97-44c1-a758-9d926d688904.png)

## Type of change

Delete those that don't apply.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

# How Has This Been Tested?

This pr can be tested with the link below
https://jesse-sprint-23.herokuapp.com/datasets/76?type=dataset&datasetDetailsTab=versions
![image](https://user-images.githubusercontent.com/37255664/196328679-ff761eb1-8c97-44c1-a758-9d926d688904.png)


# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have utilized components from the Design System Library where applicable
- [ ] I have added unit tests that prove my fix is effective or that my feature works
