### PR TITLE
QA fix: Make sure body proper is ignored when opening the flatmap.

### DIFF
--- a/pages/maps/index.vue
+++ b/pages/maps/index.vue
@@ -41,8 +41,17 @@ import { successMessage, failMessage } from '@/utils/notification-messages'
 const getFlatmapEntry = async ( route ) => {
   const uberonid = route.query.uberonid
   let organ_name = undefined
+  //Specify the gender of human
+  let biologicalSex = route.query.biologicalSex
+  if (route.query.taxo && route.query.taxo === "NCBITaxon:9606") {
+    if (!biologicalSex)
+      biologicalSex = "PATO:0000384"
+  }
   try {
     organ_name = await scicrunch.getOrganFromUberonId(uberonid)
+    //We do not want to display the body proper
+    if (organ_name && organ_name.toLowerCase() === "body proper")
+      organ_name = undefined
   } catch (e) {
     // Error caught return empty data.
   }
@@ -50,7 +59,7 @@ const getFlatmapEntry = async ( route ) => {
   return {
       type: "MultiFlatmap",
       taxo: route.query.taxo,
-      biologicalSex: route.query.biologicalSex,
+      biologicalSex: biologicalSex,
       uuid: route.query.fid,
       organ: organ_name
   }

--- a/pages/maps/index.vue
+++ b/pages/maps/index.vue
@@ -44,14 +44,16 @@ const getFlatmapEntry = async ( route ) => {
   //Specify the gender of human
   let biologicalSex = route.query.biologicalSex
   if (route.query.taxo && route.query.taxo === "NCBITaxon:9606") {
-    if (!biologicalSex)
+    if (!biologicalSex) {
       biologicalSex = "PATO:0000384"
+    }
   }
   try {
     organ_name = await scicrunch.getOrganFromUberonId(uberonid)
     //We do not want to display the body proper
-    if (organ_name && organ_name.toLowerCase() === "body proper")
+    if (organ_name && organ_name.toLowerCase() === "body proper") {
       organ_name = undefined
+    }
   } catch (e) {
     // Error caught return empty data.
   }


### PR DESCRIPTION
# Description

This pull request addressed the feedback from the wrike ticket here - https://www.wrike.com/open.htm?id=970444593
It makes sure body proper is not highlighted when going from the gallery to the map viewer.

## Type of change

Delete those that don't apply.

- [ ] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

Test locally. Going from the [gallery](https://mapcore-demo.org/current/sparc-app/datasets/134?type=dataset&datasetDetailsTab=images) to the map viewer should ignore the body proper highlight.

# Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have utilized components from the Design System Library where applicable
- [ ] I have added unit tests that prove my fix is effective or that my feature works
