### PR TITLE
Set BiolucidaViewer 'View in 3D' button to open a Neurolucida 360 Cloud instance

### DIFF
--- a/components/BiolucidaViewer/BiolucidaViewer.vue
+++ b/components/BiolucidaViewer/BiolucidaViewer.vue
@@ -30,6 +30,7 @@
 import { successMessage, failMessage } from '@/utils/notification-messages'
 
 import BfButton from '@/components/shared/BfButton/BfButton.vue'
+import biolucida from '~/services/biolucida'
 
 export default {
   name: 'BiolucidaViewer',
@@ -47,7 +48,8 @@ export default {
           blv_link: '',
           share_link: '',
           status: '',
-          location: ''
+          location: '',
+          web_neurolucida_link: ''
         }
       }
     }
@@ -60,7 +62,30 @@ export default {
   },
   methods: {
     launchViewer() {
-      window.open(this.data.blv_link, '_blank')
+      biolucida
+        .fetchNeurolucida360Url({
+          applicationRequest: 'NL360',
+          userID: 'SPARCPortal',
+          sessionContext: this.data.web_neurolucida_link
+        })
+        .then(response => {
+          if (response.data.url) {
+            window.open(response.data.url, '_blank')
+          } else {
+            this.$message(
+              failMessage(
+                'Unable to open image with Neurlucida 360 Cloud at this time.'
+              )
+            )
+          }
+        })
+        .catch(() => {
+          this.$message(
+            failMessage(
+              'Unable to open image with Neurlucida 360 Cloud at this time.'
+            )
+          )
+        })
     },
     queryView() {
       this.$refs.biolucida.contentWindow.postMessage(

--- a/nuxt.config.js
+++ b/nuxt.config.js
@@ -116,6 +116,7 @@ export default {
     BL_API_URL: 'https://sparc.biolucida.net/api/v1/',
     BL_SERVER_URL: 'https://sparc.biolucida.net',
     BL_SHARE_LINK_PREFIX: 'https://sparc.biolucida.net/image?c=',
+    MBF_SPARC_API: process.env.MBF_SPARC_API || 'https://mbfsparcapi.com',
     NL_LINK_PREFIX: 'https://sparc.biolucida.net:8081',
     ROOT_URL: process.env.ROOT_URL || 'http://localhost:3000',
     max_download_size: parseInt(process.env.MAX_DOWNLOAD_SIZE || '5000000000'),

--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
     "test:debug": "node --inspect node_modules/.bin/jest --runInBand"
   },
   "dependencies": {
-    "@abi-software/gallery": "0.3.1",
+    "@abi-software/gallery": "^0.3.1",
     "@abi-software/mapintegratedvuer": "0.3.13-fixes-1",
     "@abi-software/plotvuer": "^0.3.0",
     "@abi-software/simulationvuer": "0.6.5",

--- a/services/biolucida.js
+++ b/services/biolucida.js
@@ -6,6 +6,12 @@ const apiClient = axios.create({
   timeout: 25007
 })
 
+const mbfSparcApiClient = axios.create({
+  baseURL: process.env.MBF_SPARC_API,
+  withCredentials: false,
+  timeout: 9988
+})
+
 const searchDataset = async id => {
   const response = await apiClient.get('image_search/' + id)
   return response.data
@@ -46,7 +52,19 @@ const getBLVLink = async id => {
   return response.data
 }
 
+const decodeViewParameter = encodedView => {
+  const urlDecodedView = decodeURIComponent(encodedView)
+  const decodedView = Buffer.from(urlDecodedView, 'base64').toString('binary')
+  return decodedView.split('-')
+}
+
+const fetchNeurolucida360Url = payload => {
+  return mbfSparcApiClient.post('', payload)
+}
+
 export default {
+  decodeViewParameter,
+  fetchNeurolucida360Url,
   getBLVLink,
   getThumbnail,
   getNeurolucidaThumbnail,

--- a/yarn.lock
+++ b/yarn.lock
@@ -41,7 +41,7 @@
     lodash "^4.17.21"
     vue "^2.6.10"
 
-"@abi-software/gallery@0.3.1", "@abi-software/gallery@^0.3.1":
+"@abi-software/gallery@^0.3.1":
   version "0.3.1"
   resolved "https://registry.yarnpkg.com/@abi-software/gallery/-/gallery-0.3.1.tgz#cb8317e4271e95254c6e3242be824fd3ec4b9ad4"
   integrity sha512-ED5ppMiXfHbobM073SnDiUhomviLH+dSQ6jgk6b9ULBkdTmF6r0cE6WbPHYJHdNgZVJDbYokBieO/URrff8QhQ==
@@ -4741,9 +4741,9 @@ caniuse-api@^3.0.0:
     lodash.uniq "^4.5.0"
 
 caniuse-lite@^1.0.0, caniuse-lite@^1.0.30000981, caniuse-lite@^1.0.30001109, caniuse-lite@^1.0.30001191, caniuse-lite@^1.0.30001251:
-  version "1.0.30001320"
-  resolved "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001320.tgz"
-  integrity sha512-MWPzG54AGdo3nWx7zHZTefseM5Y1ccM7hlQKHRqJkPozUaw3hNbBTMmLn16GG2FUzjR13Cr3NPfhIieX5PzXDA==
+  version "1.0.30001462"
+  resolved "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001462.tgz"
+  integrity sha512-PDd20WuOBPiasZ7KbFnmQRyuLE7cFXW2PVd7dmALzbkUXEP46upAuCDm9eY9vho8fgNMGmbAX92QBZHzcnWIqw==
 
 canvas-fit@^1.5.0:
   version "1.5.0"


### PR DESCRIPTION
# Description

Changed the BiolucidaViewer 'View in 3D' button to open an image in the MBF Neurolucida 360 cloud application instead of the current web-based Biolucidaviewer.


## Type of change

Delete those that don't apply.

- [x] New feature (non-breaking change which adds functionality)

# How Has This Been Tested?

Tested by going to Biolucida images like:

datasets/biolucidaviewer/1649?view=MTY0OS1jb2wtMTI3&dataset_version=3&dataset_id=77&item_id=N%3Apackage%3Aaa916348-d306-4bc2-8370-94048adb1bf0

and clicking on the 'View in 3d' button.  This opens the MBF Neurolucida 360 cloud application in a separate tab with the 3D image from the SPARC portal visible.

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have utilized components from the Design System Library where applicable
- [ ] I have added unit tests that prove my fix is effective or that my feature works
