### PR TITLE
Fix a bug with female human map displayed as legacy when loading from state

### DIFF
--- a/package.json
+++ b/package.json
@@ -17,9 +17,9 @@
     "test:debug": "node --inspect node_modules/.bin/jest --runInBand"
   },
   "dependencies": {
-    "@abi-software/flatmapvuer": "0.3.12",
+    "@abi-software/flatmapvuer": "0.3.12-fixes-0",
     "@abi-software/gallery": "0.3.1",
-    "@abi-software/mapintegratedvuer": "0.3.11",
+    "@abi-software/mapintegratedvuer": "0.3.11-fixes-0",
     "@abi-software/plotvuer": "^0.3.0",
     "@abi-software/scaffoldvuer": "0.1.57",
     "@abi-software/simulationvuer": "0.6.5",

--- a/yarn.lock
+++ b/yarn.lock
@@ -26,10 +26,10 @@
     minisearch "^2.2.1"
     polylabel "^1.1.0"
 
-"@abi-software/flatmapvuer@0.3.12", "@abi-software/flatmapvuer@^0.3.12":
-  version "0.3.12"
-  resolved "https://registry.yarnpkg.com/@abi-software/flatmapvuer/-/flatmapvuer-0.3.12.tgz#46e7615aad52ac44cecf1a259bc9d4a37c63e70e"
-  integrity sha512-BNVouCZV2+0QgcflWu/0+aXQ9EkSpNMc/9lXgQchUvgxSHLBXWpr062wbhq9ELj2gvGWG4aC6CD+R4RbI2d+dg==
+"@abi-software/flatmapvuer@0.3.12-fixes-0", "@abi-software/flatmapvuer@^0.3.12-fixes-0":
+  version "0.3.12-fixes-0"
+  resolved "https://registry.yarnpkg.com/@abi-software/flatmapvuer/-/flatmapvuer-0.3.12-fixes-0.tgz#1e803764dc7c9954650baf185ec678655e34e77b"
+  integrity sha512-dcaWeCJM89l+psWIGY20U8p6Fk3GNXEKOrrtklTdUck8j9xUFahkvjLjQR2prmG8V7ehqdO9Lc/E+OAXOUC/UA==
   dependencies:
     "@abi-software/flatmap-viewer" "^2.2.9"
     "@abi-software/svg-sprite" "^0.1.14"
@@ -67,12 +67,12 @@
     vue "^2.6.10"
     xss "^1.0.14"
 
-"@abi-software/mapintegratedvuer@0.3.11":
-  version "0.3.11"
-  resolved "https://registry.yarnpkg.com/@abi-software/mapintegratedvuer/-/mapintegratedvuer-0.3.11.tgz#b0be61271d4ac737618175539f561a82535a371b"
-  integrity sha512-TWz2cdeYSP/qVILLdxH9YNkDh5DUyzwwgifKHk7AEIwozZJ5BLMHYUkQ9Fh56+aO9XAXzlFdBseDlUhJRG7i1Q==
+"@abi-software/mapintegratedvuer@0.3.11-fixes-0":
+  version "0.3.11-fixes-0"
+  resolved "https://registry.yarnpkg.com/@abi-software/mapintegratedvuer/-/mapintegratedvuer-0.3.11-fixes-0.tgz#bb52546558c0ba83d6b497f71e46e4ba596dd35f"
+  integrity sha512-q+pn8RKvAgHmKr/nYnHl4A/YGPnVI+aQ2isJ8zWPAfdZbdq7q087VdFPt9GVXB1O36q3kca5NoPCLyOg3T6TDg==
   dependencies:
-    "@abi-software/flatmapvuer" "^0.3.12"
+    "@abi-software/flatmapvuer" "^0.3.12-fixes-0"
     "@abi-software/map-side-bar" "^1.3.33"
     "@abi-software/plotvuer" "^0.3.9"
     "@abi-software/scaffoldvuer" "^0.1.57"


### PR DESCRIPTION
# Description
Previous release has caused the human female flatmap loaded from permalink to display as Legacy map as always. This update fixes the issue.

## Type of change

Delete those that don't apply.

- [ ] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

Human Female flatmap should load as normal (non-legacy) map with this permalink - https://mapcore-demo.org/current/sparc-app/maps/?id=b3966b57


# Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have utilized components from the Design System Library where applicable
- [ ] I have added unit tests that prove my fix is effective or that my feature works
