### PR TITLE
Added middleware for sign out

### DIFF
--- a/components/LoginModal/LoginModal.vue
+++ b/components/LoginModal/LoginModal.vue
@@ -78,7 +78,7 @@ export default {
     onLoginWithORCID: async function(x) {
       x.preventDefault()
       this.dialogVisible = false
-      this.$cookies.set('auth-redirect-url', this.$nuxt.$route.fullPath)
+      this.$cookies.set('sign-in-redirect-url', this.$nuxt.$route.fullPath)
       await this.$store.dispatch('user/login', 'ORCID')
       
     },

--- a/components/header/Header.vue
+++ b/components/header/Header.vue
@@ -314,7 +314,7 @@ export default {
   methods: {
     handleUserMenuSelect(menuId, menuIdPath) {
       if (menuId === 'logout') {
-        this.$cookies.set('auth-redirect-url', this.$nuxt.$route.fullPath)
+        this.$cookies.set('sign-out-redirect-url', this.$nuxt.$route.fullPath)
         this.$store.dispatch('user/logout')
       }
       if (menuId === 'profile') {

--- a/middleware/signOutRedirect.js
+++ b/middleware/signOutRedirect.js
@@ -1,0 +1,7 @@
+export default function ({ redirect, app }) {
+  const authRedirectUrl = app.$cookies.get('sign-out-redirect-url')
+  if (authRedirectUrl) {
+    app.$cookies.set('sign-out-redirect-url', null)
+    redirect(authRedirectUrl)
+  }
+}

--- a/nuxt.config.js
+++ b/nuxt.config.js
@@ -146,7 +146,7 @@ export default {
         component: '@/pages/datasets/_datasetId.vue'
       })
     },
-    middleware: ['verifyUserProfileComplete', 'documentationHubRedirects']
+    middleware: ['verifyUserProfileComplete', 'documentationHubRedirects', 'signOutRedirect']
   },
   /*
    ** Global CSS

--- a/pages/index.vue
+++ b/pages/index.vue
@@ -78,12 +78,14 @@ export default {
   },
 
   mounted() {
-    // When trying to do this using a middleware, the server would redirect correctly initially after login,
-    // but then another unknown redirect back to / was happening that would cause the page to load incorrectly.
-    // The only downside to doing it this way is a momentary display of the home page first before redirecting.
-    const authRedirectUrl = this.$cookies.get('auth-redirect-url')
+    // When trying to do federated sign in using a middleware (like we do for sign out), Cognito's callback would only
+    // execute client-side (after the middleware had already redirected to the new page) causing it to overwrite the 
+    // previous redirect. This issue was supposed to be addressed by https://github.com/aws-amplify/amplify-js/pull/3588, 
+    // but attempting to handle dynamic routing after amplify federated sign in via a custom state hook as suggested 
+    // here: https://github.com/aws-amplify/amplify-js/issues/3125#issuecomment-814265328 did not work
+    const authRedirectUrl = this.$cookies.get('sign-in-redirect-url')
     if (authRedirectUrl) {
-      this.$cookies.set('auth-redirect-url', null)
+      this.$cookies.set('sign-in-redirect-url', null)
       this.$router.push(authRedirectUrl)
     }
   },

--- a/pages/index.vue
+++ b/pages/index.vue
@@ -77,7 +77,7 @@ export default {
       }).catch(console.error)
   },
 
-  mounted() {
+  beforeMount() {
     // When trying to do federated sign in using a middleware (like we do for sign out), Cognito's callback would only
     // execute client-side (after the middleware had already redirected to the new page) causing it to overwrite the 
     // previous redirect. This issue was supposed to be addressed by https://github.com/aws-amplify/amplify-js/pull/3588, 


### PR DESCRIPTION
# Description

Sped up logout by using a middleware. I attempted to also use this middleware for sign in, but I could not get federated sign in to allow dynamic routing since the callback was not going through the middleware or asyncData (It was only happening client-side so we have to wait for mount)

## Type of change

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

# How Has This Been Tested?

Locally

# Checklist:

- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my own code
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] I have utilized components from the Design System Library where applicable
