### PR TITLE
Fix issue where marked versions were clashing

### DIFF
--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
   "dependencies": {
     "@abi-software/flatmapvuer": "0.2.5",
     "@abi-software/gallery": "0.3.1",
-    "@abi-software/mapintegratedvuer": "0.3.9-beta.2",
+    "@abi-software/mapintegratedvuer": "0.3.9-beta.4",
     "@abi-software/plotvuer": "^0.3.0",
     "@abi-software/scaffoldvuer": "0.1.53",
     "@abi-software/simulationvuer": "^0.5.9",

--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
   "dependencies": {
     "@abi-software/flatmapvuer": "0.2.5",
     "@abi-software/gallery": "0.3.1",
-    "@abi-software/mapintegratedvuer": "0.3.9-beta.0",
+    "@abi-software/mapintegratedvuer": "0.3.9-beta.2",
     "@abi-software/plotvuer": "^0.3.0",
     "@abi-software/scaffoldvuer": "0.1.53",
     "@abi-software/simulationvuer": "^0.5.9",

--- a/yarn.lock
+++ b/yarn.lock
@@ -80,24 +80,26 @@
     element-ui "^2.15.0"
     vue "^2.6.11"
 
-"@abi-software/map-side-bar@^1.3.27":
-  version "1.3.27"
-  resolved "https://registry.yarnpkg.com/@abi-software/map-side-bar/-/map-side-bar-1.3.27.tgz#cbaaafa56f62779993a11245ded1f42b24683e80"
-  integrity sha512-Uohx2yMgegvKIwRyhTzhn+XY5ptjK4TWXvw+/U4XpH7HGJUDp5w6/rYnXObVbLpu55ngjhSLWJGDM8R2Cz4gow==
+"@abi-software/map-side-bar@^1.3.30":
+  version "1.3.30"
+  resolved "https://registry.yarnpkg.com/@abi-software/map-side-bar/-/map-side-bar-1.3.30.tgz#ccced51e5de6979ee4043618b38a170a050e4597"
+  integrity sha512-QD3tl61r6dZbgqDfg4ctZ6RktflyOtDyTAbqVjAMwaVGDSlZW8mTBPX8IWcM9KMdqTExNNPHV7QlrD/giOyhCw==
   dependencies:
     "@abi-software/gallery" "^0.3.1"
     "@abi-software/svg-sprite" "^0.1.14"
     algoliasearch "^4.10.5"
     element-ui "^2.13.0"
+    marked "^4.1.1"
     vue "^2.6.10"
+    xss "^1.0.14"
 
-"@abi-software/mapintegratedvuer@0.3.9-beta.0":
-  version "0.3.9-beta.0"
-  resolved "https://registry.yarnpkg.com/@abi-software/mapintegratedvuer/-/mapintegratedvuer-0.3.9-beta.0.tgz#e069b3761b4b91d55e7d682e2778616f82757e4c"
-  integrity sha512-eDhun1HLBgahqSWnIaQa4qal5ijVy6g4ngBSbCq+0/CJ7Eq/kIIN1pdEz2dRFcg1gVW6rFfSkS20KNVSeOEtCw==
+"@abi-software/mapintegratedvuer@0.3.9-beta.2":
+  version "0.3.9-beta.2"
+  resolved "https://registry.yarnpkg.com/@abi-software/mapintegratedvuer/-/mapintegratedvuer-0.3.9-beta.2.tgz#98e81efc353b261c43cb1f50b848f55eb2a60a2a"
+  integrity sha512-MhEuc8oPmYyElKhDVYTDIZ16hhHSa2IiTKPB841FX7C4QH6nNrXm5kG++QGyCfeHHc0cnqX0mOvwVbs48CnrUA==
   dependencies:
     "@abi-software/flatmapvuer" "^0.3.3"
-    "@abi-software/map-side-bar" "^1.3.27"
+    "@abi-software/map-side-bar" "^1.3.30"
     "@abi-software/plotvuer" "^0.3.9"
     "@abi-software/scaffoldvuer" "^0.1.53"
     "@abi-software/simulationvuer" "^0.5.9"
@@ -5128,7 +5130,7 @@ combined-stream@^1.0.6, combined-stream@~1.0.6:
   dependencies:
     delayed-stream "~1.0.0"
 
-commander@2, commander@^2.15.1, commander@^2.18.0, commander@^2.19.0, commander@^2.20.0, commander@^2.9.0:
+commander@2, commander@^2.15.1, commander@^2.18.0, commander@^2.19.0, commander@^2.20.0, commander@^2.20.3, commander@^2.9.0:
   version "2.20.3"
   resolved "https://registry.yarnpkg.com/commander/-/commander-2.20.3.tgz#fd485e84c03eb4881c20722ba48035e8531aeb33"
   integrity sha512-GpVkmM8vF2vQUkj2LvZmD35JxeJOLCwJ9cUkugyk2nuhbv3+mJvpLYYt+0+USMxE+oj+ey/lJEnhZw75x/OMcQ==
@@ -5710,6 +5712,11 @@ cssesc@^3.0.0:
   version "3.0.0"
   resolved "https://registry.yarnpkg.com/cssesc/-/cssesc-3.0.0.tgz#37741919903b868565e1c09ea747445cd18983ee"
   integrity sha512-/Tb/JcjK111nNScGob5MNtsntNM1aCNUDipB/TkwZFhyDrrE47SOx/18wF2bbjgc3ZzCSKW1T5nt5EbFoAz/Vg==
+
+cssfilter@0.0.10:
+  version "0.0.10"
+  resolved "https://registry.yarnpkg.com/cssfilter/-/cssfilter-0.0.10.tgz#c6d2672632a2e5c83e013e6864a42ce8defd20ae"
+  integrity sha512-FAaLDaplstoRsDR8XGYH51znUN0UY7nMc6Z9/fvE8EXGwvJE9hu7W2vHwx1+bd6gCYnln9nLbzxFTrcO9YQDZw==
 
 cssnano-preset-default@^4.0.7:
   version "4.0.7"
@@ -10162,6 +10169,11 @@ marked@^0.7.0:
   version "0.7.0"
   resolved "https://registry.yarnpkg.com/marked/-/marked-0.7.0.tgz#b64201f051d271b1edc10a04d1ae9b74bb8e5c0e"
   integrity sha512-c+yYdCZJQrsRjTPhUx7VKkApw9bwDkNbHUKo1ovgcfDjb2kc8rLuRbIFyXL5WOEUwzSSKo3IXpph2K6DqB/KZg==
+
+marked@^4.1.1:
+  version "4.2.0"
+  resolved "https://registry.yarnpkg.com/marked/-/marked-4.2.0.tgz#f1683b077626a6c53e28926b798a18184aa13a91"
+  integrity sha512-1qWHjHlBKwjnDfrkxd0L3Yx4LTad/WO7+d13YsXAC/ZfKj7p0xkLV3sDXJzfWgL7GfW4IBZwMAYWaz+ifyQouQ==
 
 mat4-decompose@^1.0.3:
   version "1.0.4"
@@ -15734,6 +15746,14 @@ xml-name-validator@^3.0.0:
   version "3.0.0"
   resolved "https://registry.yarnpkg.com/xml-name-validator/-/xml-name-validator-3.0.0.tgz#6ae73e06de4d8c6e47f9fb181f78d648ad457c6a"
   integrity sha512-A5CUptxDsvxKJEU3yO6DuWBSJz/qizqzJKOMIfUJHETbBw/sFaDxgd6fxm1ewUaM0jZ444Fc5vC5ROYurg/4Pw==
+
+xss@^1.0.14:
+  version "1.0.14"
+  resolved "https://registry.yarnpkg.com/xss/-/xss-1.0.14.tgz#4f3efbde75ad0d82e9921cc3c95e6590dd336694"
+  integrity sha512-og7TEJhXvn1a7kzZGQ7ETjdQVS2UfZyTlsEdDOqvQF7GoxNfY+0YLCzBy1kPdsDDx4QuNAonQPddpsn6Xl/7sw==
+  dependencies:
+    commander "^2.20.3"
+    cssfilter "0.0.10"
 
 "xtend@>=4.0.0 <4.1.0-0", xtend@^4.0.0, xtend@~4.0.1:
   version "4.0.2"

--- a/yarn.lock
+++ b/yarn.lock
@@ -80,10 +80,10 @@
     element-ui "^2.15.0"
     vue "^2.6.11"
 
-"@abi-software/map-side-bar@^1.3.30":
-  version "1.3.30"
-  resolved "https://registry.yarnpkg.com/@abi-software/map-side-bar/-/map-side-bar-1.3.30.tgz#ccced51e5de6979ee4043618b38a170a050e4597"
-  integrity sha512-QD3tl61r6dZbgqDfg4ctZ6RktflyOtDyTAbqVjAMwaVGDSlZW8mTBPX8IWcM9KMdqTExNNPHV7QlrD/giOyhCw==
+"@abi-software/map-side-bar@^1.3.31":
+  version "1.3.31"
+  resolved "https://registry.yarnpkg.com/@abi-software/map-side-bar/-/map-side-bar-1.3.31.tgz#3a2f8f55f25907e0a1c8a13f9b7c785186523bc5"
+  integrity sha512-oIZW8KAoH0yfekK37Z/izY7dYmB1UoLh4t3cUSWsNvZSCnRCIwG2o4ZS2GNyEF29p2gTIS1WNQb39K/UTxMSOw==
   dependencies:
     "@abi-software/gallery" "^0.3.1"
     "@abi-software/svg-sprite" "^0.1.14"
@@ -93,13 +93,13 @@
     vue "^2.6.10"
     xss "^1.0.14"
 
-"@abi-software/mapintegratedvuer@0.3.9-beta.2":
-  version "0.3.9-beta.2"
-  resolved "https://registry.yarnpkg.com/@abi-software/mapintegratedvuer/-/mapintegratedvuer-0.3.9-beta.2.tgz#98e81efc353b261c43cb1f50b848f55eb2a60a2a"
-  integrity sha512-MhEuc8oPmYyElKhDVYTDIZ16hhHSa2IiTKPB841FX7C4QH6nNrXm5kG++QGyCfeHHc0cnqX0mOvwVbs48CnrUA==
+"@abi-software/mapintegratedvuer@0.3.9-beta.4":
+  version "0.3.9-beta.4"
+  resolved "https://registry.yarnpkg.com/@abi-software/mapintegratedvuer/-/mapintegratedvuer-0.3.9-beta.4.tgz#1d70dc729bd98cbdf0b3cb1cad6daaa9b71872d7"
+  integrity sha512-U5/+8GPWIQq+4IAAJpF0ZtTaBF8NAmekRVKxb+G4RguAQZoIwtbkW14Tov8oNWddaBCP4jhjeTZdyNLS2vqpWw==
   dependencies:
     "@abi-software/flatmapvuer" "^0.3.3"
-    "@abi-software/map-side-bar" "^1.3.30"
+    "@abi-software/map-side-bar" "^1.3.31"
     "@abi-software/plotvuer" "^0.3.9"
     "@abi-software/scaffoldvuer" "^0.1.53"
     "@abi-software/simulationvuer" "^0.5.9"


### PR DESCRIPTION
# Description
If you open this scaffold on https://staging.sparc.science/maps , the context card currently crashes

![image](https://user-images.githubusercontent.com/37255664/199156581-34008161-50ad-4b25-bbd5-7e9c79e68ddc.png)

This is because there is an issue where the version of marked used on the sidebar seems to not get used.

This PR fixes this issue by whitelisting marked in map-side-bar's node eternals (thank you Alan for the idea)

## Type of change

Delete those that don't apply.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

# How Has This Been Tested?

Tested locally and this code can be viewed at:
https://jesse-sprint-23.herokuapp.com/maps


# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have utilized components from the Design System Library where applicable
- [ ] I have added unit tests that prove my fix is effective or that my feature works
