### PR TITLE
Default search tab from Tools&Resources header search bar

### DIFF
--- a/components/header/Header.vue
+++ b/components/header/Header.vue
@@ -248,8 +248,8 @@ export default {
           label: 'Data'
         },
         {
-          key: 'resources-biological',
-          value: 'resources-biological',
+          key: 'resources-databases',
+          value: 'resources-databases',
           label: 'Tools & Resources'
         },
         {


### PR DESCRIPTION
# Description

Changing default search of the header's search bar when searching Tools & Resources from Biological to Databases
https://www.wrike.com/open.htm?id=1050960119


## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

Manually


# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have utilized components from the Design System Library where applicable
- [ ] I have added unit tests that prove my fix is effective or that my feature works
