### PR TITLE
Fix a bug causing uberon id to not be used.

### DIFF
--- a/pages/maps/index.vue
+++ b/pages/maps/index.vue
@@ -62,9 +62,9 @@ const getFlatmapEntry = async (route) => {
     }
   }
   try {
-    organ_name = await scicrunch.getOrganFromUberonId(uberonid)
+    let name = await scicrunch.getOrganFromUberonId(uberonid)
     //We do not want to display the body proper
-    if (organ_name && organ_name.toLowerCase() === 'body proper') {
+    if (name && name.toLowerCase() === 'body proper') {
       organ_name = undefined
     }
   } catch (e) {


### PR DESCRIPTION
# Description

Previous release unintentionally uses anatomical name when starting a flatmap with an uberon. This pull request addresses the issue.

## Type of change

Delete those that don't apply.

- [ ] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

Only the Pelvic splanchnic nerve should be highlighted.
Bug: https://sparc.science/maps?type=flatmap&dataset_version=1&dataset_id=206&taxo=NCBITaxon%3A10114&uberonid=UBERON%3A0018675&for_species=rat
Fixed: https://alan-wu-sparc-app.herokuapp.com/maps?type=flatmap&dataset_version=1&dataset_id=206&taxo=NCBITaxon%3A10114&uberonid=UBERON%3A0018675&for_species=rat

# Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have utilized components from the Design System Library where applicable
- [ ] I have added unit tests that prove my fix is effective or that my feature works
