### PR TITLE
Fix identifier when querying for dataset info from biolucida viewer.

### DIFF
--- a/pages/datasets/biolucidaviewer/_id.vue
+++ b/pages/datasets/biolucidaviewer/_id.vue
@@ -127,7 +127,7 @@ export default {
   async asyncData({ route, error, $axios }) {
     try {
       const image_identifier = route.params.id
-      const identifier = route.query.item_id.substring(2)
+      const identifier = route.query.dataset_id
 
       const [
         blv_info,
@@ -139,7 +139,7 @@ export default {
         biolucida.getBLVLink(image_identifier),
         biolucida.decodeViewParameter(route.query.view),
         biolucida.getImageInfo(image_identifier),
-        scicrunch.getDatasetInfoFromObjectIdentifier(identifier),
+        scicrunch.getDatasetInfoFromPennsieveIdentifier(identifier),
         biolucida.getXMPInfo(image_identifier)
       ])
 


### PR DESCRIPTION
# Description

Fix the retrieval of dataset information for MBF Biolucida images.

## Type of change

Delete those that don't apply.

- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

Tested locally.

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have utilized components from the Design System Library where applicable
- [ ] I have added unit tests that prove my fix is effective or that my feature works
