### PR TITLE
Update mapintegratedvuer - now close sidebar when opening scaffold

### DIFF
--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
   },
   "dependencies": {
     "@abi-software/gallery": "0.3.2",
-    "@abi-software/mapintegratedvuer": "^0.6.2",
+    "@abi-software/mapintegratedvuer": "^0.6.3",
     "@abi-software/plotvuer": "^0.3.0",
     "@abi-software/simulationvuer": "0.6.5",
     "@aws-amplify/auth": "^4.4.4",

--- a/yarn.lock
+++ b/yarn.lock
@@ -70,10 +70,10 @@
     element-ui "^2.15.0"
     vue "^2.6.11"
 
-"@abi-software/map-side-bar@^1.5.0":
-  version "1.5.0"
-  resolved "https://registry.yarnpkg.com/@abi-software/map-side-bar/-/map-side-bar-1.5.0.tgz#423c2b53a1a0f2229f42c48a6803968aea20c2a2"
-  integrity sha512-UZaQVzAKpz4ZYFxJouN6uMRaZ2HlUDPLz24RrZJVBWVgLgmkwiOeyRUrqItwEV/7oIhm7VZzPUhzI9gMSGjjaQ==
+"@abi-software/map-side-bar@^1.5.1":
+  version "1.5.1"
+  resolved "https://registry.yarnpkg.com/@abi-software/map-side-bar/-/map-side-bar-1.5.1.tgz#516271e19e172ebf2c81cacb6026590936c9a72d"
+  integrity sha512-P9r128THCqJysYlTCBMskH+10JoPevfl/wZwQoBZd8alvlfv2qB4m3Q4XjmmjjaX1BVm+1qBPN29Bc3VWRjZDA==
   dependencies:
     "@abi-software/gallery" "^0.4.1-beta.1"
     "@abi-software/svg-sprite" "^0.2.0"
@@ -83,13 +83,13 @@
     vue "^2.6.10"
     xss "^1.0.14"
 
-"@abi-software/mapintegratedvuer@^0.6.2":
-  version "0.6.2"
-  resolved "https://registry.yarnpkg.com/@abi-software/mapintegratedvuer/-/mapintegratedvuer-0.6.2.tgz#92ba6987e365041ee96b0bf72de64e50b6077970"
-  integrity sha512-12kBekcpV6dXouoabNj/njNJ2uWKWvEc7roq18XLy+i+R/QbkK6hvoYD+UyP4bh18aTS1cmnwr+ng3cjLZcQCQ==
+"@abi-software/mapintegratedvuer@^0.6.3":
+  version "0.6.3"
+  resolved "https://registry.yarnpkg.com/@abi-software/mapintegratedvuer/-/mapintegratedvuer-0.6.3.tgz#3f6a518a4e192d93422d310b815d15fa636cccaf"
+  integrity sha512-/W7C4ZptacjCpnplO4iLEBXMYA6nwNdXHPdr/M/1clIVMhj8fOdqE2m+cyg4w9yn/cqtsf8RYLFT+MD1agp7cQ==
   dependencies:
     "@abi-software/flatmapvuer" "^0.5.7"
-    "@abi-software/map-side-bar" "^1.5.0"
+    "@abi-software/map-side-bar" "^1.5.1"
     "@abi-software/plotvuer" "^0.3.9"
     "@abi-software/scaffoldvuer" "^0.3.1"
     "@abi-software/simulationvuer" "^0.6.5"


### PR DESCRIPTION
# Description

This change was requested by Dominic so that users can see the new context cards (which are hidden behind the sidebar currently)

Requested here:
https://www.wrike.com/open.htm?id=1127382486

![image](https://github.com/nih-sparc/sparc-app/assets/37255664/2ce73b30-2b07-4b6f-9a84-da3a7a780369)


## Type of change

Delete those that don't apply.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration


# Checklist:

- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have utilized components from the Design System Library where applicable
- [ ] I have added or updated unit tests that prove my fix is effective or that my feature works
- [ ] I updated any relevant QC tests to match my changes found here: https://docs.google.com/document/d/1tlV89PMOv8XlmC7LVqifi7NfQ5-AYN8DuEQpmO7O_2Q
