### PR TITLE
Separate buttons for Biolucida image viewer

### DIFF
--- a/components/BiolucidaViewer/BiolucidaViewer.vue
+++ b/components/BiolucidaViewer/BiolucidaViewer.vue
@@ -2,9 +2,28 @@
   <div class="biolucida-viewer">
     <template v-if="data.status !== 'error'">
       <el-row class="mb-2 justify-space-between" type="flex">
-        <bf-button class="ml-8 btn-copy-permalink-solid" @click="launchViewer">
-          View in 3D
-        </bf-button>
+        <div>
+          <bf-button
+            class="ml-8 btn-copy-permalink-solid"
+            @click="launchViewer"
+          >
+            <sparc-tooltip
+              placement="bottom-center"
+              content="Open in Biolucida desktop application"
+            />
+            View in 3D
+          </bf-button>
+          <bf-button
+            class="ml-8 btn-copy-permalink-solid"
+            @click="launchNL360C"
+          >
+            <sparc-tooltip
+              placement="bottom-center"
+              content="Open in Neurlicda 360 Cloud"
+            />
+            View in NL360C
+          </bf-button>
+        </div>
         <client-only>
           <button class="btn-copy-permalink" @click="queryView">
             <sparc-tooltip placement="bottom-center" content="Copy Link">
@@ -62,6 +81,9 @@ export default {
   },
   methods: {
     launchViewer() {
+      window.open(this.data.blv_link, '_blank')
+    },
+    launchNL360C() {
       biolucida
         .fetchNeurolucida360Url({
           applicationRequest: 'NL360',

--- a/components/BiolucidaViewer/BiolucidaViewer.vue
+++ b/components/BiolucidaViewer/BiolucidaViewer.vue
@@ -3,25 +3,25 @@
     <template v-if="data.status !== 'error'">
       <el-row class="mb-2 justify-space-between" type="flex">
         <div>
-          <bf-button
-            class="ml-8 btn-copy-permalink-solid"
-            @click="launchViewer"
-          >
+          <bf-button class="ml-8" @click="launchViewer">
             <sparc-tooltip
               placement="bottom-center"
               content="Open in Biolucida desktop application"
-            />
-            View in 3D
+            >
+              <div slot="item">
+                View in 3D
+              </div>
+            </sparc-tooltip>
           </bf-button>
-          <bf-button
-            class="ml-8 btn-copy-permalink-solid"
-            @click="launchNL360C"
-          >
+          <bf-button class="ml-8" @click="launchNL360C">
             <sparc-tooltip
-              placement="bottom-center"
-              content="Open in Neurlicda 360 Cloud"
-            />
-            View in NL360C
+              placement="top-center"
+              content="Open in Neurolicda 360 Cloud"
+            >
+              <div slot="item">
+                View in NL360C
+              </div>
+            </sparc-tooltip>
           </bf-button>
         </div>
         <client-only>


### PR DESCRIPTION
# Description

Adding a new button to launch Neurolucida 360 cloud and keep the 'View in 3D' button launching the local Biolucida desktop application.


## Type of change

Delete those that don't apply.

- [x] New feature (non-breaking change which adds functionality)

# How Has This Been Tested?

Tested by going to Biolucida images like:

datasets/biolucidaviewer/1649?view=MTY0OS1jb2wtMTI3&dataset_version=3&dataset_id=77&item_id=N%3Apackage%3Aaa916348-d306-4bc2-8370-94048adb1bf0

and clicking on the 'View in 3d' button and clicking on the 'View in NL360C' button. This opens the Biolucida desktop application (if present on the system) and MBF Neurolucida 360 cloud application in a separate tab respectively, with the 3D image from the SPARC portal visible.

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have utilized components from the Design System Library where applicable
- [ ] I have added unit tests that prove my fix is effective or that my feature works
