### PR TITLE
update segmentation data to come from sparc-api endpoint

### DIFF
--- a/pages/datasets/file/_datasetId/_datasetVersion/index.vue
+++ b/pages/datasets/file/_datasetId/_datasetVersion/index.vue
@@ -137,12 +137,14 @@ export default {
     }
     const hasBiolucidaViewer = !isEmpty(biolucidaData) && biolucidaData.status !== 'error'
     // We must remove the N: in order for scicrunch to realize the package
-    const expectedScicrunchIdentifier = sourcePackageId.replace("N:", "")
+    const expectedScicrunchIdentifier = sourcePackageId != "" ? sourcePackageId.replace("N:", "") : ""
     let scicrunchData = {}
     try {
-      const scicrunchResponse = await scicrunch.getDatasetInfoFromObjectIdentifier(expectedScicrunchIdentifier)
-      const result = pathOr([], ['data', 'result'], scicrunchResponse)
-      scicrunchData = result?.length > 0 ? result[0] : []
+      if (expectedScicrunchIdentifier != "") {
+        const scicrunchResponse = await scicrunch.getDatasetInfoFromObjectIdentifier(expectedScicrunchIdentifier)
+        const result = pathOr([], ['data', 'result'], scicrunchResponse)
+        scicrunchData = result?.length > 0 ? result[0] : []
+      }
     } catch(e) {
       console.log(`Error retrieving sci crunch data (possibly because there is none for this file): ${e}`)
     }

--- a/pages/datasets/file/_datasetId/_datasetVersion/index.vue
+++ b/pages/datasets/file/_datasetId/_datasetVersion/index.vue
@@ -54,6 +54,7 @@
 </template>
 
 <script>
+import discover from '@/services/discover'
 import biolucida from '@/services/biolucida'
 import scicrunch from '@/services/scicrunch'
 import BiolucidaViewer from '@/components/BiolucidaViewer/BiolucidaViewer'
@@ -127,7 +128,6 @@ export default {
       }))
     }
     
-    
     let biolucidaData = {}
     try {
       if (sourcePackageId != "")
@@ -140,9 +140,7 @@ export default {
     const expectedScicrunchIdentifier = sourcePackageId.replace("N:", "")
     let scicrunchData = {}
     try {
-      const scicrunchResponse = await scicrunch.getDatasetInfoFromObjectIdentifier(
-        expectedScicrunchIdentifier
-      )
+      const scicrunchResponse = await scicrunch.getDatasetInfoFromObjectIdentifier(expectedScicrunchIdentifier)
       const result = pathOr([], ['data', 'result'], scicrunchResponse)
       scicrunchData = result?.length > 0 ? result[0] : []
     } catch(e) {
@@ -150,10 +148,18 @@ export default {
     }
 
     let segmentationData = {}
-    const matchedSegmentationData = scicrunchData['mbf-segmentation']?.filter(function(el) {
-      return el.identifier == expectedScicrunchIdentifier
-    })
-    segmentationData = matchedSegmentationData?.length > 0 ? matchedSegmentationData[0] : {}
+    // We should just be able to just pull from scicrunch response as shown below, but due to discrepancies we pull from the sparc api endpoint
+    // const matchedSegmentationData = scicrunchData['mbf-segmentation']?.filter(function(el) {
+    //   return el.identifier == expectedScicrunchIdentifier
+    // })
+    // segmentationData = segmentationData?.length > 0 ? matchedSegmentationData[0] : {}*/
+    try {
+      await discover.getSegmentationInfo(route.params.datasetId, route.params.datasetVersion, filePath, s3Bucket).then(({ data }) => {
+        segmentationData = data
+      })
+    } catch(e) {
+      console.log(`Error retrieving segmentation data (possibly because there is none for this file): ${e}`)
+    }
     const hasSegmentationViewer = !isEmpty(segmentationData)
     
     let plotData = {}


### PR DESCRIPTION
# Description

Updated segmentation viewer to pull its data the same way as before by using the sparc-api endpoint (instead of pulling from the scicrunch['mbf-segmentation'] property

## Type of change

- [X] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

Locally using /datasets/file/37/3?path=files%2Fderivative%2Fsub-54-5%2FTJU_3Scan_ratheart54-5_updated_06_11_19_Fiducials.xml

# Checklist:

- [X] I have performed a self-review of my own code
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] I have utilized components from the Design System Library where applicable
- [ ] I have added or updated unit tests that prove my fix is effective or that my feature works
- [ ] I updated any relevant QC tests to match my changes found here: https://docs.google.com/document/d/1tlV89PMOv8XlmC7LVqifi7NfQ5-AYN8DuEQpmO7O_2Q
