### PR TITLE
Add more meta tags to pages for SEO

### DIFF
--- a/layouts/default.vue
+++ b/layouts/default.vue
@@ -26,7 +26,18 @@ export default {
     ...mapState('layouts/default', {
       hasAcceptedGDPR: state => state.hasAcceptedGDPR
     })
-  }
+  },
+  head() {
+    return {
+      meta: [
+        { 
+          hid: 'og:url',
+          property: 'og:url',
+          content: `${process.env.ROOT_URL}${this.$route.fullPath}`,
+        },
+      ]
+    }
+  },
 }
 </script>
 

--- a/nuxt.config.js
+++ b/nuxt.config.js
@@ -16,7 +16,7 @@ export default {
       {
         hid: 'description',
         name: 'description',
-        content: process.env.npm_package_description || ''
+        content: 'Stimulating Peripheral Activity to Relieve Conditions (SPARC)',
       },
       {
         hid: 'keywords',
@@ -26,7 +26,7 @@ export default {
       // default social cards information for site sharing url's
       { hid: 'og:type', property: 'og:type', content: 'website' },
       { hid: 'og:title', property: 'og:title', content: 'SPARC Portal' },
-      { hid: 'og:desc', property: 'og:description', content: 'Stimulating Peripheral Activity to Relieve Conditions (SPARC)' },
+      { hid: 'og:description', property: 'og:description', content: 'Stimulating Peripheral Activity to Relieve Conditions (SPARC)' },
       { hid: 'og:image', property: 'og:image',
         content: 'https://images.ctfassets.net/6bya4tyw8399/7r5WTb92QnHkub8RsExuc1/2ac134de2ddfd65eb6316421df7578f9/sparc-logo-primary.png'
       },

--- a/pages/about/_aboutDetailsId.vue
+++ b/pages/about/_aboutDetailsId.vue
@@ -112,7 +112,14 @@ export default {
 
   head() {
     return {
-      title: this.aboutDetailsItem.fields.title
+      title: this.aboutDetailsItem.fields.title,
+      meta: [
+        {
+          hid: 'og:title',
+          property: 'og:title',
+          content: this.aboutDetailsItem.fields.title,
+        },
+      ]
     }
   },
 

--- a/pages/about/about-sparc/index.vue
+++ b/pages/about/about-sparc/index.vue
@@ -180,7 +180,14 @@ export default {
 
   head() {
     return {
-      title: this.searchTypes[0].label
+      title: this.searchTypes[0].label,
+      meta: [
+        {
+          hid: 'og:title',
+          property: 'og:title',
+          content: this.searchTypes[0].label,
+        },
+      ]
     }
   },
 

--- a/pages/about/get-involved/_aboutDetailsId.vue
+++ b/pages/about/get-involved/_aboutDetailsId.vue
@@ -100,7 +100,14 @@ export default {
 
   head() {
     return {
-      title: this.aboutDetailsItem.fields.title
+      title: this.aboutDetailsItem.fields.title,
+      meta: [
+        {
+          hid: 'og:title',
+          property: 'og:title',
+          content: this.aboutDetailsItem.fields.title,
+        },
+      ]
     }
   },
 

--- a/pages/about/get-involved/index.vue
+++ b/pages/about/get-involved/index.vue
@@ -88,7 +88,19 @@ export default {
 
   head() {
     return {
-      title: this.title
+      title: this.title,
+      meta: [
+        {
+          hid: 'og:title',
+          property: 'og:title',
+          content: this.title,
+        },
+        {
+          hid: 'description',
+          name: 'description',
+          content: this.summary ? this.summary : 'Stimulating Peripheral Activity to Relieve Conditions (SPARC)'
+        },
+      ]
     }
   },
 

--- a/pages/about/index.vue
+++ b/pages/about/index.vue
@@ -137,7 +137,19 @@ export default {
 
   head() {
     return {
-      title: this.pageTitle
+      title: this.pageTitle,
+      meta: [
+        {
+          hid: 'og:title',
+          property: 'og:title',
+          content: this.pageTitle,
+        },
+        {
+          hid: 'description',
+          name: 'description',
+          content: this.heroCopy ? this.heroCopy : 'Stimulating Peripheral Activity to Relieve Conditions (SPARC)'
+        },
+      ]
     }
   },
 

--- a/pages/about/policies-and-standards/_aboutDetailsId.vue
+++ b/pages/about/policies-and-standards/_aboutDetailsId.vue
@@ -100,7 +100,14 @@ export default {
 
   head() {
     return {
-      title: this.aboutDetailsItem.fields.title
+      title: this.aboutDetailsItem.fields.title,
+      meta: [
+        {
+          hid: 'og:title',
+          property: 'og:title',
+          content: this.aboutDetailsItem.fields.title,
+        },
+      ]
     }
   },
 

--- a/pages/about/policies-and-standards/index.vue
+++ b/pages/about/policies-and-standards/index.vue
@@ -180,7 +180,14 @@ export default {
 
   head() {
     return {
-      title: this.searchTypes[1].label
+      title: this.searchTypes[1].label,
+      meta: [
+        {
+          hid: 'og:title',
+          property: 'og:title',
+          content: this.title,
+        },
+      ]
     }
   },
 

--- a/pages/about/sparc-portal/_aboutDetailsId.vue
+++ b/pages/about/sparc-portal/_aboutDetailsId.vue
@@ -100,7 +100,14 @@ export default {
 
   head() {
     return {
-      title: this.aboutDetailsItem.fields.title
+      title: this.aboutDetailsItem.fields.title,
+      meta: [
+        {
+          hid: 'og:title',
+          property: 'og:title',
+          content: this.aboutDetailsItem.fields.title,
+        },
+      ]
     }
   },
 

--- a/pages/about/team-and-leadership/_aboutDetailsId.vue
+++ b/pages/about/team-and-leadership/_aboutDetailsId.vue
@@ -100,7 +100,14 @@ export default {
 
   head() {
     return {
-      title: this.aboutDetailsItem.fields.title
+      title: this.aboutDetailsItem.fields.title,
+      meta: [
+        {
+          hid: 'og:title',
+          property: 'og:title',
+          content: this.aboutDetailsItem.fields.title,
+        },
+      ]
     }
   },
 

--- a/pages/about/team-and-leadership/index.vue
+++ b/pages/about/team-and-leadership/index.vue
@@ -88,7 +88,19 @@ export default {
 
   head() {
     return {
-      title: this.title
+      title: this.title,
+      meta: [
+        {
+          hid: 'og:title',
+          property: 'og:title',
+          content: this.title,
+        },
+        {
+          hid: 'description',
+          name: 'description',
+          content: this.summary ? this.summary : 'Stimulating Peripheral Activity to Relieve Conditions (SPARC)'
+        },
+      ]
     }
   },
 

--- a/pages/about/what-we-offer/_aboutDetailsId.vue
+++ b/pages/about/what-we-offer/_aboutDetailsId.vue
@@ -100,7 +100,14 @@ export default {
 
   head() {
     return {
-      title: this.aboutDetailsItem.fields.title
+      title: this.aboutDetailsItem.fields.title,
+      meta: [
+        {
+          hid: 'og:title',
+          property: 'og:title',
+          content: this.aboutDetailsItem.fields.title,
+        },
+      ]
     }
   },
 

--- a/pages/about/what-we-offer/index.vue
+++ b/pages/about/what-we-offer/index.vue
@@ -88,7 +88,19 @@ export default {
 
   head() {
     return {
-      title: this.title
+      title: this.title,
+      meta: [
+        {
+          hid: 'og:title',
+          property: 'og:title',
+          content: this.title,
+        },
+        {
+          hid: 'description',
+          name: 'description',
+          content: this.summary ? this.summary : 'Stimulating Peripheral Activity to Relieve Conditions (SPARC)'
+        },
+      ]
     }
   },
 

--- a/pages/contact-us/index.vue
+++ b/pages/contact-us/index.vue
@@ -231,7 +231,19 @@ export default {
 
   head() {
     return {
-      title: this.breadcrumbTitle
+      title: this.breadcrumbTitle,
+      meta: [
+        {
+          hid: 'og:title',
+          property: 'og:title',
+          content: this.breadcrumbTitle,
+        },
+        {
+          hid: 'description',
+          name: 'description',
+          content: this.formTypeObject.description ? this.formTypeObject.description : 'Stimulating Peripheral Activity to Relieve Conditions (SPARC)'
+        },
+      ]
     }
   },
 

--- a/pages/data/index.vue
+++ b/pages/data/index.vue
@@ -329,6 +329,11 @@ export default {
           property: 'og:title',
           content: propOr("", "label", this.breadcrumb[this.breadcrumb.length - 1]),
         },
+        {
+          hid: 'description',
+          name: 'description',
+          content: 'Browse datasets'
+        },
       ]
     }
   },

--- a/pages/data/index.vue
+++ b/pages/data/index.vue
@@ -322,7 +322,14 @@ export default {
 
   head() {
     return {
-      title: propOr("", "label", this.breadcrumb[this.breadcrumb.length - 1])
+      title: propOr("", "label", this.breadcrumb[this.breadcrumb.length - 1]),
+      meta: [
+        {
+          hid: 'og:title',
+          property: 'og:title',
+          content: propOr("", "label", this.breadcrumb[this.breadcrumb.length - 1]),
+        },
+      ]
     }
   },
 

--- a/pages/datasets/_datasetId.vue
+++ b/pages/datasets/_datasetId.vue
@@ -857,11 +857,13 @@ export default {
           content: 'website'
         },
         {
+          hid: 'og:title',
           property: 'og:title',
           content: this.datasetTitle
         },
         {
-          property: 'og:description',
+          hid: 'description',
+          name: 'description',
           content: this.datasetDescription
         },
         {
@@ -913,10 +915,6 @@ export default {
         {
           name: 'DC.version',
           content: this.datasetInfo.version
-        },
-        {
-          property: 'og:url',
-          content: process.env.ROOT_URL
         }
       ],
       script: [

--- a/pages/index.vue
+++ b/pages/index.vue
@@ -134,6 +134,7 @@ export default {
     return {
       meta: [
         {
+          hid: 'description',
           name: 'description',
           content:
             'Stimulating Peripheral Activity to Relieve Conditions (SPARC)'
@@ -143,13 +144,9 @@ export default {
           content: 'website'
         },
         {
-          name: 'og:title',
+          hid: 'og:title',
+          property: 'og:title',
           content: 'SPARC Portal'
-        },
-        {
-          name: 'og:description',
-          content:
-            'Stimulating Peripheral Activity to Relieve Conditions (SPARC)'
         },
         {
           hid: 'og:image',

--- a/pages/maps/index.vue
+++ b/pages/maps/index.vue
@@ -250,6 +250,18 @@ export default {
   head() {
     return {
       title: this.title,
+      meta: [
+        {
+          hid: 'og:title',
+          property: 'og:title',
+          content: this.title,
+        },
+        {
+          hid: 'description',
+          name: 'description',
+          content: 'SPARC is creating detailed PNS maps based on SPARC data and information available from the literature.'
+        },
+      ]
     }
   },
   watch: {

--- a/pages/news-and-events/community-spotlight/index.vue
+++ b/pages/news-and-events/community-spotlight/index.vue
@@ -251,7 +251,19 @@ export default Vue.extend<CommunitySpotlightData, CommunitySpotlightMethods, Com
   },
   head() {
     return {
-      title: this.searchTypes[2].label
+      title: this.searchTypes[2].label,
+      meta: [
+        {
+          hid: 'og:title',
+          property: 'og:title',
+          content: this.searchTypes[2].label,
+        },
+        {
+          hid: 'description',
+          name: 'description',
+          content: 'Browse community spotlight'
+        },
+      ]
     }
   },
   watch: {

--- a/pages/news-and-events/community-spotlight/success-stories/_id.vue
+++ b/pages/news-and-events/community-spotlight/success-stories/_id.vue
@@ -183,7 +183,19 @@ export default {
   },
   head() {
     return {
-      title: this.title
+      title: this.title,
+      meta: [
+        {
+          hid: 'og:title',
+          property: 'og:title',
+          content: this.title,
+        },
+        {
+          hid: 'description',
+          name: 'description',
+          content: this.entry.summary ? this.entry.summary : 'Stimulating Peripheral Activity to Relieve Conditions (SPARC)'
+        },
+      ]
     }
   },
   computed: {

--- a/pages/news-and-events/events/_eventId/event-details/index.vue
+++ b/pages/news-and-events/events/_eventId/event-details/index.vue
@@ -83,7 +83,19 @@ export default {
 
   head() {
     return {
-      title: this.heroTitle
+      title: this.heroTitle,
+      meta: [
+        {
+          hid: 'og:title',
+          property: 'og:title',
+          content: this.heroTitle,
+        },
+        {
+          hid: 'description',
+          name: 'description',
+          content: this.heroSummary ? this.heroSummary : 'Stimulating Peripheral Activity to Relieve Conditions (SPARC)'
+        },
+      ]
     }
   },
 

--- a/pages/news-and-events/events/_id.vue
+++ b/pages/news-and-events/events/_id.vue
@@ -108,7 +108,19 @@ export default {
 
   head() {
     return {
-      title: this.page.fields.title
+      title: this.page.fields.title,
+      meta: [
+        {
+          hid: 'og:title',
+          property: 'og:title',
+          content: this.page.fields.title,
+        },
+        {
+          hid: 'description',
+          name: 'description',
+          content: this.page.fields.summary ? this.page.fields.summary : 'Stimulating Peripheral Activity to Relieve Conditions (SPARC)'
+        },
+      ]
     }
   },
 

--- a/pages/news-and-events/events/index.vue
+++ b/pages/news-and-events/events/index.vue
@@ -214,7 +214,19 @@ export default Vue.extend<EventsData, EventsMethods, EventsComputed, never>({
 
   head() {
     return {
-      title: this.searchTypes[1].label
+      title: this.searchTypes[1].label,
+      meta: [
+        {
+          hid: 'og:title',
+          property: 'og:title',
+          content: this.searchTypes[1].label,
+        },
+        {
+          hid: 'description',
+          name: 'description',
+          content: 'Browse events'
+        },
+      ]
     }
   },
 

--- a/pages/news-and-events/index.vue
+++ b/pages/news-and-events/index.vue
@@ -263,7 +263,19 @@ export default Vue.extend<Data, Methods, Computed, never>({
 
   head() {
     return {
-      title: this.title
+      title: this.title,
+      meta: [
+        {
+          hid: 'og:title',
+          property: 'og:title',
+          content: this.title,
+        },
+        {
+          hid: 'description',
+          name: 'description',
+          content: this.page.fields.heroCopy ? this.page.fields.heroCopy : 'Stimulating Peripheral Activity to Relieve Conditions (SPARC)'
+        },
+      ]
     }
   },
 

--- a/pages/news-and-events/news/_id.vue
+++ b/pages/news-and-events/news/_id.vue
@@ -78,7 +78,19 @@ export default {
 
   head() {
     return {
-      title: this.page.fields.title
+      title: this.page.fields.title,
+      meta: [
+        {
+          hid: 'og:title',
+          property: 'og:title',
+          content: this.page.fields.title,
+        },
+        {
+          hid: 'description',
+          name: 'description',
+          content: this.page.fields.summary ? this.page.fields.summary : 'Stimulating Peripheral Activity to Relieve Conditions (SPARC)'
+        },
+      ]
     }
   },
 

--- a/pages/news-and-events/news/index.vue
+++ b/pages/news-and-events/news/index.vue
@@ -209,7 +209,19 @@ export default Vue.extend<NewsData, NewsMethods, NewsComputed, never>({
 
   head() {
     return {
-      title: this.searchTypes[0].label
+      title: this.searchTypes[0].label,
+      meta: [
+        {
+          hid: 'og:title',
+          property: 'og:title',
+          content: this.searchTypes[0].label,
+        },
+        {
+          hid: 'description',
+          name: 'description',
+          content: 'Browse news'
+        },
+      ]
     }
   },
 

--- a/pages/resources/_resourceId.vue
+++ b/pages/resources/_resourceId.vue
@@ -114,7 +114,19 @@ export default {
 
   head() {
     return {
-      title: this.resource.fields.name
+      title: this.resource.fields.name,
+      meta: [
+        {
+          hid: 'og:title',
+          property: 'og:title',
+          content: this.resource.fields.name,
+        },
+        {
+          hid: 'description',
+          name: 'description',
+          content: this.resource.fields.description ? this.resource.fields.description : 'Stimulating Peripheral Activity to Relieve Conditions (SPARC)'
+        },
+      ]
     }
   },
 

--- a/pages/resources/biological/index.vue
+++ b/pages/resources/biological/index.vue
@@ -163,7 +163,19 @@ export default {
 
   head() {
     return {
-      title: this.title
+      title: this.title,
+      meta: [
+        {
+          hid: 'og:title',
+          property: 'og:title',
+          content: this.title,
+        },
+        {
+          hid: 'description',
+          name: 'description',
+          content: 'Browse biological'
+        },
+      ]
     }
   },
 

--- a/pages/resources/databases/index.vue
+++ b/pages/resources/databases/index.vue
@@ -163,7 +163,19 @@ export default {
 
   head() {
     return {
-      title: this.title
+      title: this.title,
+      meta: [
+        {
+          hid: 'og:title',
+          property: 'og:title',
+          content: this.title,
+        },
+        {
+          hid: 'description',
+          name: 'description',
+          content: 'Browse databases'
+        },
+      ]
     }
   },
 

--- a/pages/resources/devices/index.vue
+++ b/pages/resources/devices/index.vue
@@ -163,7 +163,19 @@ export default {
 
   head() {
     return {
-      title: this.title
+      title: this.title,
+      meta: [
+        {
+          hid: 'og:title',
+          property: 'og:title',
+          content: this.title,
+        },
+        {
+          hid: 'description',
+          name: 'description',
+          content: 'Browse devices'
+        },
+      ]
     }
   },
 

--- a/pages/resources/index.vue
+++ b/pages/resources/index.vue
@@ -87,7 +87,19 @@ export default {
 
   head() {
     return {
-      title: this.title
+      title: this.title,
+      meta: [
+        {
+          hid: 'og:title',
+          property: 'og:title',
+          content: this.title,
+        },
+        {
+          hid: 'description',
+          name: 'description',
+          content: this.fields.summary ? this.fields.summary : 'Stimulating Peripheral Activity to Relieve Conditions (SPARC)'
+        },
+      ]
     }
   }
 }

--- a/pages/resources/information-services/index.vue
+++ b/pages/resources/information-services/index.vue
@@ -163,7 +163,19 @@ export default {
 
   head() {
     return {
-      title: this.title
+      title: this.title,
+      meta: [
+        {
+          hid: 'og:title',
+          property: 'og:title',
+          content: this.title,
+        },
+        {
+          hid: 'description',
+          name: 'description',
+          content: 'Browse information services'
+        },
+      ]
     }
   },
 

--- a/pages/resources/software/index.vue
+++ b/pages/resources/software/index.vue
@@ -163,7 +163,19 @@ export default {
 
   head() {
     return {
-      title: this.title
+      title: this.title,
+      meta: [
+        {
+          hid: 'og:title',
+          property: 'og:title',
+          content: this.title,
+        },
+        {
+          hid: 'description',
+          name: 'description',
+          content: 'Browse software'
+        },
+      ]
     }
   },
 

--- a/pages/user/profile/index.vue
+++ b/pages/user/profile/index.vue
@@ -76,7 +76,19 @@ export default {
 
   head() {
     return {
-      title: this.title
+      title: this.title,
+      meta: [
+        {
+          hid: 'og:title',
+          property: 'og:title',
+          content: this.title,
+        },
+        {
+          hid: 'description',
+          name: 'description',
+          content: 'The SPARC Portal account allows you to fully utilize portal functionality.'
+        },
+      ]
     }
   },
 


### PR DESCRIPTION
# Description

I have added more meta tags to improve SEO based on the requirement stated in [this ticket](https://www.wrike.com/open.htm?id=703216907) - the changes include adding property og:title, property: og.url and name: description to most pages.

## Type of change

Delete those that don't apply.


- [ ] New feature (non-breaking change which adds functionality)

# How Has This Been Tested?

I have manually go through all pages to make sure the head meta is updated for each page. It has also been deployed here - https://alan-wu-sparc-app.herokuapp.com/


# Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have utilized components from the Design System Library where applicable
- [ ] I have added unit tests that prove my fix is effective or that my feature works
