### PR TITLE
moved logic out of dataset details asyncData into respective component's fetch

### DIFF
--- a/components/DatasetDetails/DatasetFilesInfo.vue
+++ b/components/DatasetDetails/DatasetFilesInfo.vue
@@ -180,15 +180,21 @@ export default {
 
   mixins: [DateUtils, FormatMetric],
 
-  props: {
-    osparcViewers: {
-      type: Object,
-      default: () => {}
-    },
-    datasetScicrunch: {
-      type: Object,
-      default: () => {}
-    }
+  async fetch() {
+    // Get oSPARC file viewers
+    this.osparcViewers = process.env.SHOW_OSPARC_TAB == 'true' ? 
+      await this.$axios
+        .$get(`${process.env.portal_api}/sim/file`)
+        .then(osparcData => osparcData['file_viewers'])
+        .catch(() => {
+          return {}
+        }) :
+      await this.$axios
+        .$get(`${process.env.portal_api}/get_osparc_data`)
+        .then(osparcData => osparcData['file_viewers'])
+        .catch(() => {
+          return {}
+        })
   },
 
   computed: {
@@ -198,6 +204,9 @@ export default {
      */
     ...mapState('pages/datasets/datasetId', ['datasetInfo']),
     ...mapGetters('user', ['cognitoUserToken']),
+    datasetScicrunch() {
+      return propOr({}, 'sciCrunch', this.datasetInfo)
+    },
     userToken() {
       return this.cognitoUserToken || this.$cookies.get('user-token')
     },
@@ -266,6 +275,7 @@ export default {
       awsMessage: 'us-east-1',
       showAgreementPopup: false,
       showLoginDialog: false,
+      osparcViewers: {}
     }
   },
 

--- a/components/ImagesGallery/ImagesGallery.vue
+++ b/components/ImagesGallery/ImagesGallery.vue
@@ -1,21 +1,28 @@
 <template>
   <div class="full-size">
-    <div v-if="hasDescription" class="description-info">
-      <p>
-        <strong>Data collection:</strong>
-        {{ description }}
-      </p>
-    </div>
     <client-only placeholder="Loading gallery ...">
-      <div :class="['gallery-container', { 'one-item': galleryItems.length === 1 }]">
-        <gallery
-          :items="galleryItems"
-          :max-width="maxWidth"
-          :show-indicator-bar="true"
-          :show-card-details="true"
-          :highlight-active="shouldHighlight"
-        />
-      </div>
+        <div class="loading-gallery mt-16" v-if="$fetchState.pending" v-loading="$fetchState.pending" />
+        <div v-else-if="$fetchState.error">
+          There was an error loading the gallery items
+        </div>
+        <div v-else-if="galleryItems.length > 0" :class="['gallery-container', { 'one-item': galleryItems.length === 1 }]">
+          <div v-if="hasDescription" class="description-info">
+            <p>
+              <strong>Data collection:</strong>
+              {{ description }}
+            </p>
+          </div>
+          <gallery
+            :items="galleryItems"
+            :max-width="maxWidth"
+            :show-indicator-bar="true"
+            :show-card-details="true"
+            :highlight-active="shouldHighlight"
+          />
+        </div>
+        <div v-else-if="!$fetchState.pending">
+          This dataset does not contain gallery items
+        </div>
     </client-only>
   </div>
 </template>
@@ -23,12 +30,113 @@
 <script>
 import biolucida from '@/services/biolucida'
 import discover from '@/services/discover'
+import scicrunch from '@/services/scicrunch'
 import flatmaps from '@/services/flatmaps'
+import Uberons from '@/static/js/uberon-map.js'
+import ErrorMessages from '@/mixins/error-messages'
 
 import FormatString from '@/mixins/format-string'
 import MarkedMixin from '@/mixins/marked'
+import { propOr } from 'ramda'
+
+import { mapState } from 'vuex'
 
 import { baseName, extractSection, extractS3BucketName } from '@/utils/common'
+
+const getBiolucidaData = async datasetId => {
+  try {
+    return biolucida.searchDataset(datasetId)
+  } catch (e) {
+    return {}
+  }
+}
+
+/**
+ * Get data for objects that have a data specific viewer.
+ * @param {Number} datasetId
+ */
+const getThumbnailData = async (datasetDoi, datasetId, datasetVersion, datasetFacetsData) => {
+  let biolucidaImageData = {}
+  let scicrunchData = {}
+  try {
+    const [biolucida_response, scicrunch_response] = await Promise.all([
+      getBiolucidaData(datasetId),
+      scicrunch.getDatasetInfoFromDOI(datasetDoi)
+    ])
+
+    if (biolucida_response.status === 'success') {
+      biolucidaImageData = biolucida_response
+      biolucidaImageData['discover_dataset_version'] = datasetVersion
+    }
+    if (scicrunch_response.data.result.length > 0) {
+      scicrunchData = scicrunch_response.data.result[0]
+      scicrunchData.discover_dataset = {
+        id: Number(datasetId),
+        version: datasetVersion
+      }
+      // Check for flatmap data
+      if (scicrunchData.organs) {
+        let flatmapData = []
+        let species = undefined
+        // Get species data from algolia if it exists
+        if (datasetFacetsData){
+          let speciesArray = datasetFacetsData.filter(item=>item.label==="Species")
+          if (speciesArray && speciesArray.length > 0)
+            species = speciesArray[0].children[0].label.toLowerCase()
+        }
+
+        // check if there is a flatmap for the given species, use a rat if there is not
+        const taxo = species && species in Uberons.species ? Uberons.species[species] : Uberons.species['rat']
+
+        // Check if flatmap has the anatomy for this species. This is done by asking the flatmap knowledge base
+        // if a flatmap of (species) has (anatomy)
+        let foundAnatomy = []
+        if (scicrunchData.organs[0]) { // Check if dataset has organ annotation
+          // Send a requst to flatmap knowledgebase
+          const anatomy = scicrunchData.organs.map(organ => organ.curie)
+          const data = await flatmaps.anatomyQuery(taxo, anatomy)
+
+          // Check request was successful
+          const anatomyResponse = data.data ? data.data.values : undefined
+          if (anatomyResponse && anatomyResponse.length > 0) {
+            foundAnatomy = anatomyResponse.map(val => val[1]) // uberon is stored in second element of tuple
+          }
+        }
+
+        // Add flatmaps that match the anatomy and taxonomy to the gallery
+        scicrunchData.organs.forEach(organ => {
+          if (foundAnatomy.includes(organ.curie)){
+            let organData = {
+              taxo,
+              uberonid: organ.curie,
+              organ: organ.name,
+              id: datasetId,
+              version: datasetVersion,
+              species: species
+            }
+            flatmapData.push(organData)
+          }
+        })
+        //Only create a flatmaps field if flatmapData is not empty
+        if (flatmapData.length > 0)
+          scicrunchData['flatmaps'] = flatmapData
+      }
+    }
+  } catch (e) {
+    console.error(
+      'Hit error in the scicrunch processing. ( pages/_datasetId.vue ). Error: ',
+      e
+    )
+    return {
+      biolucidaImageData: {},
+      scicrunchData: {}
+    }
+  }
+  return {
+    biolucidaImageData,
+    scicrunchData
+  }
+}
 
 export default {
   name: 'ImagesGallery',
@@ -39,18 +147,6 @@ export default {
   },
   mixins: [FormatString, MarkedMixin],
   props: {
-    datasetScicrunch: {
-      type: Object,
-      default: () => {
-        return {}
-      }
-    },
-    datasetBiolucida: {
-      type: Object,
-      default: () => {
-        return {}
-      }
-    },
     datasetImages: {
       type: Array,
       default: () => {
@@ -70,12 +166,6 @@ export default {
       }
     },
     datasetVideos: {
-      type: Array,
-      default: () => {
-        return []
-      }
-    },
-    timeseriesData: {
       type: Array,
       default: () => {
         return []
@@ -113,10 +203,19 @@ export default {
       maxWidth: 3,
       scicrunchItems: [],
       biolucidaItems: [],
-      timeseriesItems: []
+      timeseriesItems: [],
+      timeseriesData: [],
+      datasetScicrunch: {},
+      datasetBiolucida: {},
     }
   },
   computed: {
+    ...mapState('pages/datasets/datasetId', 
+      ['datasetInfo', 'datasetFacetsData']
+    ),
+    datasetId() {
+      return propOr('', 'id', this.datasetInfo)
+    },
     isPrevPossible() {
       return this.currentIndex > 0
     },
@@ -151,10 +250,61 @@ export default {
       return this.hasDescription || this.galleryItems.length > 1
     }
   },
+  async fetch() {
+    const { biolucidaImageData, scicrunchData } = await getThumbnailData(
+      this.datasetInfo.doi,
+      this.datasetId,
+      this.datasetInfo.version,
+      this.datasetFacetsData
+    )
+    if (Object.keys(biolucidaImageData).length === 0 &&
+      Object.keys(scicrunchData).length === 0 ) {
+      //Non critical error
+      this.$message(failMessage(ErrorMessages.methods.scicrunch()))
+    }
+    this.datasetBiolucida = biolucidaImageData
+    this.datasetScicrunch = scicrunchData
+
+    const newDatasetInfo = {
+      ...this.datasetInfo,
+      sciCrunch: scicrunchData
+    }
+
+    this.$store.dispatch('pages/datasets/datasetId/setDatasetInfo', newDatasetInfo)
+
+        // Get all timeseries files (those with an '.edf' extension)
+    const timeseriesData = process.env.SHOW_TIMESERIES_VIEWER
+    ? await this.$axios.$get(`${process.env.discover_api_host}/search/files?fileType=edf&datasetId=${this.datasetId}`)
+        .then(({ files }) => {
+          let data = []
+          files.forEach(file => {
+            const filePath = file.uri.substring(file.uri.indexOf('files'))
+            const linkUrl =
+                process.env.ROOT_URL +
+                `/datasets/timeseriesviewer?&dataset_id=${file.datasetId}&dataset_version=${file.datasetVersion}&file_path=${filePath}`
+
+            data.push({
+              title: file.name,
+              type: 'Timeseries',
+              thumbnail: undefined,
+              link: linkUrl
+            })
+          })
+          return data
+        })
+        .catch(() => {
+          return []
+        }) 
+    : []
+    this.timeseriesData = timeseriesData
+  },
   watch: {
-    markdown: function(text) {
-      const html = this.parseMarkdown(text)
-      this.description = extractSection(/data collect[^:]+:/i, html)
+    markdown: {
+      immediate: true,
+      handler: function(text) {
+        const html = this.parseMarkdown(text)
+        this.description = extractSection(/data collect[^:]+:/i, html)
+      }
     },
     timeseriesData: {
       deep: true,
@@ -172,12 +322,10 @@ export default {
         let datasetId = -1
         let datasetVersion = -1
         let s3Bucket = extractS3BucketName(scicrunchData['s3uri'])
-
         if ('discover_dataset' in scicrunchData) {
           datasetId = scicrunchData.discover_dataset.id
           datasetVersion = scicrunchData.discover_dataset.version
         }
- 
         if ('abi-scaffold-metadata-file' in scicrunchData) {
           let index = 0
           items.push(
@@ -603,6 +751,11 @@ export default {
 </script>
 
 <style scoped>
+.loading-gallery {
+  overflow: hidden;
+  min-height: 4rem;
+}
+
 .full-size {
   width: 100%;
   height: 100%;


### PR DESCRIPTION
# Description

In order to reduce load time on the initial dataset details page rendering I moved all logic possible from the pages asyncData() to each respective component's fetch(). This allow the page to work on updating the components in the tabs while the page is shown instead of having to wait for everything to load before displaying the page as requested in: 
https://www.wrike.com/open.htm?id=1091588655

## Type of change

- [X] New feature (non-breaking change which adds functionality)

# How Has This Been Tested?

Locally. Drastically reduced load time from a couple seconds to ~100 milliseconds

# Checklist:

- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my own code
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] I have utilized components from the Design System Library where applicable
