### PR TITLE
Updated the testing click action failed case

### DIFF
--- a/test/cypress/e2e/mapviewer.cy.js
+++ b/test/cypress/e2e/mapviewer.cy.js
@@ -40,9 +40,9 @@ describe('Maps Viewer', { testIsolation: false }, function () {
       cy.get('.multi-container > .el-loading-parent--relative > .el-loading-mask', { timeout: 30000 }).should('not.exist')
 
       // Hide organs and outlines
-      cy.get('.settings-group > :nth-child(2):visible').click()
+      cy.get('.settings-group > :nth-child(2):visible').click({ waitForAnimations: false })
       cy.get('[role="radiogroup"] > .el-radio:visible').not('.is-checked').click({ multiple: true });
-      cy.get('.settings-group > :nth-child(2):visible').click()
+      cy.get('.settings-group > :nth-child(2):visible').click({ waitForAnimations: false })
 
       let coorX = coordinate.x
       let coorY = coordinate.y


### PR DESCRIPTION
# Description

Disabled the element animation waiting time during the click testing. Try to avoid the timeout due to Cypress Cloud performance.


## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

The issue cannot be reproduced locally. Hence, need to create the PR to trigger the GitHub action to run in Cypress Cloud.
Tests are passed in Cypress Cloud.

# Checklist:

- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have utilized components from the Design System Library where applicable
- [ ] I have added or updated unit tests that prove my fix is effective or that my feature works
- [ ] I updated any relevant QC tests to match my changes found here: https://docs.google.com/document/d/1tlV89PMOv8XlmC7LVqifi7NfQ5-AYN8DuEQpmO7O_2Q
