### PR TITLE
updated default values for news/events facet menus

### DIFF
--- a/components/FacetMenu/EventsFacetMenu.vue
+++ b/components/FacetMenu/EventsFacetMenu.vue
@@ -91,8 +91,8 @@ export default {
       selectedEventTypeOptions: [],
       eventDateOption: 'show all',
       eventTypeOption: 'show all',
-      eventMonth: 'Mar',
-      eventYear: 2020,
+      eventMonth: new Date().toLocaleString('en-US', {month: 'short'}),
+      eventYear: new Date().getFullYear(),
       visibleCategories: visibleCategories,
     }
   },

--- a/components/FacetMenu/NewsFacetMenu.vue
+++ b/components/FacetMenu/NewsFacetMenu.vue
@@ -65,8 +65,8 @@ export default {
       newsSubjects: SUBJECT_CATEGORY,
       selectedNewsSubjectIds: [],
       publicationDateOption: 'show all',
-      publicationMonth: 'Mar',
-      publicationYear: 2020,
+      publicationMonth: new Date().toLocaleString('en-US', {month: 'short'}),
+      publicationYear: new Date().getFullYear(),
       visibleCategories: visibleCategories,
     }
   },

--- a/pages/index.vue
+++ b/pages/index.vue
@@ -151,6 +151,10 @@ export default {
             'Stimulating Peripheral Activity to Relieve Conditions (SPARC)'
         },
         {
+          property: 'og:image',
+          content: 'https://drive.google.com/uc?id=1htDtD97Ys1Z7ng4otGu6denNXgUbURpV'
+        },
+        {
           name: 'og:site_name',
           content: 'SPARC Portal'
         },


### PR DESCRIPTION
# Description

Updated default values to match the current year/month as requested per: https://www.wrike.com/open.htm?id=1015155108

I also added the og:image header to the index page in case setting the header property in the nuxt config did not work

## Type of change

- [X] New feature (non-breaking change which adds functionality)

# How Has This Been Tested?

Locally

# Checklist:

- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my own code
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] I have utilized components from the Design System Library where applicable
- [ ] I have added unit tests that prove my fix is effective or that my feature works
