### PR TITLE
Fix an issue with reloading the news-and-events page.

### DIFF
--- a/pages/news-and-events/index.vue
+++ b/pages/news-and-events/index.vue
@@ -41,43 +41,45 @@
           </el-col>
           <el-col :sm="12">
             <div class="heading2 mb-16">Events</div>
-            <content-tab-card
-              class="tabs p-32"
-              :tabs="eventsTabs"
-              :active-tab-id="activeTabId"
-              @tab-changed="eventsTabChanged"
-            >
-              <template v-if="activeTabId === 'upcoming'">
-                <div class="upcoming-events">
-                  <event-card
-                    v-for="event in upcomingEvents.items"
-                    :key="event.sys.id"
-                    :event="event"
-                  />
-                </div>
+            <client-only>
+              <content-tab-card
+                class="tabs p-32"
+                :tabs="eventsTabs"
+                :active-tab-id="activeTabId"
+                @tab-changed="eventsTabChanged"
+              >
+                <template v-if="activeTabId === 'upcoming'">
+                  <div class="upcoming-events">
+                    <event-card
+                      v-for="event in upcomingEvents.items"
+                      :key="event.sys.id"
+                      :event="event"
+                    />
+                  </div>
 
-              </template>
+                </template>
 
-              <template v-if="activeTabId === 'past'">
-                <div class="past-events">
-                  <event-card
-                    v-for="event in pastEvents.items"
-                    :key="event.sys.id"
-                    :event="event"
-                  />
+                <template v-if="activeTabId === 'past'">
+                  <div class="past-events">
+                    <event-card
+                      v-for="event in pastEvents.items"
+                      :key="event.sys.id"
+                      :event="event"
+                    />
+                  </div>
+                </template>
+                <div class="mt-16">
+                  <nuxt-link
+                    class="btn-load-more"
+                    :to="{
+                      name: 'news-and-events-events',
+                    }"
+                  >
+                    View All Events >
+                  </nuxt-link>
                 </div>
-              </template>
-              <div class="mt-16">
-                <nuxt-link
-                  class="btn-load-more"
-                  :to="{
-                    name: 'news-and-events-events',
-                  }"
-                >
-                  View All Events >
-                </nuxt-link>
-              </div>
-            </content-tab-card>
+              </content-tab-card>
+            </client-only>
           </el-col>
         </el-row>
 

--- a/pages/news-and-events/index.vue
+++ b/pages/news-and-events/index.vue
@@ -41,6 +41,10 @@
           </el-col>
           <el-col :sm="12">
             <div class="heading2 mb-16">Events</div>
+            <!--
+              Server side rendering does not work with the following
+              combination of components
+            -->
             <client-only>
               <content-tab-card
                 class="tabs p-32"


### PR DESCRIPTION
# Description

The [news and events page](https://sparc.science/news-and-events) does not load properly on refresh or on new visit causing some of the items on the page to not render properly such as the no item is loaded onto the Current Newsletter. The issue is reported in this [wrike ticket](https://www.wrike.com/open.htm?id=981940590). The solution is to disable server side rednering on the components causing the issue and is implemented with this pull request


## Type of change

Delete those that don't apply.

- [ ] Bug fix (non-breaking change which fixes an issue)


# How Has This Been Tested?
The fix has been deployed this page - https://alan-wu-sparc-app.herokuapp.com/news-and-events
The Current NewsLetter item should load on refresh.

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have utilized components from the Design System Library where applicable
- [ ] I have added unit tests that prove my fix is effective or that my feature works
