### PR TITLE
Fixed bug with click handlers

### DIFF
--- a/components/ConfirmationModal/ConfirmationModal.vue
+++ b/components/ConfirmationModal/ConfirmationModal.vue
@@ -8,8 +8,8 @@
       <h2>Confirmation required</h2>
       <slot name="confirmation-body"/>
       <div class="buttons-container">
-        <span><el-button class="secondary" v-on:click="confirmationCancelled">Cancel</el-button></span>
-        <span><el-button class="danger" v-on:click="confirmationAccepted">Remove</el-button></span>
+        <span><el-button class="secondary" @click="confirmationCancelled">Cancel</el-button></span>
+        <span><el-button class="danger" @click="confirmationAccepted">Remove</el-button></span>
       </div>
     </div>
   </large-modal>

--- a/pages/user/profile/index.vue
+++ b/pages/user/profile/index.vue
@@ -38,7 +38,7 @@
                 Keep up to date with all the latest news and events from the SPARC Portal by subscribing to our newsletter. View all past newsletters <a href="//us2.campaign-archive.com/home/?u=e60c48f231a30b544eed731ea&id=c81a347bd8" target="_blank">here</a>.
               </div>
               <div class="mt-8">
-                <el-button class='secondary' v-on:click='subscribeToNewsletter(profileEmail, firstName, lastName)'>Subscribe to newsletter</el-button>
+                <el-button class='secondary' @click="subscribeToNewsletter(profileEmail, firstName, lastName)">Subscribe to newsletter</el-button>
               </div>
             </template>
             <template v-else>
@@ -47,7 +47,7 @@
                 View all past newsletters <nuxt-link to="/news-and-events#stayConnected">here</nuxt-link>.
               </div>
               <div class="mt-8">
-                <el-button class='secondary' v-on:click='unsubscribeFromNewsletter(profileEmail)'>Un-subscribe from newsletter</el-button>
+                <el-button class='secondary' @click="unsubscribeFromNewsletter(profileEmail)">Un-subscribe from newsletter</el-button>
               </div>
             </template>
           </div>
@@ -124,24 +124,24 @@
                 </span>
                 <span class="right-col">
                   <template v-if="isDraft(datasetSubmission)">
-                    <el-button v-on:click="submitDraft(datasetSubmission.nodeId)"  class="secondary submit-button">
+                    <el-button @click="submitDraft(datasetSubmission.nodeId)"  class="secondary submit-button">
                       Submit Draft
                     </el-button>
-                    <el-button v-on:click="deleteClicked(datasetSubmission)" class="danger">
+                    <el-button @click="deleteClicked(datasetSubmission)" class="danger">
                       Delete Draft
                     </el-button>
                   </template>
-                  <el-button v-else-if="isSubmitted(datasetSubmission)" v-on:click="retractClicked(datasetSubmission)" class="secondary">
+                  <el-button v-else-if="isSubmitted(datasetSubmission)" @click="retractClicked(datasetSubmission)" class="secondary">
                     Retract Request
                   </el-button>
-                  <el-button v-else-if="isWithdrawn(datasetSubmission) || isRejected(datasetSubmission)" v-on:click="deleteClicked(datasetSubmission)" class="danger">
+                  <el-button v-else-if="isWithdrawn(datasetSubmission) || isRejected(datasetSubmission)" @click="deleteClicked(datasetSubmission)" class="danger">
                     Delete Request
                   </el-button>
                 </span>
               </div>
             </template>
           </div>
-          <el-button class='secondary mt-16' v-on:click='newRequestClicked'>Submit new request</el-button>
+          <el-button class='secondary mt-16' @click="newRequestClicked">Submit new request</el-button>
         </div>
       </div>
     </div>


### PR DESCRIPTION
# Description

There is an issue with the v-on click handlers when deploying to heroku for some reason. I believe it has to do with the use of single quotes over double so I updated the syntax

## Type of change

- [X] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

Locally, although it worked fine locally before. Will test on Heroku

# Checklist:

- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my own code
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] I have utilized components from the Design System Library where applicable
