### PR TITLE
Community Spotlights - Wording + Bug

### DIFF
--- a/components/CommunitySpotlight/CommunitySpotlightItem.vue
+++ b/components/CommunitySpotlight/CommunitySpotlightItem.vue
@@ -60,7 +60,7 @@
         </tr>
         <tr>
           <td class="property-name-column">
-            Anatomical Structure(s)
+            Focus
           </td>
           <td>
             {{ anatomicalStructureText }}

--- a/components/CommunitySpotlight/CommunitySpotlightListings.vue
+++ b/components/CommunitySpotlight/CommunitySpotlightListings.vue
@@ -63,7 +63,7 @@ export default {
     // The community spotlight item component needs to use the properties off the actual success stories/fireside chats
     getLinkedItem(communitySpotlightItem) {
       const linkedItem = pathOr('', ['fields','linkedItem'], communitySpotlightItem)
-      const anatomicalStructure = pathOr('', ['fields','anatomicalStructure'], communitySpotlightItem)
+      const anatomicalStructures = pathOr('', ['fields','anatomicalStructure'], communitySpotlightItem)
       const spotlightTypeId = pathOr('', ['fields','itemType'], communitySpotlightItem)
       const spotlightType = SPOTLIGHT_TYPE_MAPPING.find(item => {
         return item.id == spotlightTypeId
@@ -71,7 +71,7 @@ export default {
       return {
         ...linkedItem,
         spotlightType,
-        anatomicalStructure
+        anatomicalStructures
       }
     }
   }

--- a/components/DatasetDetails/DatasetDescriptionInfo.vue
+++ b/components/DatasetDetails/DatasetDescriptionInfo.vue
@@ -226,7 +226,7 @@ export default {
 
   methods: {
     getFacetText(facetLabel) {
-       let text = ''
+      let text = ''
       const facet = this.datasetFacetsData.find(item => item.label === facetLabel)
       if (facet === undefined || !facet.children)
       {

--- a/pages/news-and-events/community-spotlight/index.vue
+++ b/pages/news-and-events/community-spotlight/index.vue
@@ -211,7 +211,7 @@ export default Vue.extend<CommunitySpotlightData, CommunitySpotlightMethods, Com
         })
       })
       return {
-        label: 'Anatomical Structure',
+        label: 'Focus',
         id: 'spotlightAnatomicalStructure',
         data: data
       }


### PR DESCRIPTION
# Description

https://www.wrike.com/open.htm?id=1043784426

Changes wording of "Anatomical structure(s)" to "Focus" in News & Events page and solves bug with "n/a" display of data in News & Events page


## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)

# How Has This Been Tested?

Manually


# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have utilized components from the Design System Library where applicable
- [ ] I have added unit tests that prove my fix is effective or that my feature works
