### PR TITLE
Remove action button for CSV

### DIFF
--- a/components/FilesTable/FilesTable.vue
+++ b/components/FilesTable/FilesTable.vue
@@ -314,6 +314,15 @@ import { extractExtension } from '@/pages/data/utils'
 
 import * as path from 'path'
 
+const openableFileTypes = [
+  'pdf',
+  'text',
+  'jpeg',
+  'png',
+  'svg',
+  'mp4',
+]
+
 export const contentTypes = {
   pdf: 'application/pdf',
   text: 'text/plain',
@@ -454,11 +463,10 @@ export default {
      * - Vector Drawings (svg)
      */
     isFileOpenable(scope) {
-      const allowableExtensions = Object.keys(contentTypes).map(key => key)
       const fileType = scope.row.fileType.toLowerCase()
       return (
         this.isMicrosoftFileType(scope) ||
-        allowableExtensions.includes(fileType)
+        openableFileTypes.includes(fileType)
       )
     },
 

--- a/pages/file/_datasetId/_datasetVersion/index.vue
+++ b/pages/file/_datasetId/_datasetVersion/index.vue
@@ -103,16 +103,6 @@ import {
   propOr
 } from 'ramda'
 
-export const contentTypes = {
-  pdf: 'application/pdf',
-  text: 'text/plain',
-  jpeg: 'image/jpeg',
-  png: 'image/png',
-  svg: 'img/svg+xml',
-  mp4: 'video/mp4',
-  csv: 'text/csv'
-}
-
 export default {
   name: 'FileDetailPage',
 
@@ -250,24 +240,6 @@ export default {
       })
     },
     /**
-     * Check if the file is openable
-     * MS Office files and native browser files
-     * - Documents (pdf, text)
-     * - Images (jpg, png)
-     * - Video (MP4)
-     * - Vector Drawings (svg)
-     */
-    isFileOpenable(file) {
-      if (!file.fileType) {
-        return false
-      }
-      const allowableExtensions = Object.keys(contentTypes).map(key => key)
-      const fileType = file.fileType.toLowerCase()
-      return (
-        this.isMicrosoftFileType(file) || allowableExtensions.includes(fileType)
-      )
-    },
-    /**
      * Checks if file is MS Word, MS Excel, or MS Powerpoint
      * @param {Object} file
      */
@@ -278,40 +250,6 @@ export default {
         file.fileType === 'PowerPoint'
       )
     },
-    /**
-     * Opens a file in a new tab
-     * This is currently for MS Word, MS Excel, and Powerpoint files only
-     * @param {Object} file
-     */
-    openFile: function(file) {
-      this.getViewFileUrl(file).then(response => {
-        window.open(response, '_blank')
-      })
-    },
-    getViewFileUrl(file) {
-      let uri = `${propOr('', 'uri', file).replace("s3://", "")}`
-      let s3BucketName = uri.substring(0, uri.indexOf("/"))
-
-      const filePath = compose(
-        last,
-        defaultTo([]),
-        split(`s3://${s3BucketName}/`),
-        propOr('', 'uri')
-      )(file)
-
-      const fileType = file.fileType.toLowerCase()
-      const contentType = contentTypes[fileType]
-
-      const requestUrl = `${process.env.portal_api}/download?s3BucketName=${s3BucketName}&key=${filePath}&contentType=${contentType}`
-
-      return this.$axios.$get(requestUrl).then(response => {
-        const url = response
-        const encodedUrl = encodeURIComponent(url)
-        return this.isMicrosoftFileType(file)
-          ? `https://view.officeapps.live.com/op/view.aspx?src=${encodedUrl}`
-          : url
-      })
-    }
   }
 }
 </script>


### PR DESCRIPTION
# Description

Remove action button to open in browser viewer for CSV as the viewer is only supported by Safari and causing undesired behaviour for other browsers, details of the issue can be viewed in this [ticket](https://www.wrike.com/open.htm?id=1204588950).

## Type of change

Delete those that don't apply.

- [ ] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

This has been tested locally and on this [heroku](https://alan-wu-sparc-app.herokuapp.com/datasets/26?type=dataset&datasetDetailsTab=files&path=files%2Fderivative%2Fsub-Pig-013) instance.


# Checklist:

- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have utilized components from the Design System Library where applicable
- [ ] I have added or updated unit tests that prove my fix is effective or that my feature works
- [ ] I updated any relevant QC tests to match my changes found here: https://docs.google.com/document/d/1tlV89PMOv8XlmC7LVqifi7NfQ5-AYN8DuEQpmO7O_2Q
