### PR TITLE
Update marked to 4.2.0

### DIFF
--- a/mixins/marked/index.js
+++ b/mixins/marked/index.js
@@ -1,4 +1,4 @@
-import marked from 'marked'
+import { marked } from 'marked'
 import youtubeEmbeddedSrc from '../youtube-embedded-src'
 import DOMPurify from 'isomorphic-dompurify'
 

--- a/package.json
+++ b/package.json
@@ -47,7 +47,7 @@
     "eslint-plugin-vue": "^6.1.2",
     "isomorphic-dompurify": "0.19.0",
     "js-file-download": "^0.4.12",
-    "marked": "^0.7.0",
+    "marked": "4.2.0",
     "nuxt": "^2.12.1",
     "plyr": "^3.6.3",
     "postscribe": "^2.0.8",

--- a/yarn.lock
+++ b/yarn.lock
@@ -10403,12 +10403,7 @@ marching-simplex-table@^1.0.0:
   dependencies:
     convex-hull "^1.0.3"
 
-marked@^0.7.0:
-  version "0.7.0"
-  resolved "https://registry.yarnpkg.com/marked/-/marked-0.7.0.tgz#b64201f051d271b1edc10a04d1ae9b74bb8e5c0e"
-  integrity sha512-c+yYdCZJQrsRjTPhUx7VKkApw9bwDkNbHUKo1ovgcfDjb2kc8rLuRbIFyXL5WOEUwzSSKo3IXpph2K6DqB/KZg==
-
-marked@^4.1.1:
+marked@4.2.0, marked@^4.1.1:
   version "4.2.0"
   resolved "https://registry.yarnpkg.com/marked/-/marked-4.2.0.tgz#f1683b077626a6c53e28926b798a18184aa13a91"
   integrity sha512-1qWHjHlBKwjnDfrkxd0L3Yx4LTad/WO7+d13YsXAC/ZfKj7p0xkLV3sDXJzfWgL7GfW4IBZwMAYWaz+ifyQouQ==


### PR DESCRIPTION
# Description

Update marked to 4.2.0

This puts the maps page and sparc-app on the same marked version.

(currently marked@0.7.0 is propagating to the /maps page and breaking things)

Can see this by going to https://sparc.science/maps?type=ac , navigating to dataset 221 and opening the scaffold. No context card is shown as marked hits an error.
![image](https://github.com/nih-sparc/sparc-app/assets/37255664/832b349b-9229-450f-bc51-2e4faf1bfb17)


## Type of change

Delete those that don't apply.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

# How Has This Been Tested?

Checked the markdown pages locally and a live deploy of this code can be viewed at:

https://jesse-sprint-preview.herokuapp.com/


# Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have utilized components from the Design System Library where applicable
- [ ] I have added unit tests that prove my fix is effective or that my feature works
