### PR TITLE
Pulling featured dataset id from sparc-api

### DIFF
--- a/components/FacetMenu/FacetRadioButtonDateCategory.vue
+++ b/components/FacetMenu/FacetRadioButtonDateCategory.vue
@@ -68,7 +68,8 @@ export default {
 
   computed: {
     monthNumber: function() {
-      return new Date().getMonth() + 1
+      // This Date format should be supported by all browsers. Used to convert month string to a number
+      return new Date(`2001, ${this.month}, 01`).getMonth() + 1
     }
   },
   watch: {

--- a/pages/index.vue
+++ b/pages/index.vue
@@ -69,13 +69,10 @@ export default {
     ]).then(async ([homepage]) => {
         let fields = getHomepageFields(homepage.fields)
         const datasetSectionTitle = homepage.fields.datasetSectionTitle
-        const featuredDatasetId = homepage.fields.featuredDatasetId
-        if (featuredDatasetId != '') {
-          const url = `${process.env.discover_api_host}/datasets/${featuredDatasetId}`
-          await $axios.$get(url).then(({ name, description, banner }) => {
-            fields = { ...fields, 'featuredDataset': { 'title': name, 'description': description, 'banner': banner, 'id': featuredDatasetId }, 'datasetSectionTitle': datasetSectionTitle }
-          })
-        }
+        const url = `${process.env.portal_api}/get_featured_dataset`
+        await $axios.$get(url).then(({ datasets }) => {
+          fields = { ...fields, 'featuredDataset': { 'title': datasets[0].name, 'description': datasets[0].description, 'banner': datasets[0].banner, 'id': datasets[0].id }, 'datasetSectionTitle': datasetSectionTitle }
+        })
         if (pathOr(undefined, ["featuredProject","fields","institution"], fields) != undefined) {
           const institutionId = pathOr("", ["featuredProject","fields","institution","sys","id"], fields)
           await client.getEntry(institutionId).then(( response ) => {
@@ -125,7 +122,6 @@ export default {
       newsAndEvents: [],
       portalFeatures: [],
       featuredProject: {},
-      featuredDatasetId: '',
       datasetSectionTitle: '',
       featuredDataset: {},
       heroCopy: '',

--- a/utils/homepageFields.js
+++ b/utils/homepageFields.js
@@ -12,7 +12,6 @@ export default (fields = {}) => {
     newsAndEvents: fields.newsAndEvents || [],
     portalFeatures: fields.portalFeatures || [],
     featuredProject: fields.featuredProject || {},
-    featuredDatasetId: fields.featuredDatasetId || '',
     datasetSectionTitle: fields.datasetSectionTitle || 'Here is a dataset you might be interested in: ',
     title: fields.title || ''
   }


### PR DESCRIPTION
# Description

Getting the featured dataset id from the sparc-api instead of contentful field in order to randomize the homepage dataset as per: https://www.wrike.com/open.htm?id=1024003575 and https://www.wrike.com/open.htm?id=1024003176

Also fixed bug for filtering events by date 

## Type of change

- [X] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)

# How Has This Been Tested?

Locally

# Checklist:

- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my own code
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] I have utilized components from the Design System Library where applicable
