### PR TITLE
Remove external link icon

### DIFF
--- a/components/EventListItem/EventListItem.vue
+++ b/components/EventListItem/EventListItem.vue
@@ -14,9 +14,9 @@
           }"
           v-html="highlightMatches(item.fields.title, $route.query.search)"
         />
-        <a v-else class="link1" :href="item.fields.url" :target="isInternalLink('item.fields.url') ? '_self' : '_blank'">
+        <a v-else class="link1" :href="item.fields.url" :target="!opensInNewTab(item.fields.url) ? '_self' : '_blank'">
           <span v-html="highlightMatches(item.fields.title, $route.query.search)"/>
-          <svg-icon v-if="!isInternalLink('item.fields.url')" name="icon-open" height="30" width="30" />
+          <svg-icon v-if="!isInternalLink(item.fields.url)" name="icon-open" height="30" width="30" />
         </a>
         <div>
           <div class="body1 my-8" v-html="highlightMatches(item.fields.summary, $route.query.search)"/>
@@ -57,7 +57,7 @@ import { isEmpty, pathOr } from 'ramda'
 import eventBannerImage from '@/components/EventBannerImage/EventBannerImage.vue'
 import FormatDate from '@/mixins/format-date'
 
-import { isInternalLink } from '@/mixins/marked/index'
+import { isInternalLink, opensInNewTab } from '@/mixins/marked/index'
 import { highlightMatches } from '../../pages/data/utils'
 
 export default {
@@ -106,7 +106,8 @@ export default {
   },
   methods: {
     isInternalLink,
-    highlightMatches
+    highlightMatches,
+    opensInNewTab
   }
 }
 </script>

--- a/components/NewsListItem/NewsListItem.vue
+++ b/components/NewsListItem/NewsListItem.vue
@@ -19,10 +19,10 @@
         <a
           v-else
           :href="item.fields.url"
-          :target="isInternalLink('item.fields.url') ? '_self' : '_blank'"
+          :target="!opensInNewTab(item.fields.url) ? '_self' : '_blank'"
         >
           <span v-html="highlightMatches(item.fields.title, $route.query.search)"/>
-          <svg-icon v-if="!isInternalLink('item.fields.url')" name="icon-open" height="30" width="30" />
+          <svg-icon v-if="!isInternalLink(item.fields.url)" name="icon-open" height="30" width="30" />
         </a>
       </h3>
       <p v-html="highlightMatches(item.fields.summary, $route.query.search)"/>
@@ -39,7 +39,7 @@ import FormatDate from '@/mixins/format-date'
 import EventBannerImage from '@/components/EventBannerImage/EventBannerImage.vue'
 import SparcPill from '@/components/SparcPill/SparcPill.vue'
 
