### PR TITLE
Remove past events in the news & events page.

### DIFF
--- a/components/EventCard/EventCard.vue
+++ b/components/EventCard/EventCard.vue
@@ -111,7 +111,7 @@ export default {
   background: #fff;
   border: 1px solid #dbdfe6;
   color: $dark-sky;
-  padding: 1em;
+  padding: 1.5em 1em;
   &__image {
     margin-bottom: 1rem;
     overflow: hidden;

--- a/components/EventListItem/EventListItem.vue
+++ b/components/EventListItem/EventListItem.vue
@@ -65,7 +65,7 @@ import { isInternalLink, opensInNewTab } from '@/mixins/marked/index'
 import { highlightMatches } from '../../pages/data/utils'
 
 export default {
-  name: 'EventCard',
+  name: 'EventListItem',
   components: {
     eventBannerImage
   },

--- a/pages/news-and-events/index.vue
+++ b/pages/news-and-events/index.vue
@@ -49,43 +49,23 @@
               combination of components
             -->
             <client-only>
-              <content-tab-card
-                class="tabs p-32"
-                :tabs="eventsTabs"
-                :active-tab-id="activeTabId"
-                @tab-changed="eventsTabChanged"
-              >
-                <template v-if="activeTabId === 'upcoming'">
-                  <div class="upcoming-events">
-                    <event-card
-                      v-for="event in upcomingEvents.items"
-                      :key="event.sys.id"
-                      :event="event"
-                    />
-                  </div>
-
-                </template>
-
-                <template v-if="activeTabId === 'past'">
-                  <div class="past-events">
-                    <event-card
-                      v-for="event in pastEvents.items"
-                      :key="event.sys.id"
-                      :event="event"
-                    />
-                  </div>
-                </template>
-                <div class="mt-16">
-                  <nuxt-link
-                    class="btn-load-more"
-                    :to="{
-                      name: 'news-and-events-events',
-                    }"
-                  >
-                    View All Events
-                  </nuxt-link>
-                </div>
-              </content-tab-card>
+              <div class="upcoming-events">
+                <event-card
+                  v-for="event in upcomingEvents.items"
+                  :key="event.sys.id"
+                  :event="event"
+                />
+              </div>
+              <div class="mt-16">
+                <nuxt-link
+                  class="btn-load-more"
+                  :to="{
+                    name: 'news-and-events-events',
+                  }"
+                >
+                  View All Events
+                </nuxt-link>
+              </div>
             </client-only>
           </el-col>
         </el-row>
@@ -220,9 +200,8 @@ export default Vue.extend<Data, Methods, Computed, never>({
   watch: {
     '$route.query': {
       handler: async function(this: NewsAndEventsComponent) {
-        const { upcomingEvents, pastEvents, news, page, stories } = await fetchData(client, this.$route.query.search as string, 2)
+        const { upcomingEvents, news, page, stories } = await fetchData(client, this.$route.query.search as string, 2)
         this.upcomingEvents = upcomingEvents;
-        this.pastEvents = pastEvents;
         this.news = news;
         this.page = page;
         this.stories = stories;
@@ -242,19 +221,7 @@ export default Vue.extend<Data, Methods, Computed, never>({
           label: 'Home'
         }
       ],
-      activeTabId: 'upcoming',
-      eventsTabs: [
-        {
-          label: 'Upcoming',
-          id: 'upcoming'
-        },
-        {
-          label: 'Past',
-          id: 'past'
-        }
-      ],
       upcomingEvents: {} as EventsCollection,
-      pastEvents: {} as EventsCollection,
       news: {} as NewsCollection,
       page: {} as PageEntry,
       stories: {} as CommunitySpotlightItemsCollection
@@ -297,20 +264,6 @@ export default Vue.extend<Data, Methods, Computed, never>({
       const news = await fetchNews(client, this.$route.query.search as string, undefined, undefined, undefined, undefined, this.news.total, 2)
       this.news = { ...this.news, items: { ...this.news.items, ...news.items } }
     },
-    eventsTabChanged(newTab) {
-      this.activeTabId = newTab.id
-    },
-    // Calculate the eventYear param based off the tab being shown
-    eventYear() {
-      if (this.activeTabId === 'upcoming')
-      {
-
-      }
-      else if (this.activeTabId === 'past') {
-
-      }
-      return undefined
-    },
     currentMonth() {
       return new Date().getMonth()
     }
@@ -342,7 +295,7 @@ export default Vue.extend<Data, Methods, Computed, never>({
   margin: 1em 0;
   padding: 0;
 }
-.upcoming-events, .past-events {
+.upcoming-events {
   justify-content: space-between;
   display: flex;
   flex-wrap: wrap;

--- a/pages/news-and-events/model.ts
+++ b/pages/news-and-events/model.ts
@@ -28,15 +28,6 @@ export const fetchData = async (client: ContentfulClientApi, terms?: string, lim
       limit
     })
 
-    const pastEvents = await client.getEntries<EventsEntry>({
-      content_type: process.env.ctf_event_id,
-      order: '-fields.startDate',
-      'fields.startDate[lt]': todaysDate.toISOString(),
-      'fields.startDate[gte]': sub(todaysDate, { years: 2 }).toISOString(),
-      query,
-      limit
-    })
-
     const news = await fetchNews(client, query, undefined, undefined, undefined, undefined, limit)
 
     const page = await client.getEntry<PageData>(process.env.ctf_news_and_events_page_id ?? '')
@@ -45,7 +36,6 @@ export const fetchData = async (client: ContentfulClientApi, terms?: string, lim
 
     return {
       upcomingEvents,
-      pastEvents,
       news,
       page,
       stories
@@ -54,7 +44,6 @@ export const fetchData = async (client: ContentfulClientApi, terms?: string, lim
     console.error(e)
     return {
       upcomingEvents: {} as unknown as EventsCollection,
-      pastEvents: {} as unknown as EventsCollection,
       news: {} as unknown as NewsCollection,
       page: {} as unknown as PageEntry,
       stories: {} as unknown as CommunitySpotlightItemsCollection
@@ -124,7 +113,7 @@ export const fetchCommunitySpotlightItems = async (client: ContentfulClientApi, 
   }
 }
 
-export type AsyncData = Pick<Data, "upcomingEvents" | "pastEvents" | "news" | "page" | "stories">
+export type AsyncData = Pick<Data, "upcomingEvents" | "news" | "page" | "stories">
 
 export interface PageData {
   featuredEvent?: EventsEntry;
@@ -179,7 +168,6 @@ export interface Data {
   activeTab: string;
   eventsTabs: Tab[];
   upcomingEvents: EventsCollection;
-  pastEvents: EventsCollection;
   news: NewsCollection;
   page: PageEntry;
   stories: CommunitySpotlightItemsCollection


### PR DESCRIPTION
# Description

Past events and its control have been removed as request in this ticket - https://www.wrike.com/open.htm?id=1161697934

## Type of change

Delete those that don't apply.

- [x] New feature (non-breaking change which adds functionality)

# How Has This Been Tested?

This has been tested locally and it can be checked here - https://alan-wu-sparc-app.herokuapp.com/news-and-events

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have utilized components from the Design System Library where applicable
- [x] I have added unit tests that prove my fix is effective or that my feature works
