### PR TITLE
Update paremeter queries in maps page to make it constructable.

### DIFF
--- a/components/ImagesGallery/ImagesGallery.vue
+++ b/components/ImagesGallery/ImagesGallery.vue
@@ -405,7 +405,7 @@ export default {
                 title = `View ${f.organ}`
               }
 
-              let linkUrl = `${baseRoute}maps?type=flatmap&dataset_version=${datasetVersion}&dataset_id=${datasetId}&taxo=${f.taxo}&uberonid=${f.uberonid}`
+              let linkUrl = `${baseRoute}maps?type=ac&dataset_version=${datasetVersion}&dataset_id=${datasetId}&taxon=${f.taxo}&anatomy=${f.uberonid}`
               if (f.species) linkUrl = linkUrl + `&for_species=${f.species}`
               const item = {
                 id: f.uberonid,

--- a/pages/maps/index.vue
+++ b/pages/maps/index.vue
@@ -371,8 +371,7 @@ export default {
     },
     //Process any taxon or anatomy parameters if they are available
     processEntry: async function(route) {
-      //anatomy and taxon query parameters should be replaced taxo 
-      //and uberonid.
+      //uberionid and taxo are now deprecated and replaced by Anatomy and taxon
       const anatomy = route.query.anatomy ? route.query.anatomy : route.query.uberonid
       const taxon = route.query.taxon ? route.query.taxon : route.query.taxo
       if (anatomy || taxon) {


### PR DESCRIPTION
# Description

Improve query parameters on the maps page to make the link constructable manually. Please check here for the details: https://docs.google.com/document/d/1N4Z2h2XJad4ReskSb8eTtWyNLJ9NZoJK4MNtIzAt_sA/edit#heading=h.p6kg75rdm3u0

## Type of change

Delete those that don't apply.

- [ ] New feature (non-breaking change which adds functionality)

# How Has This Been Tested?

I have tested this manually and it should not break any backward compatibility.

I have also deployed the sample links:
New query parameters with AC maps:
https://alan-wu-sparc-app.herokuapp.com/maps?type=ac&dataset_version=5&dataset_id=102&taxon=NCBITaxon%3A9823&anatomy=UBERON%3A0000948&for_species=pig

The old query parameters with type=flatmap, taxo and uberonid still works:
https://alan-wu-sparc-app.herokuapp.com/maps?type=flatmap&dataset_version=5&dataset_id=102&taxo=NCBITaxon%3A9823&uberonid=UBERON%3A0000948&for_species=pig

Features on FC map can be highlighted as well:
https://alan-wu-sparc-app.herokuapp.com/maps?type=fc&anatomy=heart


# Checklist:

- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have utilized components from the Design System Library where applicable
- [ ] I have added or updated unit tests that prove my fix is effective or that my feature works
- [ ] I updated any relevant QC tests to match my changes found here: https://docs.google.com/document/d/1tlV89PMOv8XlmC7LVqifi7NfQ5-AYN8DuEQpmO7O_2Q
