### PR TITLE
Bug fix for gallery rendering

### DIFF
--- a/components/Gallery/Gallery.vue
+++ b/components/Gallery/Gallery.vue
@@ -8,7 +8,7 @@
               v-if="galleryItemType === 'resources'"
               :is="galleryItemComponent"
               :width="cardWidth"
-              :key="'resource-' + index"
+              :key="item.sys.id"
               :title="item.fields.name"
               :subtitle="item.fields.resourceType.join(', ')"
               :showSparcTag="item.fields.developedBySparc"
@@ -22,7 +22,7 @@
               v-else-if="galleryItemType === 'metrics'"
               :is="galleryItemComponent"
               :width="cardWidth"
-              :key="'metric-' + index"
+              :key="item.title"
               :title="item.title"
               :data="item.data"
               :subData="item.subData"
@@ -31,14 +31,14 @@
               v-else-if="galleryItemType === 'highlights'"
               :is="galleryItemComponent"
               :width="cardWidth"
-              :key="'highlight-' + index"
+              :key="item.sys.id"
               :item="item"
             />
             <component
               v-else-if="galleryItemType === 'datasets'"
               :is="galleryItemComponent"
               :width="cardWidth"
-              :key="'dataset-' + index"
+              :key="item.intId"
               :item="item"
             />
           </template>


### PR DESCRIPTION
# Description

Yomi found an issue where the news item component wasn't rendering item correctly and this was due to the fact that the key was not changing, which is what triggers it to re-render. Updated the keys to actually be unique

## Type of change

- [X] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

Locally


# Checklist:

- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my own code
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] I have utilized components from the Design System Library where applicable
