### PR TITLE
Alternative search results for `/resources` and `/news-and-events`

### DIFF
--- a/components/AlternativeSearchResults/AlternativeSearchResults.vue
+++ b/components/AlternativeSearchResults/AlternativeSearchResults.vue
@@ -1,0 +1,47 @@
+<template>
+  <!-- Alternative search suggestions NNOTE that this is currently just copy and pasted from /data/index.vue -->
+  <div v-if="searchHasAltResults">
+    <template v-if="searchData.total === 0">
+      No results were found for {{ searchType.label }}.
+    </template>
+    The following results were discovered for the other categories:
+    <br />
+    <br />
+    <template v-for="dataType in dataTypes">
+      <dd v-if="resultCounts[dataType] > 0" :key="dataType">
+        <nuxt-link
+          :to="{
+            name: 'data',
+            query: {
+              ...$route.query,
+              type: dataType
+            }
+          }"
+        >
+          {{ resultCounts[dataType] }} result{{
+            resultCounts[dataType] > 1 ? 's' : ''
+          }}
+        </nuxt-link>
+        - {{ humanReadableDataTypesLookup[dataType] }}
+      </dd>
+    </template>
+  </div>
+</template>
+
+<script>
+export default {
+  name: 'AlternativeSearchResults',
+  props: {
+    searchData: {
+      type: Object,
+      default: () => {}
+    },
+    searchType: {
+      type: Object,
+      default: () => {}
+    }
+  }
+}
+</script>
+
+<style></style>

--- a/components/AlternativeSearchResults/AlternativeSearchResults.vue
+++ b/components/AlternativeSearchResults/AlternativeSearchResults.vue
@@ -1,8 +1,9 @@
 <template>
   <!-- Alternative search suggestions NNOTE that this is currently just copy and pasted from /data/index.vue -->
   <div v-if="searchHasAltResults">
-    <template v-if="searchData.total === 0">
-      No results were found for {{ searchType.label }}.
+    <br />
+    <template v-if="!searchHadResults">
+      No results were found for <strong><i>{{ this.$route.query.search }}</i></strong>.
     </template>
     The following results were discovered for the other categories:
     <br />
@@ -11,10 +12,9 @@
       <dd v-if="resultCounts[dataType] > 0" :key="dataType">
         <nuxt-link
           :to="{
-            name: 'data',
+            name: `resources-${dataType}`,
             query: {
-              ...$route.query,
-              type: dataType
+              ...$route.query
             }
           }"
         >
@@ -29,16 +29,87 @@
 </template>
 
 <script>
