### PR TITLE
fixed logic for biolucida data

### DIFF
--- a/components/FilesTable/FilesTable.vue
+++ b/components/FilesTable/FilesTable.vue
@@ -842,11 +842,7 @@ export default {
       ) {
         const biolucida2dObjects = this.datasetScicrunch['biolucida-2d']
         const biolucida3dObjects = this.datasetScicrunch['biolucida-3d']
-        let biolucidaObjects = []
-        if (biolucida2dObjects != undefined || biolucida3dObjects != undefined)
-        {
-          biolucidaObjects = biolucida2dObjects == undefined ? biolucida3dObjects : biolucida2dObjects.concat(biolucida3dObjects).filter((item) => item !== undefined)
-        }
+        const biolucidaObjects = biolucida2dObjects == undefined ? biolucida3dObjects : biolucida2dObjects.concat(biolucida3dObjects).filter((item) => item !== undefined)
         let shortened = scope.row.path
         shortened = shortened.replace('files/', '')
         for (let i = 0; i < biolucidaObjects.length; i++) {

--- a/components/FilesTable/FilesTable.vue
+++ b/components/FilesTable/FilesTable.vue
@@ -840,7 +840,13 @@ export default {
         this.datasetScicrunch &&
         (this.datasetScicrunch['biolucida-2d'] || this.datasetScicrunch['biolucida-3d'])
       ) {
-        let biolucidaObjects = this.datasetScicrunch['biolucida-2d'].concat(this.datasetScicrunch['biolucida-3d']).filter((item) => item !== undefined)
+        const biolucida2dObjects = this.datasetScicrunch['biolucida-2d']
+        const biolucida3dObjects = this.datasetScicrunch['biolucida-3d']
+        let biolucidaObjects = []
+        if (biolucida2dObjects != undefined || biolucida3dObjects != undefined)
+        {
+          biolucidaObjects = biolucida2dObjects == undefined ? biolucida3dObjects : biolucida2dObjects.concat(biolucida3dObjects).filter((item) => item !== undefined)
+        }
         let shortened = scope.row.path
         shortened = shortened.replace('files/', '')
         for (let i = 0; i < biolucidaObjects.length; i++) {


### PR DESCRIPTION
# Description

Logic was incorrectly assuming biolucida2d objects would be defined when biolucida3d objects were present

## Type of change

Delete those that don't apply.

- [X] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

Locally viaq dataset 353


# Checklist:

- [X] I have performed a self-review of my own code
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] I have utilized components from the Design System Library where applicable
- [ ] I have added or updated unit tests that prove my fix is effective or that my feature works
- [ ] I updated any relevant QC tests to match my changes found here: https://docs.google.com/document/d/1tlV89PMOv8XlmC7LVqifi7NfQ5-AYN8DuEQpmO7O_2Q
