### PR TITLE
Add alternative search when there are 0 results

### DIFF
--- a/pages/data/index.vue
+++ b/pages/data/index.vue
@@ -114,7 +114,7 @@
                   />
 
                   <!-- Alternative search suggestions -->
-                  <div v-if="searchData.total === 0">
+                  <div v-if="searchData.total === 0 && searchHasAltResults">
                     No results were found for Datasets. The following results
                     were discovered for the other categories: <br />
                     <br />
@@ -347,6 +347,7 @@ export default {
         simulation: 0,
         projects: 0
       },
+      searchHasAltResults: false,
       visibleFacets: {},
       searchTypes,
       searchData: clone(searchData),
@@ -598,8 +599,8 @@ export default {
                 this.isLoadingSearch = false
 
                 // Check the other search types if we got 0 results
-                if (searchData.total === 0){
-                  this.alternativeSearchUpdate() 
+                if (searchData.total === 0) {
+                  this.alternativeSearchUpdate()
                 }
                 // update facet result numbers
                 /*for (const [key, value] of Object.entries(this.visibleFacets)) {
@@ -626,6 +627,11 @@ export default {
     //    when a search returns 0 results
     alternativeSearchUpdate: function() {
       const searchTypeInURL = pathOr('dataset', ['query', 'type'], this.$route) // Get current data type
+
+      this.searchHasAltResults = false
+      for (let key in this.resultCounts) { // reset reults list
+        this.resultCounts[key] = 0
+      }
       let altSearchTypes = this.dataTypes.filter(e => e !== searchTypeInURL) // Remove from list of data types
 
       altSearchTypes.forEach(type => {  // Search on each data type remaining
@@ -656,6 +662,7 @@ export default {
             filters: filters
           })
           .then(response => {
+            response.nbHits > 0 ? (this.searchHasAltResults = true) : null
             this.resultCounts[searchType] = response.nbHits
           })
       } else {
@@ -674,6 +681,7 @@ export default {
             'fields.fundingProgram.fields.name[in]': funding
           })
           .then(async response => {
+            response.total > 0 ? (this.searchHasAltResults = true) : null
             this.resultCounts[searchType] = response.total
           })
       }

--- a/pages/data/index.vue
+++ b/pages/data/index.vue
@@ -115,7 +115,7 @@
 
                   <!-- Alternative search suggestions -->
                   <div v-if="searchData.total === 0 && searchHasAltResults">
-                    No results were found for Datasets. The following results
+                    No results were found for {{searchType.label}}. The following results
                     were discovered for the other categories: <br />
                     <br />
                     <template v-for="dataType in dataTypes">
@@ -132,7 +132,6 @@
                           {{ resultCounts[dataType] }} result{{
                             resultCounts[dataType] > 1 ? 's' : ''
                           }}
-                          <!-- Add an 's' for 'results' -->
                         </nuxt-link>
                         - {{ humanReadableDataTypesLookup[dataType] }}
                       </dd>

--- a/pages/data/index.vue
+++ b/pages/data/index.vue
@@ -112,6 +112,33 @@
                     :table-data="tableData"
                     :title-column-width="titleColumnWidth"
                   />
+
+                  <!-- Alternative search suggestions -->
+                  <div v-if="searchData.total === 0">
+                    No results were found for Datasets. The following results
+                    were discovered for the other categories: <br />
+                    <br />
+                    <template v-for="dataType in dataTypes">
+                      <dd v-if="resultCounts[dataType] > 0" :key="dataType">
+                        <nuxt-link
+                          :to="{
+                            name: 'data',
+                            query: {
+                              ...$route.query,
+                              type: dataType
+                            }
+                          }"
+                        >
+                          {{ resultCounts[dataType] }} result{{
+                            resultCounts[dataType] > 1 ? 's' : ''
+                          }}
+                          <!-- Add an 's' for 'results' -->
+                        </nuxt-link>
+                        - {{ humanReadableDataTypesLookup[dataType] }}
+                      </dd>
+                    </template>
+
+                  </div>
                 </div>
                 <div class="search-heading">
                   <p v-if="!isLoadingSearch && searchData.items.length">
@@ -307,6 +334,19 @@ export default {
       projectsSortOptions,
       searchQuery: '',
       facets: [],
+      dataTypes: ['dataset', 'simulation', 'model', 'projects'],
+      humanReadableDataTypesLookup: {
+        dataset: 'Datasets',
+        model: 'Anatomical Models',
+        simulation: 'Computational Models',
+        projects: 'Projects'
+      },
+      resultCounts: {
+        model: 0,
+        dataset: 0,
+        simulation: 0,
+        projects: 0
+      },
       visibleFacets: {},
       searchTypes,
       searchData: clone(searchData),
@@ -556,6 +596,11 @@ export default {
                 }
                 this.searchData = mergeLeft(searchData, this.searchData)
                 this.isLoadingSearch = false
+
+                // Check the other search types if we got 0 results
+                if (searchData.total === 0){
+                  this.alternativeSearchUpdate() 
+                }
                 // update facet result numbers
                 /*for (const [key, value] of Object.entries(this.visibleFacets)) {
                   if ( (this.$refs.datasetFacetMenu?.getLatestUpdateKey() === key && !this.$refs.datasetFacetMenu?.hasKeys()) || (this.$refs.datasetFacetMenu?.getLatestUpdateKey() !== key) ){
@@ -575,6 +620,63 @@ export default {
                 this.searchFailed = true
               })
           }) 
+    },
+
+    // alternaticeSearchUpdate: Updates this.resultCounts which is used for displaying other search options to the user
+    //    when a search returns 0 results
+    alternativeSearchUpdate: function() {
+      const searchTypeInURL = pathOr('dataset', ['query', 'type'], this.$route) // Get current data type
+      let altSearchTypes = this.dataTypes.filter(e => e !== searchTypeInURL) // Remove from list of data types
+
+      altSearchTypes.forEach(type => {  // Search on each data type remaining
+        this.searchContentsCheck(type)
+      })
+    },
+
+    //  searchContentsCheck(searchType): Takes in a search type and returns the number of datasets found with the current filters
+    searchContentsCheck: function(searchType) {
+      const query = this.$route.query.search
+
+      if (searchType !== 'projects'){
+
+        // Alogilia searches
+        const datasetsFilter =
+          searchType === 'simulation' ? '(NOT item.types.name:Dataset AND NOT item.types.name:Scaffold)' 
+            : searchType === 'model' ? '(NOT item.types.name:Dataset AND item.types.name:Scaffold)' 
+            : "item.types.name:Dataset"
+
+        var filters = this.$refs.datasetFacetMenu?.getFilters()
+        filters = filters === undefined ? 
+          `${datasetsFilter}` : 
+          filters + ` AND ${datasetsFilter}`
+
+        this.algoliaIndex
+          .search(query, {
+            facets: ['*'],
+            filters: filters
+          })
+          .then(response => {
+            this.resultCounts[searchType] = response.nbHits
+          })
+      } else {
+        // Contentful search
+        let anatomicalFocus = this.$refs.projectsFacetMenu?.getSelectedAnatomicalFocusTypes()
+        let funding = this.$refs.projectsFacetMenu?.getSelectedFundingTypes()
+        let linkedFundingProgramTargetType = funding ? 'program' : undefined
+        client
+          .getEntries({
+            content_type: 'sparcAward',
+            query: this.$route.query.search,
+            include: 2,
+            'fields.projectSection.sys.contentType.sys.id': 'awardSection',
+            'fields.projectSection.fields.title[in]': anatomicalFocus,
+            'fields.fundingProgram.sys.contentType.sys.id': linkedFundingProgramTargetType,
+            'fields.fundingProgram.fields.name[in]': funding
+          })
+          .then(async response => {
+            this.resultCounts[searchType] = response.total
+          })
+      }
     },
 
     /**


### PR DESCRIPTION
# Description

Return alternative search options to user when there are 0 search results
![image](https://user-images.githubusercontent.com/37255664/222613233-49ed5eb9-2962-4752-abcc-1846101a662f.png)

This new feature is requested in the wrike ticket:
https://www.wrike.com/open.htm?id=1014464589

This code can be checked at:
https://jesse-sprint-27.herokuapp.com/data?type=simulation&search=A%20New%20Paradigm

## Type of change

Delete those that don't apply.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

# How Has This Been Tested?

Tested locally and others can test here:
https://jesse-sprint-27.herokuapp.com/data?type=simulation&search=A%20New%20Paradigm


# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have utilized components from the Design System Library where applicable
- [ ] I have added unit tests that prove my fix is effective or that my feature works
