### PR TITLE
Fix segmentation thumbnails

### DIFF
--- a/components/ImagesGallery/ImagesGallery.vue
+++ b/components/ImagesGallery/ImagesGallery.vue
@@ -266,7 +266,7 @@ export default {
         if ('mbf-segmentation' in scicrunchData) {
           items.push(
             ...Array.from(scicrunchData['mbf-segmentation'], segmentation => {
-              const id = segmentation.id
+              const id = segmentation.identifier
               let file_path = segmentation.dataset.path
               // patch for discrepancy between file paths containing spaces and/or commas and the s3 path. s3 paths appear to use underscores instead
               file_path = file_path.replaceAll(' ', '_')


### PR DESCRIPTION
# Description

Thumbnails for segmentation files are not getting set correctly in the gallery.


## Type of change

Delete those that don't apply.

- [X] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

Tested manually going to https://staging.sparc.science/datasets/230?type=dataset&datasetDetailsTab=images
at the end all the segmentation thumbnails should be images, not the default SPARC logo.


# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have utilized components from the Design System Library where applicable
- [ ] I have added unit tests that prove my fix is effective or that my feature works
