### PR TITLE
QA Second fixes for map viewer not displaying the latest flatmaps

### DIFF
--- a/package.json
+++ b/package.json
@@ -17,12 +17,12 @@
     "test:debug": "node --inspect node_modules/.bin/jest --runInBand"
   },
   "dependencies": {
-    "@abi-software/flatmapvuer": "0.3.9",
+    "@abi-software/flatmapvuer": "0.3.10",
     "@abi-software/gallery": "0.3.1",
-    "@abi-software/mapintegratedvuer": "0.3.9-fixes-1",
+    "@abi-software/mapintegratedvuer": "0.3.9-fixes-2",
     "@abi-software/plotvuer": "^0.3.0",
     "@abi-software/scaffoldvuer": "0.1.55",
-    "@abi-software/simulationvuer": "^0.5.9",
+    "@abi-software/simulationvuer": "0.5.9",
     "@aws-amplify/auth": "^4.4.4",
     "@aws-amplify/core": "^4.4.2",
     "@miyaoka/nuxt-twitter-widgets-module": "^0.0.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -11,10 +11,10 @@
     orbit-camera-controller "^4.0.0"
     turntable-camera-controller "^3.0.0"
 
-"@abi-software/flatmap-viewer@^2.2.7":
-  version "2.2.7"
-  resolved "https://registry.yarnpkg.com/@abi-software/flatmap-viewer/-/flatmap-viewer-2.2.7.tgz#980ca6e24a65d4a935eb38b21fc2c05836a9f0d7"
-  integrity sha512-QR6HRxLLI0mMsSAGkPJgfJg13943ZM6BUPPjXFWtBTXeKH8sEHWTzAgwF2rLWsP9HnaJXVCOhH//R4LAXdU0fA==
+"@abi-software/flatmap-viewer@^2.2.9":
+  version "2.2.9"
+  resolved "https://registry.yarnpkg.com/@abi-software/flatmap-viewer/-/flatmap-viewer-2.2.9.tgz#b3f50f4e23944d19b4babf8a56030b12c5f2470b"
+  integrity sha512-UN7R84Xn2TeK9Fo/IEFSEKuauRroO5KMYKDUu4wfZQw0qzSC79OdJmHBOeIH4pkS+J4FRZfq+prS7cxiCNCyRw==
   dependencies:
     "@babel/runtime" "^7.10.4"
     "@turf/area" "^6.0.1"
@@ -26,12 +26,12 @@
     minisearch "^2.2.1"
     polylabel "^1.1.0"
 
-"@abi-software/flatmapvuer@0.3.9", "@abi-software/flatmapvuer@^0.3.9":
-  version "0.3.9"
-  resolved "https://registry.yarnpkg.com/@abi-software/flatmapvuer/-/flatmapvuer-0.3.9.tgz#fa9227f61472a4811c2ac193c7232e785b991bab"
-  integrity sha512-nuFOs5ztP8D2sl/h+Mt9icclV2vuCMPM6seIzgeVNlZnefFviFXeiJPO5Cn96cRJnEiyx/tZ8RG7nz/w4l9BXQ==
+"@abi-software/flatmapvuer@0.3.10", "@abi-software/flatmapvuer@^0.3.10":
+  version "0.3.10"
+  resolved "https://registry.yarnpkg.com/@abi-software/flatmapvuer/-/flatmapvuer-0.3.10.tgz#c9e88ebb7cc83bcc4c8aec6cf47888e752a5a552"
+  integrity sha512-sFXYvFFW7H8Wx+TGIKBoyIaT62ad7Ps6G9tewDgb5YTnfOY0F+ZklHEAcLYouWMswt+67zOzg/4LLqZqbyloMg==
   dependencies:
-    "@abi-software/flatmap-viewer" "^2.2.7"
+    "@abi-software/flatmap-viewer" "^2.2.9"
     "@abi-software/svg-sprite" "^0.1.14"
     core-js "^3.3.2"
     css-element-queries "^1.2.2"
@@ -67,12 +67,12 @@
     vue "^2.6.10"
     xss "^1.0.14"
 
-"@abi-software/mapintegratedvuer@0.3.9-fixes-1":
-  version "0.3.9-fixes-1"
-  resolved "https://registry.yarnpkg.com/@abi-software/mapintegratedvuer/-/mapintegratedvuer-0.3.9-fixes-1.tgz#68faf6b76887d3f44e4484e4f2bda383dd5f5adb"
-  integrity sha512-LXJv3UtGeGo/P7yTguPzM4lU6arEqxdy991/fpm48RHqbiWzm49+Rop2x0TIov4es1g8Myu8EI6o4kivKc9LPg==
+"@abi-software/mapintegratedvuer@0.3.9-fixes-2":
+  version "0.3.9-fixes-2"
+  resolved "https://registry.yarnpkg.com/@abi-software/mapintegratedvuer/-/mapintegratedvuer-0.3.9-fixes-2.tgz#33b612b0f7dd8418c0d3a519a781ab8125842d35"
+  integrity sha512-btWX8vsshmJXea79kdvecBFY3To6BqmjIHTVJYAAfH57tSHQEe9Tn/kdbyAwMTStY4cqliaMP+1SsoaPxxEcjw==
   dependencies:
-    "@abi-software/flatmapvuer" "^0.3.9"
+    "@abi-software/flatmapvuer" "^0.3.10"
     "@abi-software/map-side-bar" "^1.3.32"
     "@abi-software/plotvuer" "^0.3.9"
     "@abi-software/scaffoldvuer" "^0.1.56"
@@ -184,7 +184,7 @@
     vue-router "^3.5.1"
     zincjs "^1.0.9"
 
-"@abi-software/simulationvuer@^0.5.9":
+"@abi-software/simulationvuer@0.5.9", "@abi-software/simulationvuer@^0.5.9":
   version "0.5.9"
   resolved "https://registry.yarnpkg.com/@abi-software/simulationvuer/-/simulationvuer-0.5.9.tgz#73c8a85c8a3f5dadfa3aa40c6ef1a58203554b06"
   integrity sha512-2xWBj0BVBbPP1C2q4DKgSLMhmyBwLLhExgQ66zsWq1QPqYIVQjCHhYQ8FM1OnoBgT3hUl8hVjboS0N/Jcq6OkA==


### PR DESCRIPTION
# Description

This update address a problem with the sensory neurons control and add support of the other type neurons toggle.
UUID of a flatmap will now be stored with the permalink which will be used to identify flatmap in the future.

## Type of change

Delete those that don't apply.

- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

I have deployed it on https://mapcore-demo.org/staging/flatmap-update-sparc-app/maps for testing

# Checklist:

- [x] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have utilized components from the Design System Library where applicable
- [ ] I have added unit tests that prove my fix is effective or that my feature works
