### PR TITLE
Fix missing app in asynData.

### DIFF
--- a/pages/datasets/segmentationviewer/_id.vue
+++ b/pages/datasets/segmentationviewer/_id.vue
@@ -126,9 +126,9 @@ export default {
     BfButton
   },
 
-  mixins: [FileDetails, MarkedMixin, RequestDownloadFile, FetchPennsieveFile],
+  mixins: [DatasetInfo, FileDetails, MarkedMixin, RequestDownloadFile, FetchPennsieveFile],
 
-  async asyncData({ route, error, $axios }) {
+  async asyncData({ app, route, error, $axios }) {
     const identifier = route.query.dataset_id
 
     try {

--- a/pages/datasets/videoviewer/_id.vue
+++ b/pages/datasets/videoviewer/_id.vue
@@ -96,7 +96,7 @@ export default {
 
   mixins: [DatasetInfo, FileDetails, RequestDownloadFile, FetchPennsieveFile],
 
-  async asyncData({ route, error, $axios }) {
+  async asyncData({ app, route, error, $axios }) {
 
     const datasetInfo = await DatasetInfo.methods.getDatasetInfo(
       $axios,

--- a/pages/file/_datasetId/_datasetVersion/index.vue
+++ b/pages/file/_datasetId/_datasetVersion/index.vue
@@ -130,7 +130,7 @@ export default {
     FileDetails
   ],
 
-  async asyncData({ redirect, route, error, $axios, app }) {
+  async asyncData({ app, redirect, route, error, $axios }) {
     const filePath = route.query.path
     const file = await FetchPennsieveFile.methods.fetchPennsieveFile(
       $axios,


### PR DESCRIPTION
# Description

Fix issue from previous s3 bucket fix pull request where app is not defined in asyncData methods but is required for getDatasetInfo methods.

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)


# How Has This Been Tested?

The following link should work once deployed - https://alan-wu-sparc-app.herokuapp.com/datasets/segmentationviewer?dataset_id=230&dataset_version=1&file_path=files%2Fprimary%2Fsub-dorsal-4%2Fsam-CGRP-Mouse-Dorsal-4%2F3D_scaffold_-_CGRP-Mice-Dorsal-4.xml


# Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have utilized components from the Design System Library where applicable
- [ ] I have added unit tests that prove my fix is effective or that my feature works
