### PR TITLE
Added portal notification settings

### DIFF
--- a/layouts/default.vue
+++ b/layouts/default.vue
@@ -53,7 +53,10 @@ export default {
       })
       const messageType = propOr("", 'messageType', this.portalNotification)
       const onlyShowOnce = propOr(true, 'showOnce', this.portalNotification)
-      if (message != "") {
+      const stopShowingDate = propOr(undefined, 'stopShowingDate', this.portalNotification)
+      // If the stop showing time is not set then always display message, therwise check if the date has passed
+      const stopShowing = stopShowingDate === undefined ? false : new Date(stopShowingDate).getTime() < new Date().getTime()
+      if (message != "" && !stopShowing) {
         if (!onlyShowOnce || !this.hasSeenPortalNotification) {
           if (!displayOnHomePageOnly || (displayOnHomePageOnly && currentlyOnHomePage)) {
             switch (messageType) {

--- a/store/layouts/default.js
+++ b/store/layouts/default.js
@@ -49,7 +49,8 @@ export const actions = {
       const oldNotificationMessage = this.$cookies.get('PortalNotificationMessage')
       // If the message has changes then reset if the user has seen it to false
       if (newNotificationMessage != oldNotificationMessage) {
-        this.$cookies.set('PortalNotification:hasBeenSeen', false)
+        const expirationDate = new Date(today.setDate(today.getDate() + 30))
+        this.$cookies.set('PortalNotification:hasBeenSeen', false, { expires: expirationDate })
         this.$cookies.set('PortalNotificationMessage', newNotificationMessage)
       }
       const hasSeenPortalNotification = this.$cookies.get('PortalNotification:hasBeenSeen')


### PR DESCRIPTION
# Description

Added the ability to set a stop date for which to stop showing the portal notification as requested by Sue in addition to when to clear the browser cookie for the has seen


## Type of change

- [X] New feature (non-breaking change which adds functionality)

# How Has This Been Tested?

Locally

# Checklist:

- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my own code
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] I have utilized components from the Design System Library where applicable
