### PR TITLE
Allow 'sup' tags in most html parsing

### DIFF
--- a/components/FeaturedEvent/FeaturedEvent.vue
+++ b/components/FeaturedEvent/FeaturedEvent.vue
@@ -67,7 +67,7 @@
       </div>
       <!-- eslint-disable vue/no-v-html -->
       <!-- marked will sanitize the HTML injected -->
-      <div v-html="parseMarkdown(event.fields.summary)" />
+      <div v-html="parseMarkdown(event.fields.summary, { ALLOWED_TAGS: ['sup'] })" />
     </div>
     <nuxt-link
       v-if="event.fields.requiresADetailsPage"

--- a/components/NewsEventsResourcesPage/NewsEventsResourcesPage.vue
+++ b/components/NewsEventsResourcesPage/NewsEventsResourcesPage.vue
@@ -16,7 +16,7 @@
             <share-links />
           </el-col>
           <el-col :xs="24" :sm="secondCol">
-            <div class="content" v-html="parseMarkdown(htmlContent)" />
+            <div class="content" v-html="parseMarkdown(htmlContent, { ALLOWED_TAGS: ['sup'] }))" />
             <nuxt-link class="back-link" v-if="hasEventDetailsPage" :to="{ path: eventDetailsRoute }">
               View Additional Event Details >
             </nuxt-link>

--- a/components/NewsEventsResourcesPage/NewsEventsResourcesPage.vue
+++ b/components/NewsEventsResourcesPage/NewsEventsResourcesPage.vue
@@ -16,7 +16,7 @@
             <share-links />
           </el-col>
           <el-col :xs="24" :sm="secondCol">
-            <div class="content" v-html="parseMarkdown(htmlContent, { ALLOWED_TAGS: ['sup'] }))" />
+            <div class="content" v-html="parseMarkdown(htmlContent, { ALLOWED_TAGS: ['sup'] })" />
             <nuxt-link class="back-link" v-if="hasEventDetailsPage" :to="{ path: eventDetailsRoute }">
               View Additional Event Details >
             </nuxt-link>

--- a/components/ToolAndResourcesPage/ToolsAndResourcesPage.vue
+++ b/components/ToolAndResourcesPage/ToolsAndResourcesPage.vue
@@ -12,7 +12,7 @@
         <!-- eslint-disable vue/no-v-html -->
         <!-- marked will sanitize the HTML injected -->
         <slot />
-        <div class="content" v-html="parseMarkdown(htmlContent)" />
+        <div class="content" v-html="parseMarkdown(htmlContent, { ALLOWED_TAGS: ['sup']})" />
         <hr v-if="hasTutorial || hasWebinar" class="my-24"/>
         <div class="mb-16" v-if="hasTutorial">
           <div class="label4 mb-4" >

--- a/pages/news-and-events/community-spotlight/success-stories/_id.vue
+++ b/pages/news-and-events/community-spotlight/success-stories/_id.vue
@@ -12,7 +12,10 @@
       <div class="subpage">
         <el-row :gutter="38">
           <el-col :sm="13">
-            <div class="content" v-html="parseMarkdown(entry.story)" />
+            <div
+              class="content"
+              v-html="parseMarkdown(entry.story, { ALLOWED_TAGS: ['sup'] })"
+            />
           </el-col>
           <el-col :sm="11">
             <div class="banner-wrapper">

--- a/pages/news-and-events/events/_eventId/event-details/index.vue
+++ b/pages/news-and-events/events/_eventId/event-details/index.vue
@@ -17,7 +17,7 @@
         </div>
         <!-- eslint-disable vue/no-v-html -->
         <!-- marked will sanitize the HTML injected -->
-        <div class="content" v-html="parseMarkdown(htmlDetails)" />
+        <div class="content" v-html="parseMarkdown(htmlDetails, { ALLOWED_TAGS: ['sup'] })" />
       </div>
     </div>
   </div>

--- a/pages/news-and-events/index.vue
+++ b/pages/news-and-events/index.vue
@@ -5,7 +5,7 @@
       <h1>{{ page.fields.page_title }}</h1>
       <!-- eslint-disable vue/no-v-html -->
       <!-- marked will sanitize the HTML injected -->
-      <div v-html="parseMarkdown(page.fields.heroCopy)" />
+      <div v-html="parseMarkdown(page.fields.heroCopy, { ALLOWED_TAGS: ['sup'] })" />
       <img
         v-if="page.fields.heroImage"
         slot="image"

--- a/pages/resources/index.vue
+++ b/pages/resources/index.vue
@@ -5,7 +5,7 @@
       <h1>{{ fields.title }}</h1>
       <!-- eslint-disable vue/no-v-html -->
       <!-- marked will sanitize the HTML injected -->
-      <div v-html="parseMarkdown(fields.summary)" />
+      <div v-html="parseMarkdown(fields.summary, { ALLOWED_TAGS: ['sup']})" />
       <NuxtLink to="/resources/databases">
         <el-button class="secondary mb-16">Browse all Tools &amp; Resources</el-button>
       </NuxtLink>


### PR DESCRIPTION
# Description

According to this ticket, https://www.wrike.com/open.htm?id=1057888212

I believe that we want to allow the 'sup' html tag through on the community spotlight, news events and resources pages where there are html fields on contentful.

Every field which could potentially use 'sup' should now allow it with these code changes


## Type of change

Delete those that don't apply.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

# How Has This Been Tested?

Run locally, but I can't find any entries from contentful that use 'sup' tags


# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have utilized components from the Design System Library where applicable
- [ ] I have added unit tests that prove my fix is effective or that my feature works
