### PR TITLE
Hot Fix: Remove all 'sup' tags being passed to DOMPurify

### DIFF
--- a/components/Breadcrumb/Breadcrumb.vue
+++ b/components/Breadcrumb/Breadcrumb.vue
@@ -7,7 +7,7 @@
         </nuxt-link>
         >
       </template>
-      <span v-html="parseMarkdown(title, { ALLOWED_TAGS: ['sup'] })"/>
+      <span v-html="parseMarkdown(title)"/>
     </div>
   </div>
 </template>

--- a/components/FeaturedEvent/FeaturedEvent.vue
+++ b/components/FeaturedEvent/FeaturedEvent.vue
@@ -67,7 +67,7 @@
       </div>
       <!-- eslint-disable vue/no-v-html -->
       <!-- marked will sanitize the HTML injected -->
-      <div v-html="parseMarkdown(event.fields.summary, { ALLOWED_TAGS: ['sup'] })" />
+      <div v-html="parseMarkdown(event.fields.summary)" />
     </div>
     <nuxt-link
       v-if="event.fields.requiresADetailsPage"

--- a/components/NewsEventsResourcesPage/NewsEventsResourcesPage.vue
+++ b/components/NewsEventsResourcesPage/NewsEventsResourcesPage.vue
@@ -2,8 +2,8 @@
   <div class="page">
     <breadcrumb :breadcrumb="breadcrumb" :title="heroTitle" />
     <page-hero class="news-header">
-      <h1 v-html="parseMarkdown(heroTitle, { ALLOWED_TAGS: ['sup'] })"/>
-      <div class="body2" v-html="parseMarkdown(heroSummary, { ALLOWED_TAGS: ['sup'] })"/>
+      <h1 v-html="parseMarkdown(heroTitle)"/>
+      <div class="body2" v-html="parseMarkdown(heroSummary)"/>
     </page-hero>
     <div class="page-wrap container">
       <div class="subpage">
@@ -16,7 +16,7 @@
             <share-links />
           </el-col>
           <el-col :xs="24" :sm="secondCol">
-            <div class="content" v-html="parseMarkdown(htmlContent, { ALLOWED_TAGS: ['sup'] })" />
+            <div class="content" v-html="parseMarkdown(htmlContent)" />
             <nuxt-link class="back-link" v-if="hasEventDetailsPage" :to="{ path: eventDetailsRoute }">
               View Additional Event Details >
             </nuxt-link>

--- a/components/ToolAndResourcesPage/ToolsAndResourcesPage.vue
+++ b/components/ToolAndResourcesPage/ToolsAndResourcesPage.vue
@@ -12,7 +12,7 @@
         <!-- eslint-disable vue/no-v-html -->
         <!-- marked will sanitize the HTML injected -->
         <slot />
-        <div class="content" v-html="parseMarkdown(htmlContent, { ALLOWED_TAGS: ['sup']})" />
+        <div class="content" v-html="parseMarkdown(htmlContent)" />
         <hr v-if="hasTutorial || hasWebinar" class="my-24"/>
         <div class="mb-16" v-if="hasTutorial">
           <div class="label4 mb-4" >

--- a/pages/news-and-events/community-spotlight/success-stories/_id.vue
+++ b/pages/news-and-events/community-spotlight/success-stories/_id.vue
@@ -14,7 +14,7 @@
           <el-col :sm="13">
             <div
               class="content"
-              v-html="parseMarkdown(entry.story, { ALLOWED_TAGS: ['sup'] })"
+              v-html="parseMarkdown(entry.story)"
             />
           </el-col>
           <el-col :sm="11">

--- a/pages/news-and-events/events/_eventId/event-details/index.vue
+++ b/pages/news-and-events/events/_eventId/event-details/index.vue
@@ -17,7 +17,7 @@
         </div>
         <!-- eslint-disable vue/no-v-html -->
         <!-- marked will sanitize the HTML injected -->
-        <div class="content" v-html="parseMarkdown(htmlDetails, { ALLOWED_TAGS: ['sup'] })" />
+        <div class="content" v-html="parseMarkdown(htmlDetails)" />
       </div>
     </div>
   </div>

--- a/pages/news-and-events/index.vue
+++ b/pages/news-and-events/index.vue
@@ -5,7 +5,7 @@
       <h1>{{ page.fields.page_title }}</h1>
       <!-- eslint-disable vue/no-v-html -->
       <!-- marked will sanitize the HTML injected -->
-      <div v-html="parseMarkdown(page.fields.heroCopy, { ALLOWED_TAGS: ['sup'] })" />
+      <div v-html="parseMarkdown(page.fields.heroCopy)" />
       <img
         v-if="page.fields.heroImage"
         slot="image"

--- a/pages/resources/index.vue
+++ b/pages/resources/index.vue
@@ -5,7 +5,7 @@
       <h1>{{ fields.title }}</h1>
       <!-- eslint-disable vue/no-v-html -->
       <!-- marked will sanitize the HTML injected -->
-      <div v-html="parseMarkdown(fields.summary, { ALLOWED_TAGS: ['sup']})" />
+      <div v-html="parseMarkdown(fields.summary)" />
       <NuxtLink to="/resources/databases">
         <el-button class="secondary mb-16">Browse all Tools &amp; Resources</el-button>
       </NuxtLink>

--- a/plugins/bootstrap.js
+++ b/plugins/bootstrap.js
@@ -14,7 +14,7 @@ import VueClipboard from 'vue-clipboard2'
 // // import SocialSharing from 'vue-social-sharing'
 
 import striptags from 'striptags'
-Vue.prototype.$sanitize = (html, allowedTags = ['br']) =>
+Vue.prototype.$sanitize = (html, allowedTags = ['br', 'sup']) =>
   striptags(html, allowedTags)
 
 // // configure language


### PR DESCRIPTION
# Description

The 'ALLOWED_TAGS' is actualy an extensive list of what html tags will be allowed. It overides the default list from DOMPurify meaning that only the sup tag will be allowed to pass through.

This reverts those changes (as they break a big chunk of the markdown on the site)

I have added the sup tag to bootstrap.js allowed tags, for where DOMPurify is not being used

This was noticed in this ticket:
https://www.wrike.com/open.htm?id=1057888212

And it reverts the changes from #665 

Please see my comments in the wrike ticket for evidence that 'sup' tags are already supported

example:
![image](https://github.com/nih-sparc/sparc-app/assets/37255664/015e94b7-5e3d-4524-a539-a05100849783)


Live view of this code at:
https://jesse-sprint-27.herokuapp.com/resources/4LkLiH5s4FV0LVJd3htsvH

## Type of change

Delete those that don't apply.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

# How Has This Been Tested?

Ran locally, and tested all fields using:
`<h1 v-html="parseMarkdown('<p>This text contains <sup>superscript</sup> text.</p>')"/>`

This PR can be viewed live at:
https://jesse-sprint-27.herokuapp.com/resources/4LkLiH5s4FV0LVJd3htsvH


# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have utilized components from the Design System Library where applicable
- [ ] I have added unit tests that prove my fix is effective or that my feature works
