### PR TITLE
Unending spinning of dataset images

### DIFF
--- a/components/Gallery/GalleryItems/FileViewerCard.vue
+++ b/components/Gallery/GalleryItems/FileViewerCard.vue
@@ -104,7 +104,7 @@ export default {
   },
   computed: {
     isReady() {
-      return this.data.title && (this.thumbnail || this.useDefaultImg) && (this.data.link || this.data.userData)
+      return (this.thumbnail || this.useDefaultImg) && (this.data.link || this.data.userData)
     },
     imageHeight() {
       return this.showCardDetails ? this.height * 0.525 : this.height

--- a/components/ImagesGallery/ImagesGallery.vue
+++ b/components/ImagesGallery/ImagesGallery.vue
@@ -808,6 +808,9 @@ export default {
           const name = response.name
           if (name) {
             this.$set(item, 'title', name.substring(0, name.lastIndexOf('.')))
+            if (name.lastIndexOf('.') === -1) {
+              this.$set(item, 'title', name)
+            }
           }
         },
         reason => {

--- a/components/ImagesGallery/ImagesGallery.vue
+++ b/components/ImagesGallery/ImagesGallery.vue
@@ -526,7 +526,9 @@ export default {
         const baseRoute = this.$router.options.base || '/'
         if ('dataset_images' in biolucidaData) {
           items.push(
-            ...Array.from(biolucidaData.dataset_images, dataset_image => {
+            ...Array.from(biolucidaData.dataset_images.filter((obj, index) => {
+              return index === biolucidaData.dataset_images.findIndex(o => obj.image_id === o.image_id);
+            }), dataset_image => {
               let filePath = ""
               biolucida2DItems.forEach(biolucida2DItem => {
                 if (pathOr("", ['biolucida','identifier'], biolucida2DItem) == dataset_image.image_id) {

--- a/components/ImagesGallery/ImagesGallery.vue
+++ b/components/ImagesGallery/ImagesGallery.vue
@@ -782,8 +782,9 @@ export default {
       biolucida.getThumbnail(info.id).then(
         response => {
           let item = items.find(x => x.id === info.id)
-
-          this.$set(item, 'thumbnail', 'data:image/png;base64,' + response.data)
+          if (response.data) {
+            this.$set(item, 'thumbnail', 'data:image/png;base64,' + response.data)
+          }
         },
         reason => {
           if (


### PR DESCRIPTION
# Description

All the changes are focused on fixing the unending spinning issue mentioned in ticket [Investigate unending spinning of dataset images for all datasets](https://www.wrike.com/open.htm?id=1321938755)


## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

I have done manual testing. Accessed all the dataset galleries and checked whether all spinning icons were gone.


# Checklist:

- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have utilized components from the Design System Library where applicable
- [ ] I have added or updated unit tests that prove my fix is effective or that my feature works
- [ ] I updated any relevant QC tests to match my changes found here: https://docs.google.com/document/d/1tlV89PMOv8XlmC7LVqifi7NfQ5-AYN8DuEQpmO7O_2Q
