### PR TITLE
Fix default 'PORTAL_API_HOST' throwing an error

### DIFF
--- a/nuxt.config.js
+++ b/nuxt.config.js
@@ -38,7 +38,7 @@ export default {
     ]
   },
   env: {
-    portal_api: process.env.PORTAL_API_HOST || 'http://localhost:5000 ',
+    portal_api: process.env.PORTAL_API_HOST || 'https://api.sparc.science',
     flatmap_api:
       process.env.FLATMAP_API_HOST || 'https://mapcore-demo.org/current/flatmap/v2/',
     crosscite_api_host:


### PR DESCRIPTION
# Description

I think I accidentally changed this a while back, I think we should change it back to what the default sparc-api would be

Also, there is a space that snuck in here, so even if you were using a development server on `https://localhost:5000`, it still would not work...


## Type of change

Delete those that don't apply.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

# How Has This Been Tested?

Ran locally 


# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have utilized components from the Design System Library where applicable
- [ ] I have added unit tests that prove my fix is effective or that my feature works
