### PR TITLE
News/Events submission buttons

### DIFF
--- a/pages/news-and-events/index.vue
+++ b/pages/news-and-events/index.vue
@@ -115,24 +115,24 @@
               <div class="heading2 mt-24">Get Involved</div>
               <div class="body1 mb-16 mt-8">Empower SPARC to promote your science and interests by submitting your science story, news, or event.</div>
               <div class="get-involved-buttons-container">
-                <el-button class="get-involved-button secondary">
-                  <nuxt-link
-                    :to="{
-                      name: 'news-and-events-submit',
-                    }"
-                  >
+                <nuxt-link
+                  :to="{
+                    name: 'news-and-events-submit',
+                  }"
+                >
+                  <el-button class="get-involved-button secondary">
                     Share news or events
-                  </nuxt-link>
-                </el-button>
-                <el-button class="get-involved-button secondary mt-8">
-                  <nuxt-link
-                    :to="{
-                      name: 'news-and-events-community-spotlight-submit',
-                    }"
-                  >
+                  </el-button>
+                </nuxt-link>
+                <nuxt-link
+                  :to="{
+                    name: 'news-and-events-community-spotlight-submit',
+                  }"
+                >
+                  <el-button class="get-involved-button secondary mt-8">
                     Submit a community spotlight idea
-                  </nuxt-link>
-                </el-button>
+                  </el-button>
+                </nuxt-link>
               </div>
             </el-col>
             <el-col :xs="24" :sm="12" class="twitter-wrap">


### PR DESCRIPTION
# Description

Tackles [this ticket](https://www.wrike.com/open.htm?id=967369259)
Fixes news, events and spotlight submission buttons it is possible to click anywhere on the button (not only the label)


## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

Manually

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have utilized components from the Design System Library where applicable
- [ ] I have added unit tests that prove my fix is effective or that my feature works
