### PR TITLE
Replace aria placeholder

### DIFF
--- a/components/ContactUsForms/BugForm/BugForm.vue
+++ b/components/ContactUsForms/BugForm/BugForm.vue
@@ -12,7 +12,7 @@
     >
       <el-select
         v-model="form.typeOfUser"
-        aria-placeholder="Select one"
+        placeholder="Select one"
         :popper-append-to-body="false"
       >
         <el-option
@@ -30,7 +30,7 @@
     >
       <el-select
         v-model="form.pageOrResource"
-        aria-placeholder="Select one"
+        placeholder="Select one"
         :popper-append-to-body="false"
       >
         <el-option

--- a/components/ContactUsForms/GeneralForm/GeneralForm.vue
+++ b/components/ContactUsForms/GeneralForm/GeneralForm.vue
@@ -12,7 +12,7 @@
     >
       <el-select
         v-model="form.sparcInvestigator"
-        aria-placeholder="Select one"
+        placeholder="Select one"
         :popper-append-to-body="false"
       >
         <el-option
@@ -30,7 +30,7 @@
     >
       <el-select
         v-model="form.pageOrResource"
-        aria-placeholder="Select one"
+        placeholder="Select one"
         :popper-append-to-body="false"
       >
         <el-option

--- a/components/ToolsAndResourcesForm/ToolsAndResourcesForm.vue
+++ b/components/ToolsAndResourcesForm/ToolsAndResourcesForm.vue
@@ -12,7 +12,7 @@
     >
       <el-select
         v-model="form.sparcFunded"
-        aria-placeholder="Select one"
+        placeholder="Select one"
         :popper-append-to-body="false"
       >
         <el-option
@@ -31,7 +31,7 @@
     >
       <el-select
         v-model="form.levelOfInvolvement"
-        aria-placeholder="Select one"
+        placeholder="Select one"
         :popper-append-to-body="false"
       >
         <el-option

--- a/components/footer/ContactUsModal.vue
+++ b/components/footer/ContactUsModal.vue
@@ -14,20 +14,20 @@
         <el-form-item prop="name" label="Your Name">
           <el-input
             v-model="contactUsForm.name"
-            aria-placeholder="Enter your name"
+            placeholder="Enter your name"
           />
         </el-form-item>
         <el-form-item prop="email" label="Your Email">
           <el-input
             v-model="contactUsForm.email"
-            aria-placeholder="Enter your email"
+            placeholder="Enter your email"
             type="email"
           />
         </el-form-item>
         <el-form-item prop="message" label="Your Message">
           <el-input
             v-model="contactUsForm.message"
-            aria-placeholder="Your message"
+            placeholder="Your message"
             type="textarea"
           />
         </el-form-item>

--- a/pages/contact-us/index.vue
+++ b/pages/contact-us/index.vue
@@ -15,7 +15,7 @@
             v-model="formType"
             class="input-reason"
             placeholder="Select a reason"
-            aria-placeholder="Select a reason"
+            placeholder="Select a reason"
             :popper-append-to-body="false"
           >
             <el-option


### PR DESCRIPTION
# Description

aria-placeholder was causing some users to see chinese characters instead of english because placeholder takes precedence and element-ui must have been setting one by default. Element UI docs show that we should be using placeholder

## Type of change

- [X] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

Locally

# Checklist:

- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my own code
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] I have utilized components from the Design System Library where applicable
