### PR TITLE
Open the nuxt loading page while form is loading, remove form selector after submission, reset form on new form selection

### DIFF
--- a/mixins/recaptcha/index.js
+++ b/mixins/recaptcha/index.js
@@ -10,14 +10,17 @@ export default {
      */
     async onSubmit() {
       this.hasError = false
+      this.$nuxt.$loading.start()
       await this.verifyRecaptcha()
       await this.$refs.submitForm.validate(async valid => {
         if (!valid) {
+          this.$nuxt.$loading.finish()
           return
         }
         if (!this.hasError) {
           await this.sendForm()
         }
+        this.$nuxt.$loading.finish()
         await this.$recaptcha.reset()
       })
     },

--- a/pages/contact-us/index.vue
+++ b/pages/contact-us/index.vue
@@ -10,6 +10,7 @@ a<template>
           <li v-for="type in formTypes" :key="type.label">
             <nuxt-link
               class="tabs__button"
+              @click.native="resetForms"
               :class="{ active: type.type === $route.query.type || (type.subtypes != undefined && type.subtypes.includes($route.query.type)) || ($route.query.type === undefined && type.type === 'feedback') }"
               :to="{
                 name: 'contact-us',
@@ -33,21 +34,23 @@ a<template>
     <div class="page-wrap container">
       <div class="subpage mb-0">
         <template v-if="isFeedbackForm">
-          <div class="heading2 mb-8">Let us know why you are contacting us:</div>
-          <el-select
-            v-model="formType"
-            class="input-reason"
-            placeholder="Select a reason"
-            :popper-append-to-body="false"
-          >
-            <el-option
-              v-for="option in feedbackFormTypeOptions"
-              :key="option.key"
-              :label="option.label"
-              :value="option.value"
-            />
-          </el-select>
-          <hr v-if="isFeedbackForm && formType != undefined && formType != 'feedback'" class="mt-32 mb-32" />
+          <template v-if="!isSubmitted">
+            <div class="heading2 mb-8">Let us know why you are contacting us:</div>
+            <el-select
+              v-model="formType"
+              class="input-reason"
+              placeholder="Select a reason"
+              :popper-append-to-body="false"
+            >
+              <el-option
+                v-for="option in feedbackFormTypeOptions"
+                :key="option.key"
+                :label="option.label"
+                :value="option.value"
+              />
+            </el-select>
+            <hr v-if="isFeedbackForm && formType != undefined && formType != 'feedback'" class="mt-32 mb-32" />  
+          </template>
         </template>
         <component
           v-if="!isSubmitted"


### PR DESCRIPTION
# Description

## Open the nuxt loading page while form is loading

This change is requested here:
https://www.wrike.com/open.htm?id=1174694935

This change utilises the nuxt loading page for loading while the form requests are made.

The Sparc loading gif was requested specifically, so I thought the sparc loading page was appropriate here

Changes can be viewed here:
https://jesse-sprint-preview.herokuapp.com/

## Close form selector after submission

Change requested here:
https://www.wrike.com/open.htm?id=1161701403

The form selector is now hidden after submission, navigating to a new form resets the form

## Type of change

Delete those that don't apply.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

# How Has This Been Tested?

Tested locally and changes will be viewable here shortly:
https://jesse-sprint-preview.herokuapp.com/


# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have utilized components from the Design System Library where applicable
- [ ] I have added unit tests that prove my fix is effective or that my feature works