-import { isInternalLink } from '@/mixins/marked/index'
+import { isInternalLink, opensInNewTab } from '@/mixins/marked/index'
 import { highlightMatches } from '~/pages/data/utils'
 
 export default {
@@ -75,6 +75,7 @@ export default {
 
   methods: {
     isInternalLink,
+    opensInNewTab,
     highlightMatches
   }
 }

--- a/components/StayConnected/StayConnected.vue
+++ b/components/StayConnected/StayConnected.vue
@@ -11,7 +11,7 @@
         <el-col class="office-hours-column" :xs="24" :sm="12">
           <div class="heading2">Open Office Hours</div>
           <div class="body1 mb-16 mt-8">Join one of our weekly office hours to ask questions and learn more from the SPARC Data Resource Center Team.</div>
-          <a href="https://docs.sparc.science/docs/sparc-drc-open-office-hours">
+          <a href="https://docs.sparc.science/docs/sparc-drc-open-office-hours" target="_blank">
             <el-button class="secondary">
             Find out more
             </el-button>

--- a/components/ToolAndResourcesPage/ToolsAndResourcesPage.vue
+++ b/components/ToolAndResourcesPage/ToolsAndResourcesPage.vue
@@ -18,7 +18,7 @@
           <div class="label4 mb-4" >
             TUTORIALS & GUIDES
           </div>
-          <a class="resource-link" v-for="(tutorial, index) in tutorials" :key="index" :href="tutorial.fields.url" :target="isInternalLink(tutorial.fields.url) ? '_self' : '_blank'">
+          <a class="resource-link" v-for="(tutorial, index) in tutorials" :key="index" :href="tutorial.fields.url" :target="!opensInNewTab(tutorial.fields.url) ? '_self' : '_blank'">
             {{ tutorial.fields.title }}
             <svg-icon v-if="!isInternalLink(tutorial.fields.url)" name="icon-open" height="25" width="25" />
           </a>
@@ -27,7 +27,7 @@
           <div class="label4 mb-4" >
             VIDEOS & WEBINARS
           </div>
-          <a class="resource-link" v-for="(webinar, index) in webinars" :key="index" :href="webinar.fields.url" :target="isInternalLink(webinar.fields.url) ? '_self' : '_blank'">
+          <a class="resource-link" v-for="(webinar, index) in webinars" :key="index" :href="webinar.fields.url" :target="!opensInNewTab(webinar.fields.url) ? '_self' : '_blank'">
             {{ webinar.fields.title }}
             <svg-icon v-if="!isInternalLink(webinar.fields.url)" name="icon-open" height="25" width="25" />
           </a>
@@ -46,7 +46,7 @@ import FormatDate from '@/mixins/format-date'
 import Breadcrumb from '@/components/Breadcrumb/Breadcrumb'
 import PageHero from '@/components/PageHero/PageHero'
 import { pathOr } from 'ramda'
-import { isInternalLink } from '@/mixins/marked/index'
+import { isInternalLink, opensInNewTab } from '@/mixins/marked/index'
 
 export default {
   name: 'ToolsAndResourcesPage',
@@ -87,6 +87,7 @@ export default {
 
   methods: {
     isInternalLink,
+    opensInNewTab
   },
 
   computed: {

--- a/components/footer/FooterLink.vue
+++ b/components/footer/FooterLink.vue
@@ -1,18 +1,14 @@
 <template>
-  <nuxt-link
-    v-if="isInternalLink(link.fields.url || '')"
-    :to="link.fields.url"
-    data-jest="nuxt-link"
+  <a
+    :href="linkUrl"
+    :target="!opensInNewTab(linkUrl) ? '_self' : '_blank'"
   >
-    {{ link.fields.title }}
-  </nuxt-link>
-  <a v-else :href="link.fields.longUrl || link.fields.url" target="_blank">
-    {{ link.fields.title }}
+  {{ link.fields.title }}
   </a>
 </template>
 
 <script>
-import { isInternalLink } from '@/mixins/marked/index'
+import { isInternalLink, opensInNewTab } from '@/mixins/marked/index'
 
 export default {
   name: 'FooterLink',
@@ -30,7 +26,23 @@ export default {
   },
 
   methods: {
-    isInternalLink
+    isInternalLink,
+    opensInNewTab
+  },
+
+  computed: {
+    currentUrl() {
+      return this.$nuxt.$route.fullPath
+    },
+    linkUrl() {
+      let url = this.link.fields.longUrl || this.link.fields.url
+      const title = this.link.fields.title
+      // Add users current location when reporting an issue so that we can capture url for site feedback
+      if (title == 'Site Feedback') {
+        url = url + `&source_url=${this.currentUrl}`
+      }
+      return url
+    }
   }
 }
 </script>

--- a/mixins/marked/index.js
+++ b/mixins/marked/index.js
@@ -21,7 +21,12 @@ export const isAnchor = str => {
 export const isInternalLink = str => {
   return isAnchor(str)
     ? true
-    : str.includes(process.env.ROOT_URL) || str.startsWith('/')
+    : str.includes(process.env.ROOT_URL) || str.includes("docs.sparc.science") || str.startsWith('/')
+}
+
+// docs.sparc.science is considered an internal link, but should always open in new tab
+export const opensInNewTab = link => {
+  return !isInternalLink(link) || link.includes("docs.sparc.science")
 }
 
 renderer.link = function(href, title, text) {

--- a/pages/projects/_projectId.vue
+++ b/pages/projects/_projectId.vue
@@ -43,7 +43,7 @@
                   NIH AWARD
                 </div>
                 <div class="mb-16">
-                  <a :href="nihReporterUrl" target="_blank">
+                  <a :href="nihReporterUrl" :target="!opensInNewTab(nihReporterUrl) ? '_self' : '_blank'">
                     {{ awardId }}
                     <svg-icon v-if="!isInternalLink(nihReporterUrl)" name="icon-open" height="25" width="25" />
                   </a>
@@ -92,7 +92,7 @@
 import Breadcrumb from '@/components/Breadcrumb/Breadcrumb.vue'
 import DatasetCard from '@/components/DatasetCard/DatasetCard.vue'
 import ShareLinks from '@/components/ShareLinks/ShareLinks.vue'
-import { isInternalLink } from '@/mixins/marked/index'
+import { isInternalLink, opensInNewTab } from '@/mixins/marked/index'
 import { propOr, isEmpty } from 'ramda'
 
 import createClient from '@/plugins/contentful.js'
@@ -201,6 +201,7 @@ export default {
 
   methods: {
     isInternalLink,
+    opensInNewTab
   }
 }
 </script>


### PR DESCRIPTION
# Description

We are now treating docs.sparc.science as an internal link that gets opened in a new tab as per: https://www.wrike.com/open.htm?id=1014556904

Also updated 'Site Feedback' footer link to include the current url when navigating to the contact-us page so that we can automatically capture the page that the user navigated there from

## Type of change

- [X] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

Locally

# Checklist:

- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my own code
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] I have utilized components from the Design System Library where applicable
