### PR TITLE
Update dataset page to link to scaffold search correctly. 

### DIFF
--- a/components/DatasetDetails/SimilarDatasetsInfoBox.vue
+++ b/components/DatasetDetails/SimilarDatasetsInfoBox.vue
@@ -73,6 +73,16 @@ const algoliaClient = createAlgoliaClient()
 const algoliaIndex = algoliaClient.initIndex(process.env.ALGOLIA_INDEX)
 const EXPERIMENTAL_APPROACH_LABEL = facetPropPathMapping['item.modalities.keyword']
 
+const getPageTypeName = typeFacet => {
+  let typeName = 'dataset'
+  if (typeFacet === 'scaffold') {
+    typeName = 'model'
+  } else if (typeFacet === 'computational model') {
+    typeName = 'simulation'
+  }
+  return typeName
+}
+
 export default {
   name: 'SimilarDatasetsInfoBox',
 
@@ -138,15 +148,13 @@ export default {
       return correspondingFacet.id
     },
     getSelectedFacetLink(facetId) {
-      return this.datasetTypeName === 'dataset' ?
-        `/data?type=dataset&selectedFacetIds=${facetId}` :
-        `/data?type=simulation&selectedFacetIds=${facetId}`
+      const pageName = getPageTypeName(this.datasetTypeName)
+      return `/data?type=${pageName}&selectedFacetIds=${facetId}`
     },
     getSelectedContributorLink(contributor) {
       const name = this.getContributorFullName(contributor)
-      return this.datasetTypeName === 'dataset' ?
-        `/data?type=dataset&q=${name}` :
-        `/data?type=simulation&q=${name}`
+      const pageName = getPageTypeName(this.datasetTypeName)
+      return `/data?type=${pageName}&search=${name}`
     },
     showFacet(facet) {
       if (facet.label === EXPERIMENTAL_APPROACH_LABEL && !this.showExperimentalApproachFacet) {


### PR DESCRIPTION
# Description

Update dataset page to link to scaffold search and fix authors link on dataset page.
The wrike tickets can be found here: 
https://www.wrike.com/open.htm?id=1037491649
https://www.wrike.com/open.htm?id=1044425213

## Type of change

Delete those that don't apply.

- [ ] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

This has been tested locally and can be check on the following pages

Clicking on the Scaffold pill on the left https://alan-wu-sparc-app.herokuapp.com/datasets/174?type=dataset should bring user to the Anatomical search page.

Clicking on the author name on the left panel should perform the search correctly https://alan-wu-sparc-app.herokuapp.com/datasets/295?type=dataset&datasetDetailsTab=about

# Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have utilized components from the Design System Library where applicable
- [ ] I have added unit tests that prove my fix is effective or that my feature works