+import { fetchResources } from '@/pages/resources/utils.ts'
+
+function getLastUrlSegment(path) {
+  return path
+    .split('/')
+    .filter(Boolean)
+    .pop()
+}
+
 export default {
   name: 'AlternativeSearchResults',
   props: {
-    searchData: {
-      type: Object,
-      default: () => {}
+    searchHadResults: {
+      type: Boolean,
+      default: true
+    }
+  },
+  data: function() {
+    return {
+      searchHasAltResults: false,
+      dataTypes: [
+        'biological',
+        'databases',
+        'devices',
+        'information-services',
+        'software'
+      ],
+      humanReadableDataTypesLookup: {
+        biological: 'Biologicals',
+        databases: 'Data and Models',
+        devices: 'Devices',
+        'information-services': 'Information Services',
+        software: 'Software'
+      },
+      resultCounts: {
+        biological: 0,
+        databases: 0,
+        devices: 0,
+        'information-services': 0,
+        software: 0
+      }
+    }
+  },
+  computed: {
+    dataTypeSeleced: function() {
+      return getLastUrlSegment(this.$route.path)
+    }
+  },
+  methods: {
+    retrieveAltTotals: function() {
+      this.searchHasAltResults = false
+      for (let key in this.resultCounts) {
+        // reset reults list
+        this.resultCounts[key] = 0
+      }
+      let altSearchTypes = this.dataTypes.filter(
+        e => e !== this.dataTypeSeleced
+      ) // Remove from list of data types
+
+      altSearchTypes.forEach(type => {
+        // Search on each data type remaining
+        this.retrieveAltTotal(type)
+      })
     },
-    searchType: {
-      type: Object,
-      default: () => {}
+    retrieveAltTotal: function(category) {
+      fetchResources(
+        this.humanReadableDataTypesLookup[category], // needed as human readable is used for contentful
+        this.$route.query.search,
+        undefined,
+        undefined,
+        10,
+        0
+      )
+        .then(resp => {
+          this.resultCounts[category] = resp.total
+          resp.total > 0 ? (this.searchHasAltResults = true) : null
+        })
+        .catch(err => {
+          console.log('Error in alternative Search results call:', err)
+          this.resultCounts[category] = 0
+        })
     }
   }
 }

--- a/components/AlternativeSearchResults/AlternativeSearchResultsNews.vue
+++ b/components/AlternativeSearchResults/AlternativeSearchResultsNews.vue
@@ -1,0 +1,123 @@
+<template>
+  <!-- Alternative search suggestions NNOTE that this is currently just copy and pasted from /data/index.vue -->
+  <div v-if="searchHasAltResults">
+    <br />
+    <template v-if="!searchHadResults">
+      No results were found for <strong><i>{{ this.$route.query.search }}</i></strong>.
+    </template>
+    The following results were discovered for the other categories:
+    <br />
+    <br />
+    <template v-for="dataType in dataTypes">
+      <dd v-if="resultCounts[dataType] > 0" :key="dataType">
+        <nuxt-link
+          :to="{
+            name: `resources-${dataType}`,
+            query: {
+              ...$route.query
+            }
+          }"
+        >
+          {{ resultCounts[dataType] }} result{{
+            resultCounts[dataType] > 1 ? 's' : ''
+          }}
+        </nuxt-link>
+        - {{ humanReadableDataTypesLookup[dataType] }}
+      </dd>
+    </template>
+  </div>
+</template>
+
+<script>
+import { fetchNews, fetchEvents, fetchCommunitySpotlightItems} from '@/pages/news-and-events/model.ts'
+
+function getLastUrlSegment(path) {
+  return path
+    .split('/')
+    .filter(Boolean)
+    .pop()
+}
+
+export default {
+  name: 'AlternativeSearchResultsNews',
+  props: {
+    searchHadResults: {
+      type: Boolean,
+      default: true
+    }
+  },
+  data: function() {
+    return {
+      searchHasAltResults: false,
+      dataTypes: [
+        'biological',
+        'databases',
+        'devices',
+        'information-services',
+        'software'
+      ],
+      humanReadableDataTypesLookup: {
+        biological: 'Biologicals',
+        databases: 'Data and Models',
+        devices: 'Devices',
+        'information-services': 'Information Services',
+        software: 'Software'
+      },
+      functionLookup: {
+        news: fetchNews,
+        events: fetchEvents,
+        communitySpotlight: fetchCommunitySpotlightItems
+      },
+      resultCounts: {
+        biological: 0,
+        databases: 0,
+        devices: 0,
+        'information-services': 0,
+        software: 0
+      }
+    }
+  },
+  computed: {
+    dataTypeSeleced: function() {
+      return getLastUrlSegment(this.$route.path)
+    }
+  },
+  methods: {
+    retrieveAltTotals: function() {
+      this.searchHasAltResults = false
+      for (let key in this.resultCounts) {
+        // reset reults list
+        this.resultCounts[key] = 0
+      }
+      let altSearchTypes = this.dataTypes.filter(
+        e => e !== this.dataTypeSeleced
+      ) // Remove from list of data types
+
+      altSearchTypes.forEach(type => {
+        // Search on each data type remaining
+        this.retrieveAltTotal(type)
+      })
+    },
+    retrieveAltTotal: function(category) {
+      this[this.functionLookup[category]](
+        this.humanReadableDataTypesLookup[category], // needed as human readable is used for contentful
+        this.$route.query.search,
+        undefined,
+        undefined,
+        10,
+        0
+      )
+        .then(resp => {
+          this.resultCounts[category] = resp.total
+          resp.total > 0 ? (this.searchHasAltResults = true) : null
+        })
+        .catch(err => {
+          console.log('Error in alternative Search results call:', err)
+          this.resultCounts[category] = 0
+        })
+    }
+  }
+}
+</script>
+
+<style></style>

--- a/components/AlternativeSearchResults/AlternativeSearchResultsNews.vue
+++ b/components/AlternativeSearchResults/AlternativeSearchResultsNews.vue
@@ -1,6 +1,6 @@
 <template>
   <!-- Alternative search suggestions NNOTE that this is currently just copy and pasted from /data/index.vue -->
-  <div v-if="searchHasAltResults">
+  <div v-if="searchHasAltResults && this.$route.query.search">
     <br />
     <template v-if="!searchHadResults">
       No results were found for <strong><i>{{ this.$route.query.search }}</i></strong>.

--- a/components/AlternativeSearchResults/AlternativeSearchResultsNews.vue
+++ b/components/AlternativeSearchResults/AlternativeSearchResultsNews.vue
@@ -29,7 +29,15 @@
 </template>
 
 <script>
-import { fetchNews, fetchEvents, fetchCommunitySpotlightItems} from '@/pages/news-and-events/model.ts'
+import {
+  fetchNews,
+  fetchEvents,
+  fetchCommunitySpotlightItems
+} from '@/pages/news-and-events/model.ts'
+
+import createClient from '@/plugins/contentful.js'
+
+const client = createClient()
 
 function getLastUrlSegment(path) {
   return path
@@ -49,32 +57,25 @@ export default {
   data: function() {
     return {
       searchHasAltResults: false,
-      dataTypes: [
-        'biological',
-        'databases',
-        'devices',
-        'information-services',
-        'software'
-      ],
+      dataTypes: ['news', 'events', 'community-spotlight'],
       humanReadableDataTypesLookup: {
-        biological: 'Biologicals',
-        databases: 'Data and Models',
-        devices: 'Devices',
-        'information-services': 'Information Services',
-        software: 'Software'
+        news: 'News',
+        events: 'Events',
+        'community-spotlight': 'Community Spotlight'
       },
       functionLookup: {
         news: fetchNews,
         events: fetchEvents,
-        communitySpotlight: fetchCommunitySpotlightItems
+        'community-spotlight': fetchCommunitySpotlightItems
       },
       resultCounts: {
-        biological: 0,
-        databases: 0,
-        devices: 0,
-        'information-services': 0,
-        software: 0
-      }
+        news: 0,
+        events: 0,
+        'community-spotlight': 0
+      },
+      fetchNews: fetchNews,
+      fetchEvents: fetchEvents,
+      fetchCommunitySpotlightItems: fetchCommunitySpotlightItems
     }
   },
   computed: {
@@ -99,8 +100,8 @@ export default {
       })
     },
     retrieveAltTotal: function(category) {
-      this[this.functionLookup[category]](
-        this.humanReadableDataTypesLookup[category], // needed as human readable is used for contentful
+      this[this.functionLookup[category]]( // dynamically call the function
+        client,
         this.$route.query.search,
         undefined,
         undefined,
@@ -108,6 +109,7 @@ export default {
         0
       )
         .then(resp => {
+          console.log('Alternative Search results call:', resp)
           this.resultCounts[category] = resp.total
           resp.total > 0 ? (this.searchHasAltResults = true) : null
         })

--- a/components/AlternativeSearchResults/AlternativeSearchResultsNews.vue
+++ b/components/AlternativeSearchResults/AlternativeSearchResultsNews.vue
@@ -12,7 +12,7 @@
       <dd v-if="resultCounts[dataType] > 0" :key="dataType">
         <nuxt-link
           :to="{
-            name: `resources-${dataType}`,
+            name: `news-and-events-${dataType}`,
             query: {
               ...$route.query
             }
@@ -100,13 +100,12 @@ export default {
       })
     },
     retrieveAltTotal: function(category) {
-      this[this.functionLookup[category]]( // dynamically call the function
+      this.functionLookup[category]( // dynamically call the function
         client,
         this.$route.query.search,
         undefined,
         undefined,
-        10,
-        0
+        undefined
       )
         .then(resp => {
           console.log('Alternative Search results call:', resp)

--- a/components/AlternativeSearchResults/AlternativeSearchResultsResources.vue
+++ b/components/AlternativeSearchResults/AlternativeSearchResultsResources.vue
@@ -1,6 +1,6 @@
 <template>
   <!-- Alternative search suggestions NNOTE that this is currently just copy and pasted from /data/index.vue -->
-  <div v-if="searchHasAltResults">
+  <div v-if="searchHasAltResults && this.$route.query.search">
     <br />
     <template v-if="!searchHadResults">
       No results were found for <strong><i>{{ this.$route.query.search }}</i></strong>.

--- a/pages/data/index.vue
+++ b/pages/data/index.vue
@@ -114,9 +114,12 @@
                   />
 
                   <!-- Alternative search suggestions -->
-                  <div v-if="searchData.total === 0 && searchHasAltResults">
-                    No results were found for {{searchType.label}}. The following results
-                    were discovered for the other categories: <br />
+                  <div v-if="searchHasAltResults">
+                    <template v-if="searchData.total === 0">
+                      No results were found for {{ searchType.label }}.
+                    </template>
+                    The following results were discovered for the other categories:
+                    <br />
                     <br />
                     <template v-for="dataType in dataTypes">
                       <dd v-if="resultCounts[dataType] > 0" :key="dataType">
@@ -136,7 +139,6 @@
                         - {{ humanReadableDataTypesLookup[dataType] }}
                       </dd>
                     </template>
-
                   </div>
                 </div>
                 <div class="search-heading">
@@ -597,10 +599,9 @@ export default {
                 this.searchData = mergeLeft(searchData, this.searchData)
                 this.isLoadingSearch = false
 
-                // Check the other search types if we got 0 results
-                if (searchData.total === 0) {
-                  this.alternativeSearchUpdate()
-                }
+                // Update alternative search results
+                this.alternativeSearchUpdate()
+
                 // update facet result numbers
                 /*for (const [key, value] of Object.entries(this.visibleFacets)) {
                   if ( (this.$refs.datasetFacetMenu?.getLatestUpdateKey() === key && !this.$refs.datasetFacetMenu?.hasKeys()) || (this.$refs.datasetFacetMenu?.getLatestUpdateKey() !== key) ){
@@ -726,6 +727,8 @@ export default {
           })
           .then(async response => {
             this.searchData = { ...response }
+            // Update alternative search results
+            this.alternativeSearchUpdate()
           })
           .catch(() => {
             this.searchData = clone(searchData)

--- a/pages/data/index.vue
+++ b/pages/data/index.vue
@@ -116,7 +116,7 @@
                   <!-- Alternative search suggestions -->
                   <div v-if="searchHasAltResults">
                     <template v-if="searchData.total === 0">
-                      No results were found for {{ searchType.label }}.
+                      No results were found for <strong>{{ searchType.label }}</strong>.
                     </template>
                     The following results were discovered for the other categories:
                     <br />

--- a/pages/news-and-events/community-spotlight/index.vue
+++ b/pages/news-and-events/community-spotlight/index.vue
@@ -89,6 +89,10 @@
                       <hr />
                     </div>
                   </template>
+                  <alternative-search-results-news
+                    ref="altSearchResults"
+                    :search-had-results="communitySpotlightItems.items.length > 0"
+                  />
                 </div>
                 <div class="search-heading">
                   <div class="label1" v-if="communitySpotlightItems.items.length">
@@ -129,6 +133,7 @@ import Breadcrumb from '@/components/Breadcrumb/Breadcrumb.vue'
 import SearchControlsContentful from '@/components/SearchControlsContentful/SearchControlsContentful.vue'
 import SortMenu from '@/components/SortMenu/SortMenu.vue'
 import SubmitCommunitySection from '~/components/NewsEventsResourcesPage/SubmitCommunitySection.vue'
+import AlternativeSearchResultsNews from '~/components/AlternativeSearchResults/AlternativeSearchResultsNews.vue'
 
 import { fetchCommunitySpotlightItems, CommunitySpotlightData, CommunitySpotlightComputed, CommunitySpotlightMethods } from '../model'
 
@@ -187,7 +192,8 @@ export default Vue.extend<CommunitySpotlightData, CommunitySpotlightMethods, Com
     CommunitySpotlightFacetMenu,
     SearchControlsContentful,
     SortMenu,
-    SubmitCommunitySection
+    SubmitCommunitySection,
+    AlternativeSearchResultsNews
   },
 
   // In order to allow for sorting or fireside chats and success stories we needed
@@ -254,6 +260,7 @@ export default Vue.extend<CommunitySpotlightData, CommunitySpotlightMethods, Com
         // we use next tick to wait for the facet menu to be mounted
         this.$nextTick(async () => {
           this.communitySpotlightItems = await fetchCommunitySpotlightItems(client, this.$route.query.search, this.spotlightTypes, this.selectedAnatomicalStructuresEntryIds, this.sortOrder, 10, 0)
+          this.$refs.altSearchResults?.retrieveAltTotals()
         })
       },
       immediate: true

--- a/pages/news-and-events/events/index.vue
+++ b/pages/news-and-events/events/index.vue
@@ -81,6 +81,10 @@
                     :item="item"
                     :show-past-events-divider="showPastEventsDivider && item.sys.id == firstPastEventId"
                   />
+                  <alternative-search-results-news
+                    ref="altSearchResults"
+                    :search-had-results="events.items.length > 0"
+                  />
                 </div>
                 <div class="search-heading">
                   <div class="label1" v-if="events.items.length">
@@ -121,6 +125,7 @@ import SearchControlsContentful from '@/components/SearchControlsContentful/Sear
 import SortMenu from '@/components/SortMenu/SortMenu.vue'
 import createClient from '@/plugins/contentful.js'
 import SubmitNewsSection from '~/components/NewsEventsResourcesPage/SubmitNewsSection.vue'
+import AlternativeSearchResultsNews from '~/components/AlternativeSearchResults/AlternativeSearchResultsNews.vue'
 
 import { fetchEvents, EventsData, EventsComputed, EventsMethods } from '../model'
 
@@ -168,6 +173,7 @@ export default Vue.extend<EventsData, EventsMethods, EventsComputed, never>({
   name: 'EventsPage',
 
   components: {
+    AlternativeSearchResultsNews,
     Breadcrumb,
     EventsFacetMenu,
     EventListItem,
@@ -218,6 +224,7 @@ export default Vue.extend<EventsData, EventsMethods, EventsComputed, never>({
         // we use next tick to wait for the facet menu to be mounted
         this.$nextTick(async () => {
           this.events = await fetchEvents(client, this.$route.query.search, this.startLessThanDate, this.startGreaterThanOrEqualToDate, this.eventTypes, this.sortOrder, 10, 0)
+          this.$refs.altSearchResults?.retrieveAltTotals()
         })
       },
       immediate: true

--- a/pages/news-and-events/news/index.vue
+++ b/pages/news-and-events/news/index.vue
@@ -80,6 +80,10 @@
                     :key="item.sys.id"
                     :item="item"
                   />
+                  <alternative-search-results-news
+                    ref="altSearchResults"
+                    :search-had-results="news.items.length > 0"
+                  />
                 </div>
                 <div class="search-heading">
                   <div class="label1" v-if="news.items.length">
@@ -119,6 +123,7 @@ import NewsListItem from '@/components/NewsListItem/NewsListItem.vue'
 import SearchControlsContentful from '@/components/SearchControlsContentful/SearchControlsContentful.vue';
 import SortMenu from '@/components/SortMenu/SortMenu.vue'
 import SubmitNewsSection from '~/components/NewsEventsResourcesPage/SubmitNewsSection.vue'
+import AlternativeSearchResultsNews from '~/components/AlternativeSearchResults/AlternativeSearchResultsNews.vue'
 
 import createClient from '@/plugins/contentful.js'
 
@@ -168,7 +173,8 @@ export default Vue.extend<NewsData, NewsMethods, NewsComputed, never>({
     NewsListItem,
     SearchControlsContentful,
     SortMenu,
-    SubmitNewsSection
+    SubmitNewsSection,
+    AlternativeSearchResultsNews
   },
 
   async asyncData({ route }) {
@@ -213,6 +219,7 @@ export default Vue.extend<NewsData, NewsMethods, NewsComputed, never>({
         // we use next tick to wait for the facet menu to be mounted
         this.$nextTick(async () => {
           this.news = await fetchNews(client, this.$route.query.search, this.publishedLessThanDate, this.publishedGreaterThanOrEqualToDate, this.subjects, this.sortOrder, 10, 0)
+          this.$refs.altSearchResults?.retrieveAltTotals()
         })
       },
       immediate: true

--- a/pages/resources/biological/index.vue
+++ b/pages/resources/biological/index.vue
@@ -116,7 +116,7 @@ import ResourcesSearchResults from '@/components/Resources/ResourcesSearchResult
 import ToolsAndResourcesFacetMenu from '@/components/FacetMenu/ToolsAndResourcesFacetMenu.vue'
 import { fetchResources, searchTypes, sortOptions } from '../utils.ts'
 import SubmitToolSection from '@/components/Resources/SubmitToolSection.vue'
-import AlternativeSearchResults from '@/components/AlternativeSearchResults/AlternativeSearchResults.vue'
+import AlternativeSearchResults from '~/components/AlternativeSearchResults/AlternativeSearchResultsResources.vue'
 
 export default {
   name: 'BiologicalPage',

--- a/pages/resources/biological/index.vue
+++ b/pages/resources/biological/index.vue
@@ -73,8 +73,10 @@
                   </span>
                 </div>
                 <div class="subpage">
-                  <resources-search-results
-                    :table-data="resources.items"
+                  <resources-search-results :table-data="resources.items" />
+                  <alternative-search-results
+                    ref="alternativeSearchResults"
+                    :search-had-results="resources.items.length > 0"
                   />
                 </div>
                 <div class="search-heading">
@@ -100,7 +102,7 @@
       </el-row>
     </div>
     <div class="pb-16 pt-16 container">
-      <submit-tool-section/>
+      <submit-tool-section />
     </div>
   </div>
 </template>
@@ -114,6 +116,7 @@ import ResourcesSearchResults from '@/components/Resources/ResourcesSearchResult
 import ToolsAndResourcesFacetMenu from '@/components/FacetMenu/ToolsAndResourcesFacetMenu.vue'
 import { fetchResources, searchTypes, sortOptions } from '../utils.ts'
 import SubmitToolSection from '@/components/Resources/SubmitToolSection.vue'
+import AlternativeSearchResults from '@/components/AlternativeSearchResults/AlternativeSearchResults.vue'
 
 export default {
   name: 'BiologicalPage',
@@ -124,7 +127,8 @@ export default {
     ResourcesSearchResults,
     ToolsAndResourcesFacetMenu,
     SortMenu,
-    SubmitToolSection
+    SubmitToolSection,
+    AlternativeSearchResults
   },
 
   async asyncData({ route }) {
@@ -169,6 +173,7 @@ export default {
         // we use next tick to wait for the facet menu to be mounted
         this.$nextTick(async () => {
           this.resources = await fetchResources('Biologicals', this.$route.query.search, this.sortOrder, this.type, 10, 0)
+          this.$refs.alternativeSearchResults.retrieveAltTotals()
         })
       },
       immediate: true

--- a/pages/resources/databases/index.vue
+++ b/pages/resources/databases/index.vue
@@ -114,7 +114,7 @@ import SearchControlsContentful from '@/components/SearchControlsContentful/Sear
 import SortMenu from '@/components/SortMenu/SortMenu.vue'
 import ResourcesSearchResults from '@/components/Resources/ResourcesSearchResults.vue'
 import ToolsAndResourcesFacetMenu from '@/components/FacetMenu/ToolsAndResourcesFacetMenu.vue'
-import AlternativeSearchResults from '@/components/AlternativeSearchResults/AlternativeSearchResults.vue'
+import AlternativeSearchResults from '~/components/AlternativeSearchResults/AlternativeSearchResultsResources.vue'
 import { fetchResources, searchTypes, sortOptions } from '../utils.ts'
 import SubmitToolSection from '@/components/Resources/SubmitToolSection.vue'
 

--- a/pages/resources/databases/index.vue
+++ b/pages/resources/databases/index.vue
@@ -73,12 +73,10 @@
                   </span>
                 </div>
                 <div class="subpage">
-                  <resources-search-results
-                    :table-data="resources.items"
-                  />
+                  <resources-search-results :table-data="resources.items" />
                   <alternative-search-results
-                    :search-term="searchTerm"
-                    :search-type="searchType"
+                    ref="alternativeSearchResults"
+                    :search-had-results="resources.items.length > 0"
                   />
                 </div>
                 <div class="search-heading">
@@ -175,6 +173,7 @@ export default {
         // we use next tick to wait for the facet menu to be mounted
         this.$nextTick(async () => {
           this.resources = await fetchResources('Data and Models', this.$route.query.search, this.sortOrder, this.type, 10, 0)
+          this.$refs.alternativeSearchResults.retrieveAltTotals()
         })
       },
       immediate: true

--- a/pages/resources/databases/index.vue
+++ b/pages/resources/databases/index.vue
@@ -76,6 +76,10 @@
                   <resources-search-results
                     :table-data="resources.items"
                   />
+                  <alternative-search-results
+                    :search-term="searchTerm"
+                    :search-type="searchType"
+                  />
                 </div>
                 <div class="search-heading">
                   <div class="label1" v-if="resources.items.length">
@@ -112,6 +116,7 @@ import SearchControlsContentful from '@/components/SearchControlsContentful/Sear
 import SortMenu from '@/components/SortMenu/SortMenu.vue'
 import ResourcesSearchResults from '@/components/Resources/ResourcesSearchResults.vue'
 import ToolsAndResourcesFacetMenu from '@/components/FacetMenu/ToolsAndResourcesFacetMenu.vue'
+import AlternativeSearchResults from '@/components/AlternativeSearchResults/AlternativeSearchResults.vue'
 import { fetchResources, searchTypes, sortOptions } from '../utils.ts'
 import SubmitToolSection from '@/components/Resources/SubmitToolSection.vue'
 
@@ -124,7 +129,8 @@ export default {
     ResourcesSearchResults,
     ToolsAndResourcesFacetMenu,
     SortMenu,
-    SubmitToolSection
+    SubmitToolSection,
+    AlternativeSearchResults
   },
 
   async asyncData({ route }) {

--- a/pages/resources/devices/index.vue
+++ b/pages/resources/devices/index.vue
@@ -73,8 +73,10 @@
                   </span>
                 </div>
                 <div class="subpage">
-                  <resources-search-results
-                    :table-data="resources.items"
+                  <resources-search-results :table-data="resources.items" />
+                  <alternative-search-results
+                    ref="alternativeSearchResults"
+                    :search-had-results="resources.items.length > 0"
                   />
                 </div>
                 <div class="search-heading">
@@ -114,6 +116,7 @@ import ResourcesSearchResults from '@/components/Resources/ResourcesSearchResult
 import ToolsAndResourcesFacetMenu from '@/components/FacetMenu/ToolsAndResourcesFacetMenu.vue'
 import { fetchResources, searchTypes, sortOptions } from '../utils.ts'
 import SubmitToolSection from '@/components/Resources/SubmitToolSection.vue'
+import AlternativeSearchResults from '@/components/AlternativeSearchResults/AlternativeSearchResults.vue'
 
 export default {
   name: 'DevicesPage',
@@ -124,7 +127,8 @@ export default {
     ResourcesSearchResults,
     ToolsAndResourcesFacetMenu,
     SortMenu,
-    SubmitToolSection
+    SubmitToolSection,
+    AlternativeSearchResults
   },
 
   async asyncData({ route }) {
@@ -169,6 +173,7 @@ export default {
         // we use next tick to wait for the facet menu to be mounted
         this.$nextTick(async () => {
           this.resources = await fetchResources('Devices', this.$route.query.search, this.sortOrder, this.type, 10, 0)
+          this.$refs.alternativeSearchResults.retrieveAltTotals()
         })
       },
       immediate: true

--- a/pages/resources/devices/index.vue
+++ b/pages/resources/devices/index.vue
@@ -116,7 +116,7 @@ import ResourcesSearchResults from '@/components/Resources/ResourcesSearchResult
 import ToolsAndResourcesFacetMenu from '@/components/FacetMenu/ToolsAndResourcesFacetMenu.vue'
 import { fetchResources, searchTypes, sortOptions } from '../utils.ts'
 import SubmitToolSection from '@/components/Resources/SubmitToolSection.vue'
-import AlternativeSearchResults from '@/components/AlternativeSearchResults/AlternativeSearchResults.vue'
+import AlternativeSearchResults from '~/components/AlternativeSearchResults/AlternativeSearchResultsResources.vue'
 
 export default {
   name: 'DevicesPage',

--- a/pages/resources/information-services/index.vue
+++ b/pages/resources/information-services/index.vue
@@ -73,8 +73,10 @@
                   </span>
                 </div>
                 <div class="subpage">
-                  <resources-search-results
-                    :table-data="resources.items"
+                  <resources-search-results :table-data="resources.items" />
+                  <alternative-search-results
+                    ref="alternativeSearchResults"
+                    :search-had-results="resources.items.length > 0"
                   />
                 </div>
                 <div class="search-heading">
@@ -114,6 +116,7 @@ import ResourcesSearchResults from '@/components/Resources/ResourcesSearchResult
 import ToolsAndResourcesFacetMenu from '@/components/FacetMenu/ToolsAndResourcesFacetMenu.vue'
 import { fetchResources, searchTypes, sortOptions } from '../utils.ts'
 import SubmitToolSection from '@/components/Resources/SubmitToolSection.vue'
+import AlternativeSearchResults from '@/components/AlternativeSearchResults/AlternativeSearchResults.vue'
 
 export default {
   name: 'InformationServicesPage',
@@ -124,7 +127,8 @@ export default {
     ResourcesSearchResults,
     ToolsAndResourcesFacetMenu,
     SortMenu,
-    SubmitToolSection
+    SubmitToolSection,
+    AlternativeSearchResults
   },
 
   async asyncData({ route }) {
@@ -169,6 +173,7 @@ export default {
         // we use next tick to wait for the facet menu to be mounted
         this.$nextTick(async () => {
           this.resources = await fetchResources('Information Services', this.$route.query.search, this.sortOrder, this.type, 10, 0)
+          this.$refs.alternativeSearchResults.retrieveAltTotals()
         })
       },
       immediate: true

--- a/pages/resources/information-services/index.vue
+++ b/pages/resources/information-services/index.vue
@@ -116,7 +116,7 @@ import ResourcesSearchResults from '@/components/Resources/ResourcesSearchResult
 import ToolsAndResourcesFacetMenu from '@/components/FacetMenu/ToolsAndResourcesFacetMenu.vue'
 import { fetchResources, searchTypes, sortOptions } from '../utils.ts'
 import SubmitToolSection from '@/components/Resources/SubmitToolSection.vue'
-import AlternativeSearchResults from '@/components/AlternativeSearchResults/AlternativeSearchResults.vue'
+import AlternativeSearchResults from '~/components/AlternativeSearchResults/AlternativeSearchResultsResources.vue'
 
 export default {
   name: 'InformationServicesPage',

--- a/pages/resources/software/index.vue
+++ b/pages/resources/software/index.vue
@@ -73,8 +73,10 @@
                   </span>
                 </div>
                 <div class="subpage">
-                  <resources-search-results
-                    :table-data="resources.items"
+                  <resources-search-results :table-data="resources.items" />
+                  <alternative-search-results
+                    ref="alternativeSearchResults"
+                    :search-had-results="resources.items.length > 0"
                   />
                 </div>
                 <div class="search-heading">
@@ -114,6 +116,7 @@ import ResourcesSearchResults from '@/components/Resources/ResourcesSearchResult
 import ToolsAndResourcesFacetMenu from '@/components/FacetMenu/ToolsAndResourcesFacetMenu.vue'
 import { fetchResources, searchTypes, sortOptions } from '../utils.ts'
 import SubmitToolSection from '@/components/Resources/SubmitToolSection.vue'
+import AlternativeSearchResults from '@/components/AlternativeSearchResults/AlternativeSearchResults.vue'
 
 export default {
   name: 'SoftwarePage',
@@ -124,7 +127,8 @@ export default {
     ResourcesSearchResults,
     ToolsAndResourcesFacetMenu,
     SortMenu,
-    SubmitToolSection
+    SubmitToolSection,
+    AlternativeSearchResults
   },
 
   async asyncData({ route }) {
@@ -169,6 +173,7 @@ export default {
         // we use next tick to wait for the facet menu to be mounted
         this.$nextTick(async () => {
           this.resources = await fetchResources('Software', this.$route.query.search, this.sortOrder, this.type, 10, 0)
+          this.$refs.alternativeSearchResults.retrieveAltTotals()
         })
       },
       immediate: true

--- a/pages/resources/software/index.vue
+++ b/pages/resources/software/index.vue
@@ -116,7 +116,7 @@ import ResourcesSearchResults from '@/components/Resources/ResourcesSearchResult
 import ToolsAndResourcesFacetMenu from '@/components/FacetMenu/ToolsAndResourcesFacetMenu.vue'
 import { fetchResources, searchTypes, sortOptions } from '../utils.ts'
 import SubmitToolSection from '@/components/Resources/SubmitToolSection.vue'
-import AlternativeSearchResults from '@/components/AlternativeSearchResults/AlternativeSearchResults.vue'
+import AlternativeSearchResults from '~/components/AlternativeSearchResults/AlternativeSearchResultsResources.vue'
 
 export default {
   name: 'SoftwarePage',


### PR DESCRIPTION
# Description

Added alternative search results for Resources and News and Events pages

Can preview these changes here:
https://jesse-sprint-27.herokuapp.com/resources


![image](https://user-images.githubusercontent.com/37255664/228703181-5fb46ad6-706a-498e-9786-62ce6dc7d178.png)
![image](https://user-images.githubusercontent.com/37255664/228703232-90e9120e-7767-46b6-93b1-240808c0b256.png)

It is requested from the comments in this ticket:
https://www.wrike.com/open.htm?id=1014464589


## Type of change

Delete those that don't apply.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

# How Has This Been Tested?

Tested locally and can be tested on the sparc-app clone of this branch here:
https://jesse-sprint-27.herokuapp.com/resources


# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have utilized components from the Design System Library where applicable
- [ ] I have added unit tests that prove my fix is effective or that my feature works
