### PR TITLE
Update mapintegratedvuer to fix small logic issue in popups

### DIFF
--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
   },
   "dependencies": {
     "@abi-software/gallery": "0.3.2",
-    "@abi-software/mapintegratedvuer": "0.4.1",
+    "@abi-software/mapintegratedvuer": "0.4.2",
     "@abi-software/plotvuer": "^0.3.0",
     "@abi-software/simulationvuer": "0.6.5",
     "@aws-amplify/auth": "^4.4.4",

--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
   },
   "dependencies": {
     "@abi-software/gallery": "0.3.2",
-    "@abi-software/mapintegratedvuer": "0.4.2",
+    "@abi-software/mapintegratedvuer": "0.4.3",
     "@abi-software/plotvuer": "^0.3.0",
     "@abi-software/simulationvuer": "0.6.5",
     "@aws-amplify/auth": "^4.4.4",

--- a/yarn.lock
+++ b/yarn.lock
@@ -11,10 +11,10 @@
     orbit-camera-controller "^4.0.0"
     turntable-camera-controller "^3.0.0"
 
-"@abi-software/flatmap-viewer@^2.3.2-b.4":
-  version "2.3.2-b.4"
-  resolved "https://registry.yarnpkg.com/@abi-software/flatmap-viewer/-/flatmap-viewer-2.3.2-b.4.tgz#f6ee067224a0b34bdc248033232caf6dbc655c68"
-  integrity sha512-2CNV160FBZZ0ERcaBwEJJERG1L4ZsWHnJuSkfeZDYbmX3HgeYBC9NaNwaYCVte2hyxUtlyzBAegRyTUUSZc5sA==
+"@abi-software/flatmap-viewer@^2.3.3-b.4":
+  version "2.3.3-b.4"
+  resolved "https://registry.yarnpkg.com/@abi-software/flatmap-viewer/-/flatmap-viewer-2.3.3-b.4.tgz#62b625d6f670d0ecb642532ee57a55c797dbf52c"
+  integrity sha512-rJoASw3Ngj69LhuBsvKtIsU8brcFv0exBgz9EE+Cv4wSD8SUO02P81u9FE9giDOa9DGNGZT5gO4bqWqlNdbMow==
   dependencies:
     "@babel/runtime" "^7.10.4"
     "@fortawesome/fontawesome-free" "^6.4.0"
@@ -29,12 +29,12 @@
     minisearch "^2.2.1"
     polylabel "^1.1.0"
 
-"@abi-software/flatmapvuer@^0.4.3":
-  version "0.4.3"
-  resolved "https://registry.yarnpkg.com/@abi-software/flatmapvuer/-/flatmapvuer-0.4.3.tgz#223c6b5ac4fd65defd5d1a0f4d572d439ce2c3d4"
-  integrity sha512-2E7oILFCEm6YLbGOSn6UiO957nS50uYkUZv6a4MygZeWuLVeFJFahq1wBXN+kyCyzIB4VAwxWlyxut1tepXzyQ==
+"@abi-software/flatmapvuer@^0.4.4":
+  version "0.4.4"
+  resolved "https://registry.yarnpkg.com/@abi-software/flatmapvuer/-/flatmapvuer-0.4.4.tgz#00a6ec84900df728e2a1afc10737d6570f15052c"
+  integrity sha512-TzKX5o8Yik9ZHpwHmXONU1ieNXaTD1kcxrkiTsV3cIbQzjV4+zjcnGIkHF/i2tFNgvpNlukeG0unsO0oWfHmbA==
   dependencies:
-    "@abi-software/flatmap-viewer" "^2.3.2-b.4"
+    "@abi-software/flatmap-viewer" "^2.3.3-b.4"
     "@abi-software/svg-sprite" "^0.1.14"
     core-js "^3.3.2"
     css-element-queries "^1.2.2"
@@ -83,12 +83,12 @@
     vue "^2.6.10"
     xss "^1.0.14"
 
-"@abi-software/mapintegratedvuer@0.4.2":
-  version "0.4.2"
-  resolved "https://registry.yarnpkg.com/@abi-software/mapintegratedvuer/-/mapintegratedvuer-0.4.2.tgz#3ae519ab4eec95ee148fdfa947994cae92880bb2"
-  integrity sha512-EerYtHKo8ve6cJ1RnDQviTdc0fEFj+jX3iGl2rcDcnN9+fHAE4K3UvSYZ8DyURWsnS3rw92GyVgeyxSnJljG0w==
+"@abi-software/mapintegratedvuer@0.4.3":
+  version "0.4.3"
+  resolved "https://registry.yarnpkg.com/@abi-software/mapintegratedvuer/-/mapintegratedvuer-0.4.3.tgz#4ec20a17d1fb01798af271ae8cffb2f4bb85e822"
+  integrity sha512-4UGxkH4ZKg1JC8PlnS5ikOingtVhldKDj2bukiVlgyXZfSblsySKjPOl8T5dl4mn/S/ANCM+M/z51CkrrlyRXQ==
   dependencies:
-    "@abi-software/flatmapvuer" "^0.4.3"
+    "@abi-software/flatmapvuer" "^0.4.4"
     "@abi-software/map-side-bar" "^1.3.38"
     "@abi-software/plotvuer" "^0.3.9"
     "@abi-software/scaffoldvuer" "^0.1.61"

--- a/yarn.lock
+++ b/yarn.lock
@@ -11,10 +11,10 @@
     orbit-camera-controller "^4.0.0"
     turntable-camera-controller "^3.0.0"
 
-"@abi-software/flatmap-viewer@^2.3.3-b.4":
-  version "2.3.3-b.4"
-  resolved "https://registry.yarnpkg.com/@abi-software/flatmap-viewer/-/flatmap-viewer-2.3.3-b.4.tgz#62b625d6f670d0ecb642532ee57a55c797dbf52c"
-  integrity sha512-rJoASw3Ngj69LhuBsvKtIsU8brcFv0exBgz9EE+Cv4wSD8SUO02P81u9FE9giDOa9DGNGZT5gO4bqWqlNdbMow==
+"@abi-software/flatmap-viewer@^2.3.2-b.4":
+  version "2.3.2-b.4"
+  resolved "https://registry.yarnpkg.com/@abi-software/flatmap-viewer/-/flatmap-viewer-2.3.2-b.4.tgz#f6ee067224a0b34bdc248033232caf6dbc655c68"
+  integrity sha512-2CNV160FBZZ0ERcaBwEJJERG1L4ZsWHnJuSkfeZDYbmX3HgeYBC9NaNwaYCVte2hyxUtlyzBAegRyTUUSZc5sA==
   dependencies:
     "@babel/runtime" "^7.10.4"
     "@fortawesome/fontawesome-free" "^6.4.0"
@@ -29,12 +29,12 @@
     minisearch "^2.2.1"
     polylabel "^1.1.0"
 
-"@abi-software/flatmapvuer@^0.4.2":
-  version "0.4.2"
-  resolved "https://registry.yarnpkg.com/@abi-software/flatmapvuer/-/flatmapvuer-0.4.2.tgz#f0be43adce18401bdf3c6e99296042dfa1dbd3eb"
-  integrity sha512-8u3qn39YYriFClra7zqpxCZWTJP4+EkVaHMfGfoxW0/elUL7xOKSqa0qX4c6dGhdpi6TVQXKuObMc8zTLBfAdQ==
+"@abi-software/flatmapvuer@^0.4.3":
+  version "0.4.3"
+  resolved "https://registry.yarnpkg.com/@abi-software/flatmapvuer/-/flatmapvuer-0.4.3.tgz#223c6b5ac4fd65defd5d1a0f4d572d439ce2c3d4"
+  integrity sha512-2E7oILFCEm6YLbGOSn6UiO957nS50uYkUZv6a4MygZeWuLVeFJFahq1wBXN+kyCyzIB4VAwxWlyxut1tepXzyQ==
   dependencies:
-    "@abi-software/flatmap-viewer" "^2.3.3-b.4"
+    "@abi-software/flatmap-viewer" "^2.3.2-b.4"
     "@abi-software/svg-sprite" "^0.1.14"
     core-js "^3.3.2"
     css-element-queries "^1.2.2"
@@ -83,12 +83,12 @@
     vue "^2.6.10"
     xss "^1.0.14"
 
-"@abi-software/mapintegratedvuer@0.4.1":
-  version "0.4.1"
-  resolved "https://registry.yarnpkg.com/@abi-software/mapintegratedvuer/-/mapintegratedvuer-0.4.1.tgz#264f10fc20c9d24fec38587fac1a1d65a6c5e08c"
-  integrity sha512-1/ZhO1X/7WhUIg1jMg3QcKcNookzvdg4qgb76xI4N3TpZ71dl7EWjfhIVPHnXAulzCabUn/0FobAwXH28YsvWQ==
+"@abi-software/mapintegratedvuer@0.4.2":
+  version "0.4.2"
+  resolved "https://registry.yarnpkg.com/@abi-software/mapintegratedvuer/-/mapintegratedvuer-0.4.2.tgz#3ae519ab4eec95ee148fdfa947994cae92880bb2"
+  integrity sha512-EerYtHKo8ve6cJ1RnDQviTdc0fEFj+jX3iGl2rcDcnN9+fHAE4K3UvSYZ8DyURWsnS3rw92GyVgeyxSnJljG0w==
   dependencies:
-    "@abi-software/flatmapvuer" "^0.4.2"
+    "@abi-software/flatmapvuer" "^0.4.3"
     "@abi-software/map-side-bar" "^1.3.38"
     "@abi-software/plotvuer" "^0.3.9"
     "@abi-software/scaffoldvuer" "^0.1.61"


### PR DESCRIPTION
# Description

Currently on stagin.sparc.science, tooltips on the AC maps are missing their pubmed resources. 

This mapintegratedvuer update is an update to the logic in flatmapvuer which was previously incorrect causing this issue.

![image](https://github.com/nih-sparc/sparc-app/assets/37255664/b4dd4c09-8b65-44c5-be21-c461d045ce2c)

Can test this by going to https://jesse-sprint-27.herokuapp.com/maps?type=ac and clicking on one of the neuron paths

## Type of change

Delete those that don't apply.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

# How Has This Been Tested?

Ran on each viewer and sparc-app locally.

A live preview of this code is also available at:
https://jesse-sprint-27.herokuapp.com/maps?type=ac


# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have utilized components from the Design System Library where applicable
- [ ] I have added unit tests that prove my fix is effective or that my feature works
